### PR TITLE
Change submit to create and update 

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -63,6 +63,8 @@ When sending requests, ensure that the `"Content-type": "application/json+fhir"`
 This server currently supports the following CRUD operations:
 
 - Read by ID to endpoint: `4_0_1/<resourceType>/<resourceId>`
+- Create resource (Library or Measure) to endpoint: `4_0_1/<resourceType>`
+- Update resource (Library or Measure) to endpoint: `4_0_1/<resourceType>/<resourceId>`
   _More functionality coming soon!_
 
 ### Search
@@ -99,10 +101,6 @@ Supported optional parameters for `Measure` are:
 
 - periodStart
 - periodEnd
-
-### Submit
-
-The Measure Repository Service server supports the `$submit` operation for `Measure` and `Library` resources, as specified in the Authoring Measure Repository section of the [HL7 Measure Repository Docs](https://build.fhir.org/ig/HL7/cqf-measures/measure-repository-service.html#authoring-measure-repository). The operation does not take in any parameters.
 
 ## License
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -62,9 +62,9 @@ When sending requests, ensure that the `"Content-type": "application/json+fhir"`
 
 This server currently supports the following CRUD operations:
 
-- Read by ID to endpoint: `4_0_1/<resourceType>/<resourceId>`
-- Create resource (Library or Measure) to endpoint: `4_0_1/<resourceType>`
-- Update resource (Library or Measure) to endpoint: `4_0_1/<resourceType>/<resourceId>`
+- Read by ID with `GET` to endpoint: `4_0_1/<resourceType>/<resourceId>`
+- Create resource (Library or Measure) with `POST` to endpoint: `4_0_1/<resourceType>`
+- Update resource (Library or Measure) with `PUT` to endpoint: `4_0_1/<resourceType>/<resourceId>`
   _More functionality coming soon!_
 
 ### Search

--- a/backend/src/config/capabilityStatementResources.json
+++ b/backend/src/config/capabilityStatementResources.json
@@ -31,6 +31,26 @@
           ],
           "code": "search-type",
           "documentation": "Search allows clients to search for repository libraries"
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHALL"
+            }
+          ],
+          "code": "create",
+          "documentation": "Create allows authoring workflows to post new libraries in _draft_ (**submit**) or _active_ (**publish**) status."
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHALL"
+            }
+          ],
+          "code": "update",
+          "documentation": "Update allows authoring workflows to update existing libraries in _draft_ (**revise**) status, add comments to existing libraries (**review** and **approve**), and **release** or **retire** a library."
         }
       ],
       "searchParam": [
@@ -167,6 +187,26 @@
           ],
           "code": "search-type",
           "documentation": "Search allows clients to search for repository measures"
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHALL"
+            }
+          ],
+          "code": "create",
+          "documentation": "Create allows authoring workflows to post new measures in _draft_ (**submit**) or _active_ (**publish**) status."
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHALL"
+            }
+          ],
+          "code": "update",
+          "documentation": "Update allows authoring workflows to update existing measures in _draft_ (**revise**) status, add comments to existing measures (**review** and **approve**), and **release** or **retire** a measure."
         }
       ],
       "searchParam": [

--- a/backend/src/config/capabilityStatementResources.json
+++ b/backend/src/config/capabilityStatementResources.json
@@ -130,16 +130,6 @@
               "valueCode": "SHALL"
             }
           ],
-          "name": "submit",
-          "definition": "http://hl7.org/fhir/us/cqfmeasures/STU3/measure-repository-service.html#submit"
-        },
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-              "valueCode": "SHALL"
-            }
-          ],
           "name": "data-requirements",
           "definition": "https://hl7.org/fhir/us/cqfmeasures/OperationDefinition/Library-data-requirements"
         }
@@ -278,16 +268,6 @@
           ],
           "name": "data-requirements",
           "definition": "http://hl7.org/fhir/us/cqfmeasures/OperationDefinition/Measure-data-requirements"
-        },
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-              "valueCode": "SHALL"
-            }
-          ],
-          "name": "submit",
-          "definition": "http://hl7.org/fhir/us/cqfmeasures/STU3/measure-repository-service.html#submit"
         }
       ]
     }

--- a/backend/src/config/serverConfig.ts
+++ b/backend/src/config/serverConfig.ts
@@ -85,16 +85,6 @@ export const serverConfig: ServerConfig = {
           route: '/:id/$data-requirements',
           method: 'POST',
           reference: 'http://hl7.org/fhir/us/cqfmeasures/OperationDefinition/Measure-data-requirements'
-        },
-        {
-          name: 'submit',
-          route: '/$submit',
-          method: 'POST'
-        },
-        {
-          name: 'submit',
-          route: '/:id/$submit',
-          method: 'POST'
         }
       ]
     },
@@ -125,16 +115,6 @@ export const serverConfig: ServerConfig = {
           route: '/:id/$package',
           method: 'POST',
           reference: 'http://hl7.org/fhir/us/cqfmeasures/OperationDefinition/Library-package'
-        },
-        {
-          name: 'submit',
-          route: '/$submit',
-          method: 'POST'
-        },
-        {
-          name: 'submit',
-          route: '/:id/$submit',
-          method: 'POST'
         },
         {
           name: 'dataRequirements',

--- a/backend/src/db/dbOperations.ts
+++ b/backend/src/db/dbOperations.ts
@@ -28,7 +28,7 @@ export async function findResourcesWithQuery<T extends fhir4.FhirResource>(
  */
 export async function createResource(data: fhir4.FhirResource, resourceType: string) {
   const collection = Connection.db.collection<fhir4.FhirResource>(resourceType);
-  logger.info(`Inserting ${resourceType}/${data.id} into database`);
+  console.log(`Inserting ${resourceType}/${data.id} into database`);
   await collection.insertOne(data);
   return { id: data.id as string };
 }

--- a/backend/src/db/dbOperations.ts
+++ b/backend/src/db/dbOperations.ts
@@ -28,7 +28,7 @@ export async function findResourcesWithQuery<T extends fhir4.FhirResource>(
  */
 export async function createResource(data: fhir4.FhirResource, resourceType: string) {
   const collection = Connection.db.collection<fhir4.FhirResource>(resourceType);
-  console.log(`Inserting ${resourceType}/${data.id} into database`);
+  logger.info(`Inserting ${resourceType}/${data.id} into database`);
   await collection.insertOne(data);
   return { id: data.id as string };
 }
@@ -49,6 +49,5 @@ export async function updateResource(id: string, data: fhir4.FhirResource, resou
     return { id, created: true };
   }
 
-  // value being present indicates an update, so set created flag to false
   return { id, created: false };
 }

--- a/backend/src/db/dbOperations.ts
+++ b/backend/src/db/dbOperations.ts
@@ -23,12 +23,32 @@ export async function findResourcesWithQuery<T extends fhir4.FhirResource>(
   return collection.find<T>(query, { projection: { _id: 0 } }).toArray();
 }
 
-/*
+/**
  * Inserts one data object into database with specified FHIR resource type
  */
 export async function createResource(data: fhir4.FhirResource, resourceType: string) {
   const collection = Connection.db.collection<fhir4.FhirResource>(resourceType);
   logger.info(`Inserting ${resourceType}/${data.id} into database`);
   await collection.insertOne(data);
-  return { id: data.id };
+  return { id: data.id as string };
+}
+
+/**
+ * Searches for a document for a resource and updates it if found, creates it if not
+ */
+export async function updateResource(id: string, data: fhir4.FhirResource, resourceType: string) {
+  const collection = Connection.db.collection(resourceType);
+  logger.debug(`Finding and updating ${resourceType}/${data.id} in database`);
+
+  const results = await collection.replaceOne({ id }, data, { upsert: true });
+
+  // If the document cannot be created with the passed id, Mongo will throw an error
+  // before here, so should be ok to just return the passed id
+  // upsertedCount indicates that we have created a brand new document
+  if (results.upsertedCount === 1) {
+    return { id, created: true };
+  }
+
+  // value being present indicates an update, so set created flag to false
+  return { id, created: false };
 }

--- a/backend/src/services/LibraryService.ts
+++ b/backend/src/services/LibraryService.ts
@@ -59,7 +59,6 @@ export class LibraryService implements Service<fhir4.Library> {
     checkContentTypeHeader(contentType);
     const resource = req.body;
     checkExpectedResourceType(resource.resourceType, 'Library');
-    // create new id
     resource['id'] = uuidv4();
     return createResource(resource, 'Library');
   }

--- a/backend/src/services/LibraryService.ts
+++ b/backend/src/services/LibraryService.ts
@@ -1,5 +1,5 @@
-import { loggers, RequestArgs, RequestCtx, constants } from '@projecttacoma/node-fhir-server-core';
-import { findResourceById, findResourcesWithQuery } from '../db/dbOperations';
+import { loggers, RequestArgs, RequestCtx } from '@projecttacoma/node-fhir-server-core';
+import { findResourceById, findResourcesWithQuery, updateResource } from '../db/dbOperations';
 import { LibrarySearchArgs, LibraryDataRequirementsArgs, PackageArgs, parseRequestSchema } from '../requestSchemas';
 import { createResource } from '../db/dbOperations';
 import { Service } from '../types/service';
@@ -50,6 +50,39 @@ export class LibraryService implements Service<fhir4.Library> {
   }
 
   /**
+   * result of sending a POST request to {BASE_URL}/4_0_1/Library
+   * creates a new Library resource, generates an id for it, and adds it to the database
+   */
+  async create(_: RequestArgs, { req }: RequestCtx) {
+    logger.info(`POST /Library`);
+    const contentType: string | undefined = req.headers['content-type'];
+    checkContentTypeHeader(contentType);
+    const resource = req.body;
+    checkExpectedResourceType(resource.resourceType, 'Library');
+    // create new id
+    resource['id'] = uuidv4();
+    return createResource(resource, 'Library');
+  }
+
+  /**
+   * result of sending a PUT request to {BASE_URL}/4_0_1/Library/{id}
+   * updates the library with the passed in id using the passed in data
+   * or creates a library with passed in id if it does not exist in the database
+   */
+  async update(args: RequestArgs, { req }: RequestCtx) {
+    logger.info(`PUT /Library/${args.id}`);
+    const contentType: string | undefined = req.headers['content-type'];
+    checkContentTypeHeader(contentType);
+    const resource = req.body;
+    checkExpectedResourceType(resource.resourceType, 'Library');
+    // Throw error if the id arg in the url does not match the id in the request body
+    if (resource.id !== args.id) {
+      throw new BadRequestError('Argument id must match request body id for PUT request');
+    }
+    return updateResource(args.id, resource, 'Library');
+  }
+
+  /**
    * result of sending a POST or GET request to:
    * {BASE_URL}/4_0_1/Library/$package or {BASE_URL}/4_0_1/Library/:id/$package
    * creates a bundle of the library (specified by parameters) and all dependent libraries
@@ -73,35 +106,6 @@ export class LibraryService implements Service<fhir4.Library> {
     const { libraryBundle } = await createLibraryPackageBundle(query, parsedParams);
 
     return libraryBundle;
-  }
-
-  /**
-   * result of sending a POST request to:
-   * {BASE_URL}/4_0_1/Library/$submit or {BASE_URL}/4_0_1/Library/:id/$submit
-   * POSTs a new artifact in "draft" status. The operation results in an error if the artifact
-   * does not have status set to "draft."
-   */
-  async submit(args: RequestArgs, { req }: RequestCtx) {
-    logger.info(`${req.method} ${req.path}`);
-
-    const contentType: string | undefined = req.headers['content-type'];
-    checkContentTypeHeader(contentType);
-
-    const resource = req.body;
-    checkExpectedResourceType(resource.resourceType, 'Library');
-
-    // check for "draft" status on the resource
-    if (resource.status !== 'draft') {
-      throw new BadRequestError(`The artifact must be in 'draft' status.`);
-    }
-
-    const res = req.res;
-    // create new resource with server-defined id
-    resource['id'] = uuidv4();
-    await createResource(resource, 'Library');
-    res.status(201);
-    const location = `${constants.VERSIONS['4_0_1']}/Library/${resource.id}`;
-    res.set('Location', location);
   }
 
   /**

--- a/backend/src/services/MeasureService.ts
+++ b/backend/src/services/MeasureService.ts
@@ -60,7 +60,6 @@ export class MeasureService implements Service<fhir4.Measure> {
     checkContentTypeHeader(contentType);
     const resource = req.body;
     checkExpectedResourceType(resource.resourceType, 'Measure');
-    // create new id
     resource['id'] = uuidv4();
     return createResource(resource, 'Measure');
   }

--- a/backend/test/services/LibraryService.test.ts
+++ b/backend/test/services/LibraryService.test.ts
@@ -194,21 +194,21 @@ describe('LibraryService', () => {
   });
 
   describe('update', () => {
-    it('returns 200 when provided correct headers and a FHIR Library whose id is in the database', async () => {
-      await createTestResource(
+    beforeAll(() => {
+      return createTestResource(
         { resourceType: 'Library', type: { coding: [{ code: 'logic-library' }] }, id: 'exampleId', status: 'draft' },
         'Library'
       );
+    });
+
+    it('returns 200 when provided correct headers and a FHIR Library whose id is in the database', async () => {
       await supertest(server.app)
         .put('/4_0_1/Library/exampleId')
         .send({ resourceType: 'Library', id: 'exampleId', status: 'active' })
         .set('content-type', 'application/json+fhir')
-        .expect(200);
-      await supertest(server.app)
-        .get('/4_0_1/Library/exampleId')
         .expect(200)
         .then(response => {
-          expect(response.body.id).toEqual('exampleId');
+          expect(response.headers.location).toBeDefined();
         });
     });
 
@@ -220,14 +220,6 @@ describe('LibraryService', () => {
         .expect(201)
         .then(response => {
           expect(response.headers.location).toBeDefined();
-        });
-      await supertest(server.app)
-        .get('/4_0_1/Library/newId')
-        .expect(200)
-        .then(response => {
-          expect(response.body.resourceType).toEqual('Library');
-          expect(response.body.id).toEqual('newId');
-          expect(response.body.status).toEqual('draft');
         });
     });
 

--- a/backend/test/services/MeasureService.test.ts
+++ b/backend/test/services/MeasureService.test.ts
@@ -186,18 +186,18 @@ describe('MeasureService', () => {
   });
 
   describe('update', () => {
+    beforeAll(() => {
+      return createTestResource({ resourceType: 'Measure', id: 'exampleId', status: 'draft' }, 'Measure');
+    });
+
     it('returns 200 when provided correct headers and a FHIR Measure whose id is in the database', async () => {
-      await createTestResource({ resourceType: 'Measure', id: 'exampleId', status: 'draft' }, 'Measure');
       await supertest(server.app)
         .put('/4_0_1/Measure/exampleId')
         .send({ resourceType: 'Measure', id: 'exampleId', status: 'active' })
         .set('content-type', 'application/json+fhir')
-        .expect(200);
-      await supertest(server.app)
-        .get('/4_0_1/Measure/exampleId')
         .expect(200)
         .then(response => {
-          expect(response.body.id).toEqual('exampleId');
+          expect(response.headers.location).toBeDefined();
         });
     });
 
@@ -209,14 +209,6 @@ describe('MeasureService', () => {
         .expect(201)
         .then(response => {
           expect(response.headers.location).toBeDefined();
-        });
-      await supertest(server.app)
-        .get('/4_0_1/Measure/newId')
-        .expect(200)
-        .then(response => {
-          expect(response.body.resourceType).toEqual('Measure');
-          expect(response.body.id).toEqual('newId');
-          expect(response.body.status).toEqual('draft');
         });
     });
 

--- a/backend/test/services/MeasureService.test.ts
+++ b/backend/test/services/MeasureService.test.ts
@@ -1,6 +1,6 @@
 import { initialize, Server } from '@projecttacoma/node-fhir-server-core';
 import { serverConfig } from '../../src/config/serverConfig';
-import { cleanUpTestDatabase, setupTestDatabase } from '../utils';
+import { cleanUpTestDatabase, createTestResource, setupTestDatabase } from '../utils';
 import supertest from 'supertest';
 import { Calculator } from 'fqm-execution';
 
@@ -168,6 +168,71 @@ describe('MeasureService', () => {
           expect(response.body.issue[0].details.text).toEqual(
             'Version can only appear in combination with a url search'
           );
+        });
+    });
+  });
+
+  describe('create', () => {
+    it('returns 201 status with populated location when provided correct headers and a FHIR Measure', async () => {
+      await supertest(server.app)
+        .post('/4_0_1/Measure')
+        .send({ resourceType: 'Measure', status: 'draft' })
+        .set('content-type', 'application/json+fhir')
+        .expect(201)
+        .then(response => {
+          expect(response.headers.location).toBeDefined();
+        });
+    });
+  });
+
+  describe('update', () => {
+    it('returns 200 when provided correct headers and a FHIR Measure whose id is in the database', async () => {
+      await createTestResource({ resourceType: 'Measure', id: 'exampleId', status: 'draft' }, 'Measure');
+      await supertest(server.app)
+        .put('/4_0_1/Measure/exampleId')
+        .send({ resourceType: 'Measure', id: 'exampleId', status: 'active' })
+        .set('content-type', 'application/json+fhir')
+        .expect(200);
+      await supertest(server.app)
+        .get('/4_0_1/Measure/exampleId')
+        .expect(200)
+        .then(response => {
+          expect(response.body.id).toEqual('exampleId');
+        });
+    });
+
+    it('returns 201 when provided correct headers and a FHIR Measure whose id is not in the database', async () => {
+      await supertest(server.app)
+        .put('/4_0_1/Measure/newId')
+        .send({ resourceType: 'Measure', id: 'newId', status: 'draft' })
+        .set('content-type', 'application/json+fhir')
+        .expect(201)
+        .then(response => {
+          expect(response.headers.location).toBeDefined();
+        });
+      await supertest(server.app)
+        .get('/4_0_1/Measure/newId')
+        .expect(200)
+        .then(response => {
+          expect(response.body.resourceType).toEqual('Measure');
+          expect(response.body.id).toEqual('newId');
+          expect(response.body.status).toEqual('draft');
+        });
+    });
+
+    it('returns 400 when the argument id does not match the id in the body', async () => {
+      await supertest(server.app)
+        .put('/4_0_1/Measure/invalidId')
+        .send({
+          resourceType: 'Measure',
+          id: 'exampleId',
+          status: 'draft'
+        })
+        .set('content-type', 'application/json+fhir')
+        .expect(400)
+        .then(response => {
+          expect(response.body.issue[0].code).toEqual('invalid');
+          expect(response.body.issue[0].details.text).toEqual('Argument id must match request body id for PUT request');
         });
     });
   });
@@ -513,42 +578,6 @@ describe('MeasureService', () => {
           expect(response.body.issue[0].details.text).toEqual(
             'Id argument may not be sourced from both a path parameter and a query or FHIR parameter.'
           );
-        });
-    });
-  });
-
-  describe('$submit', () => {
-    it('returns 201 status with populated location when provided correct headers and FHIR Measure', async () => {
-      await supertest(server.app)
-        .post('/4_0_1/Measure/$submit')
-        .send({ resourceType: 'Measure', status: 'draft' })
-        .set('content-type', 'application/json+fhir')
-        .expect(201)
-        .then(response => {
-          expect(response.headers.location).toBeDefined();
-        });
-    });
-
-    it('returns 201 status with populated location when id is represent in the path', async () => {
-      await supertest(server.app)
-        .post(`/4_0_1/Measure/test-id/$submit`)
-        .send({ resourceType: 'Measure', status: 'draft' })
-        .set('content-type', 'application/json+fhir')
-        .expect(201)
-        .then(response => {
-          expect(response.headers.location).toBeDefined();
-        });
-    });
-
-    it('throws a 400 error when the measure is not in "draft" status', async () => {
-      await supertest(server.app)
-        .post(`/4_0_1/Measure/$submit`)
-        .send({ resourceType: 'Measure', status: 'active' })
-        .set('content-type', 'application/json+fhir')
-        .expect(400)
-        .then(response => {
-          expect(response.body.issue[0].code).toEqual('invalid');
-          expect(response.body.issue[0].details.text).toEqual(`The artifact must be in 'draft' status.`);
         });
     });
   });

--- a/backend/test/utils.ts
+++ b/backend/test/utils.ts
@@ -1,7 +1,7 @@
 import { FhirResourceType } from '@projecttacoma/node-fhir-server-core';
 import { Connection } from '../src/db/Connection';
 
-async function createTestResource(data: fhir4.FhirResource, resourceType: FhirResourceType) {
+export async function createTestResource(data: fhir4.FhirResource, resourceType: FhirResourceType) {
   const collection = Connection.db.collection<fhir4.FhirResource>(resourceType);
   await collection.insertOne({ ...data });
 }


### PR DESCRIPTION
# Summary
Because of developments in a decent CRMI call, we want to move away from implementing a $submit operation on the backend and simply allow the measure repository service to support PUT/POST of a new resource (Library or Measure).

## New behavior
The measure repository service now supports PUT/POST of a new resource, where the former uses the ID provided by the requester, and the latter generates a new server ID. This functionality is implemented through `create` and `update` which are already defined in `src/types/service.ts`. This functionality is similar to that in [deqm-test-server](https://github.com/projecttacoma/deqm-test-server).

## Code changes
- `backend/README.md` - Removed $submit info, added create and update info.
- `backend/src/config/capabilityStatementResources.json` - removed submit operation.
- `backend/src/config/serverConfig.ts` - removed submit operation.
- `dbOperations.ts` - added updateResource function and changed `logger.info` to `console.log`. Is this okay? I only changed it because I was getting a winston warning with `logger.info`.
- `LibraryService.ts` / `MeasureService.ts` - added create and update functions.
- `LibraryService.test.ts` / `MeasureService.test.ts` - added unit tests for create and update.
- `utils.ts` - export `createTestResource` function.

# Testing guidance
- If you aren't sure if you have the ColorectalCancerScreeningsFHIR bundle in your database, I would reset the database:
     - `cd backend`
     - `npm run db:reset`
     - `npm run db:loadBundle "ecqm-content-r4-2021/bundles/measure/ColorectalCancerScreeningsFHIR/ColorectalCancerScreeningsFHIR-bundle.json"`
- In the root directory, run: `npm run check:all`
     - Make sure the unit tests pass.
- In the root directory, run: `npm run start:backend`
- Send some PUT and POST requests to the new endpoints in Insomnia. Attached below are some example requests you can import into Insomnia.

[update-and-create-testing.json.zip](https://github.com/projecttacoma/measure-repository/files/11043801/update-and-create-testing.json.zip)