### PR TITLE
Transaction bundle upload

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,0 +1,12 @@
+import express from 'express';
+import { uploadTransactionBundle } from './services/BaseService';
+
+export const app = express();
+app.use(express.json({ limit: '50mb', type: 'application/json+fhir' }));
+app.use(express.json({ limit: '50mb', type: 'application/fhir+json' }));
+
+app.post('/:base_version/', (req, res, next) => {
+  return uploadTransactionBundle(req, res)
+    .then(result => res.status(200).json(result))
+    .catch(err => next(err));
+});

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -2,22 +2,11 @@ import { initialize, loggers } from '@projecttacoma/node-fhir-server-core';
 import * as dotenv from 'dotenv';
 import { serverConfig } from './config/serverConfig';
 import { Connection } from './db/Connection';
-import express from 'express';
-import { uploadTransactionBundle } from './services/BaseService';
+import { app } from './app';
 
 dotenv.config();
 
-const app = express();
-app.use(express.json({ limit: '50mb', type: 'application/json+fhir' }));
-app.use(express.json({ limit: '50mb', type: 'application/fhir+json' }));
-
-app.post('/:base_version/', (req, res, next) => {
-  return uploadTransactionBundle(req, res)
-    .then(result => res.status(200).json(result))
-    .catch(err => next(err));
-});
-
-const server = initialize(serverConfig, app);
+export const server = initialize(serverConfig, app);
 const logger = loggers.get('default');
 
 const port = process.env.PORT ? parseInt(process.env.PORT) : 3000;

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -3,12 +3,19 @@ import * as dotenv from 'dotenv';
 import { serverConfig } from './config/serverConfig';
 import { Connection } from './db/Connection';
 import express from 'express';
+import { uploadTransactionBundle } from './services/BaseService';
 
 dotenv.config();
 
 const app = express();
 app.use(express.json({ limit: '50mb', type: 'application/json+fhir' }));
 app.use(express.json({ limit: '50mb', type: 'application/fhir+json' }));
+
+app.post('/:base_version/', (req, res, next) => {
+  return uploadTransactionBundle(req, res)
+    .then(result => res.status(200).json(result))
+    .catch(err => next(err));
+});
 
 const server = initialize(serverConfig, app);
 const logger = loggers.get('default');

--- a/backend/src/services/BaseService.ts
+++ b/backend/src/services/BaseService.ts
@@ -23,7 +23,7 @@ export async function uploadTransactionBundle(req: any, res: any) {
     throw new BadRequestError(`Expected 'resourceType: Bundle'. Received 'resourceType: ${req.body.resourceType}'.`);
   }
 
-  if (req.body.type.toLowerCase() != 'transaction') {
+  if (req.body.type.toLowerCase() !== 'transaction') {
     throw new BadRequestError(`Expected 'type: transaction'. Received 'type: ${req.body.type}'.`);
   }
 
@@ -59,14 +59,14 @@ async function uploadResourcesFromBundle(entries: DetailedEntry[]) {
 }
 
 /**
- * Inserts bundle Library or Measure resources into the database through create or update.
+ * Inserts Library or Measure resources from Bundle into the database through create or update.
  */
 async function insertBundleResources(entry: DetailedEntry, method: string) {
   if (entry.resource?.resourceType === 'Library' || entry.resource?.resourceType === 'Measure') {
     if (method === 'POST') {
       entry.resource.id = uuidv4();
       const { id } = await createResource(entry.resource, entry.resource.resourceType);
-      if (id !== null) {
+      if (id != null) {
         entry.status = 201;
         entry.statusText = 'Created';
       }
@@ -105,8 +105,8 @@ function makeTransactionResponseBundle(
 ) {
   logger.info('Compiling transaction-response bundle');
   const Bundle = resolveSchema(baseVersion, 'bundle');
-  const bundle = new Bundle({ type: 'transaction-response', id: uuidv4() });
-  bundle.link = {
+  const responseBundle = new Bundle({ type: 'transaction-response', id: uuidv4() });
+  responseBundle.link = {
     url: `${res.req.protocol}://${path.join(res.req.get('host'), res.req.baseUrl)}`,
     relation: 'self'
   };
@@ -120,7 +120,7 @@ function makeTransactionResponseBundle(
     entries.push(entry);
   });
 
-  bundle.entry = entries;
+  responseBundle.entry = entries;
   logger.info('Completed transaction response');
-  return bundle;
+  return responseBundle;
 }

--- a/backend/src/services/BaseService.ts
+++ b/backend/src/services/BaseService.ts
@@ -49,7 +49,7 @@ async function uploadResourcesFromBundle(entries: DetailedEntry[]) {
           `Expected requests of type PUT or POST, received ${method} for ${entry.resource?.resourceType}/${entry.resource?.id}`
         );
       } else {
-        return insertBundleResources(entry, method);
+        return insertBundleResources(entry);
       }
     } else {
       throw new BadRequestError('Each entry must contain request details that provide the HTTP details of the action.');
@@ -61,17 +61,16 @@ async function uploadResourcesFromBundle(entries: DetailedEntry[]) {
 /**
  * Inserts Library or Measure resources from Bundle into the database through create or update.
  */
-async function insertBundleResources(entry: DetailedEntry, method: string) {
+async function insertBundleResources(entry: DetailedEntry) {
   if (entry.resource?.resourceType === 'Library' || entry.resource?.resourceType === 'Measure') {
-    if (method === 'POST') {
+    if (entry.isPost) {
       entry.resource.id = uuidv4();
       const { id } = await createResource(entry.resource, entry.resource.resourceType);
       if (id != null) {
         entry.status = 201;
         entry.statusText = 'Created';
       }
-    }
-    if (method === 'PUT') {
+    } else {
       if (entry.resource.id) {
         const { id, created } = await updateResource(entry.resource.id, entry.resource, entry.resource.resourceType);
         if (created === true) {

--- a/backend/src/services/BaseService.ts
+++ b/backend/src/services/BaseService.ts
@@ -13,7 +13,6 @@ const logger = loggers.get('default');
  */
 export async function uploadTransactionBundle(req: any, res: any) {
   logger.info('POST /');
-  logger.info(`Base >>> transaction`);
   const contentType: string | undefined = req.headers['content-type'];
   checkContentTypeHeader(contentType);
 
@@ -25,7 +24,7 @@ export async function uploadTransactionBundle(req: any, res: any) {
   }
 
   if (req.body.type.toLowerCase() != 'transaction') {
-    throw new BadRequestError(`Expected 'type: transaction. Received type: ${req.body.type}'.`);
+    throw new BadRequestError(`Expected 'type: transaction'. Received 'type: ${req.body.type}'.`);
   }
 
   const requestResults = await uploadResourcesFromBundle(entries);
@@ -39,7 +38,7 @@ export async function uploadTransactionBundle(req: any, res: any) {
  * Uploads Library and Measure resources from a transaction bundle to the server.
  */
 async function uploadResourcesFromBundle(entries: DetailedEntry[]) {
-  logger.info(`Inserting Measure and Library resources from transaction bundle`);
+  logger.info('Inserting Measure and Library resources from transaction bundle');
   const scrubbedEntries = replaceReferences(entries);
 
   const requestsArray = scrubbedEntries.map(async entry => {
@@ -73,7 +72,7 @@ async function insertBundleResources(entry: DetailedEntry, method: string) {
           entry.statusText = 'OK';
         }
       } else {
-        throw new BadRequestError(`Requests of type PUT must have an id associated with the resource.`);
+        throw new BadRequestError('Requests of type PUT must have an id associated with the resource.');
       }
     } else {
       throw new BadRequestError(
@@ -94,7 +93,7 @@ function makeTransactionResponseBundle(
   res: any,
   baseVersion: keyof typeof constants.VERSIONS
 ) {
-  logger.info('Compiling transaction response bundle');
+  logger.info('Compiling transaction-response bundle');
   const Bundle = resolveSchema(baseVersion, 'bundle');
   const bundle = new Bundle({ type: 'transaction-response', id: uuidv4() });
   bundle.link = {
@@ -112,6 +111,6 @@ function makeTransactionResponseBundle(
   });
 
   bundle.entry = entries;
-  logger.info(`Completed transaction response`);
+  logger.info('Completed transaction response');
   return bundle;
 }

--- a/backend/src/services/BaseService.ts
+++ b/backend/src/services/BaseService.ts
@@ -80,7 +80,11 @@ async function insertBundleResources(entry: DetailedEntry, method: string) {
       );
     }
   } else {
-    throw new BadRequestError('Resource in the entry must be of type Measure or Library.');
+    throw new BadRequestError(
+      entry.resource
+        ? `All resource entries must be of either resourceType 'Measure' or 'Library'. Received resourceType ${entry.resource?.resourceType}.`
+        : `All entries must contain resources of resourceType 'Measure' or 'Library'.`
+    );
   }
   return entry;
 }

--- a/backend/src/services/BaseService.ts
+++ b/backend/src/services/BaseService.ts
@@ -1,0 +1,117 @@
+import { loggers, constants, resolveSchema } from '@projecttacoma/node-fhir-server-core';
+import { BadRequestError } from '../util/errorUtils';
+import { checkContentTypeHeader } from '../util/inputUtils';
+import { v4 as uuidv4 } from 'uuid';
+import { createResource, updateResource } from '../db/dbOperations';
+import path from 'path';
+import { DetailedEntry, replaceReferences } from '../util/baseUtils';
+
+const logger = loggers.get('default');
+
+/**
+ * Uploads a transaction bundle to the server and returns the transaction-response bundle.
+ */
+export async function uploadTransactionBundle(req: any, res: any) {
+  logger.info('POST /');
+  logger.info(`Base >>> transaction`);
+  const contentType: string | undefined = req.headers['content-type'];
+  checkContentTypeHeader(contentType);
+
+  const entries: DetailedEntry[] = req.body.entry;
+  const baseVersion: keyof typeof constants.VERSIONS = req.params.base_version;
+
+  if (req.body.resourceType !== 'Bundle') {
+    throw new BadRequestError(`Expected 'resourceType: Bundle'. Received 'resourceType: ${req.body.resourceType}'.`);
+  }
+
+  if (req.body.type.toLowerCase() != 'transaction') {
+    throw new BadRequestError(`Expected 'type: transaction. Received type: ${req.body.type}'.`);
+  }
+
+  const requestResults = await uploadResourcesFromBundle(entries);
+
+  const bundle = makeTransactionResponseBundle(requestResults, res, baseVersion);
+  logger.info('Transaction bundle successfully uploaded.');
+  return bundle;
+}
+
+/**
+ * Uploads Library and Measure resources from a transaction bundle to the server.
+ */
+async function uploadResourcesFromBundle(entries: DetailedEntry[]) {
+  logger.info(`Inserting Measure and Library resources from transaction bundle`);
+  const scrubbedEntries = replaceReferences(entries);
+
+  const requestsArray = scrubbedEntries.map(async entry => {
+    const { method } = entry.request as fhir4.BundleEntryRequest;
+    return insertBundleResources(entry, method);
+  });
+  return Promise.all(requestsArray);
+}
+
+/**
+ * Inserts bundle Library or Measure resources into the database through create or update.
+ */
+async function insertBundleResources(entry: DetailedEntry, method: string) {
+  if (entry.resource?.resourceType === 'Library' || entry.resource?.resourceType === 'Measure') {
+    if (method === 'POST') {
+      entry.resource.id = uuidv4();
+      const { id } = await createResource(entry.resource, entry.resource.resourceType);
+      if (id !== null) {
+        entry.status = 201;
+        entry.statusText = 'Created';
+      }
+    }
+    if (method === 'PUT') {
+      if (entry.resource.id) {
+        const { id, created } = await updateResource(entry.resource.id, entry.resource, entry.resource.resourceType);
+        if (created === true) {
+          entry.status = 201;
+          entry.statusText = 'Created';
+        } else if (id != null && created === false) {
+          entry.status = 200;
+          entry.statusText = 'OK';
+        }
+      } else {
+        throw new BadRequestError(`Requests of type PUT must have an id associated with the resource.`);
+      }
+    } else {
+      throw new BadRequestError(
+        `Expected requests of type PUT or POST, received ${method} for ${entry.resource?.resourceType}/${entry.resource?.id}`
+      );
+    }
+  } else {
+    throw new BadRequestError('Resource in the entry must be of type Measure or Library.');
+  }
+  return entry;
+}
+
+/**
+ * Creates transaction-response bundle.
+ */
+function makeTransactionResponseBundle(
+  requestResults: DetailedEntry[],
+  res: any,
+  baseVersion: keyof typeof constants.VERSIONS
+) {
+  logger.info('Compiling transaction response bundle');
+  const Bundle = resolveSchema(baseVersion, 'bundle');
+  const bundle = new Bundle({ type: 'transaction-response', id: uuidv4() });
+  bundle.link = {
+    url: `${res.req.protocol}://${path.join(res.req.get('host'), res.req.baseUrl)}`,
+    relation: 'self'
+  };
+
+  const entries: fhir4.BundleEntry[] = [];
+  requestResults.forEach(result => {
+    const entry = new Bundle({ response: { status: `${result.status} ${result.statusText}` } });
+    if (result.status === 200 || result.status === 201) {
+      entry.response.location = `${baseVersion}/${result.resource?.resourceType}/${result.resource?.id}`;
+    }
+    entries.push(entry);
+  });
+
+  bundle.entry = entries;
+  logger.info(`Completed transaction response`);
+  return bundle;
+}

--- a/backend/src/util/baseUtils.ts
+++ b/backend/src/util/baseUtils.ts
@@ -5,11 +5,11 @@ const logger = loggers.get('default');
 
 export type DetailedEntry = fhir4.BundleEntry & {
   isPost: boolean;
-  oldId: string | undefined;
+  oldId?: string;
   newId: string;
-  status: number | undefined;
-  statusText: string | undefined;
-  data: string | undefined;
+  status?: number;
+  statusText?: string;
+  data?: string;
 };
 
 /**

--- a/backend/src/util/baseUtils.ts
+++ b/backend/src/util/baseUtils.ts
@@ -1,0 +1,63 @@
+import { v4 as uuidv4 } from 'uuid';
+import { loggers } from '@projecttacoma/node-fhir-server-core';
+
+const logger = loggers.get('default');
+
+export type DetailedEntry = fhir4.BundleEntry & {
+  isPost: boolean;
+  oldId: string | undefined;
+  newId: string;
+  status: number | undefined;
+  statusText: string | undefined;
+  data: string | undefined;
+};
+
+/**
+ * For entries in a transaction bundle whose IDs will be auto-generated, replace all instances of an existing reference
+ * to the old id with a reference to the newly generated one.
+ *
+ * Modify the request type to PUT after forcing the IDs. This will not affect returns results, just internal representation
+ */
+export function replaceReferences(entries: DetailedEntry[]) {
+  entries.forEach(e => {
+    logger.debug(`Replacing resourceIds for entry: ${JSON.stringify(e)}`);
+    if (e.request?.method === 'POST' && e.resource) {
+      e.isPost = true;
+      e.oldId = e.resource.id;
+      e.newId = uuidv4();
+    }
+  });
+
+  let entriesStr = JSON.stringify(entries);
+  const postEntries = entries.filter(e => e.isPost);
+
+  // For each POST entry, replace existing reference across all entries
+  postEntries.forEach(e => {
+    logger.debug(`Replacing referenceIds for entry: ${JSON.stringify(e)}`);
+    // Checking full Url and id in separate replace loops will prevent invalid ResourceType/ResourceId -> urn:uuid references
+    if (e.oldId) {
+      const idRegexp = new RegExp(`${e.resource?.resourceType}/${e.oldId}`, 'g');
+      entriesStr = entriesStr.replace(idRegexp, `${e.resource?.resourceType}/${e.newId}`);
+    }
+    if (e.fullUrl) {
+      const urnRegexp = new RegExp(e.fullUrl, 'g');
+      entriesStr = entriesStr.replace(urnRegexp, `${e.resource?.resourceType}/${e.newId}`);
+    }
+  });
+
+  // Remove metadata and modify request type/resource id
+  const newEntries: DetailedEntry[] = JSON.parse(entriesStr).map((e: DetailedEntry) => {
+    if (e.isPost) {
+      if (e.resource) {
+        logger.debug(`Removing metadata and changing request type to PUT for entry: ${JSON.stringify(e)}`);
+        e.resource.id = e.newId;
+        e.request = {
+          method: 'PUT',
+          url: `${e.resource?.resourceType}/${e.newId}`
+        };
+      }
+    }
+    return { resource: e.resource, request: e.request };
+  });
+  return newEntries;
+}

--- a/backend/src/util/baseUtils.ts
+++ b/backend/src/util/baseUtils.ts
@@ -16,7 +16,7 @@ export type DetailedEntry = fhir4.BundleEntry & {
  * For entries in a transaction bundle whose IDs will be auto-generated, replace all instances of an existing reference
  * to the old id with a reference to the newly generated one.
  *
- * Modify the request type to PUT after forcing the IDs. This will not affect returns results, just internal representation
+ * Modify the request type to PUT after forcing the IDs. This will not affect return results, just internal representation
  */
 export function replaceReferences(entries: DetailedEntry[]) {
   entries.forEach(e => {
@@ -31,7 +31,7 @@ export function replaceReferences(entries: DetailedEntry[]) {
   let entriesStr = JSON.stringify(entries);
   const postEntries = entries.filter(e => e.isPost);
 
-  // For each POST entry, replace existing reference across all entries
+  // For each POST entry, replace existing references across all entries
   postEntries.forEach(e => {
     logger.debug(`Replacing referenceIds for entry: ${JSON.stringify(e)}`);
     // Checking full Url and id in separate replace loops will prevent invalid ResourceType/ResourceId -> urn:uuid references

--- a/backend/test/services/BaseService.test.ts
+++ b/backend/test/services/BaseService.test.ts
@@ -1,8 +1,7 @@
 import { initialize, Server } from '@projecttacoma/node-fhir-server-core';
-import express from 'express';
 import supertest from 'supertest';
+import { app } from '../../src/app';
 import { serverConfig } from '../../src/config/serverConfig';
-import { uploadTransactionBundle } from '../../src/services/BaseService';
 import { cleanUpTestDatabase, setupTestDatabase } from '../utils';
 
 let server: Server;
@@ -113,14 +112,6 @@ const VALID_POST_REQ = {
 
 describe('BaseService', () => {
   beforeAll(async () => {
-    const app = express();
-    app.use(express.json({ limit: '50mb', type: 'application/json+fhir' }));
-    app.use(express.json({ limit: '50mb', type: 'application/fhir+json' }));
-    app.post('/:base_version/', (req, res, next) => {
-      return uploadTransactionBundle(req, res)
-        .then(result => res.status(200).json(result))
-        .catch(err => next(err));
-    });
     server = initialize(serverConfig, app);
     return setupTestDatabase([]);
   });

--- a/backend/test/services/BaseService.test.ts
+++ b/backend/test/services/BaseService.test.ts
@@ -75,6 +75,19 @@ const INVALID_ENTRY_REQ = {
   ]
 };
 
+const INVALID_REQ = {
+  resourceType: 'Bundle',
+  type: 'transaction',
+  entry: [
+    {
+      invalid: {
+        resourceType: 'Invalid',
+        id: 'test-library'
+      }
+    }
+  ]
+};
+
 const VALID_PUT_REQ = {
   resourceType: 'Bundle',
   type: 'transaction',
@@ -167,6 +180,19 @@ describe('BaseService', () => {
         .then(response => {
           expect(response.body.issue[0].details.text).toEqual(
             `All entries must contain resources of resourceType 'Measure' or 'Library'.`
+          );
+        });
+    });
+
+    it('returns 400 when the transaction bundle contains an entry where entry.request is undefined', async () => {
+      await supertest(server.app)
+        .post('/4_0_1/')
+        .send(INVALID_REQ)
+        .set('content-type', 'application/json+fhir')
+        .expect(400)
+        .then(response => {
+          expect(response.body.issue[0].details.text).toEqual(
+            'Each entry must contain request details that provide the HTTP details of the action.'
           );
         });
     });

--- a/backend/test/services/BaseService.test.ts
+++ b/backend/test/services/BaseService.test.ts
@@ -170,7 +170,9 @@ describe('BaseService', () => {
         .set('content-type', 'application/json+fhir')
         .expect(400)
         .then(response => {
-          expect(response.body.issue[0].details.text).toEqual(`Expected 'type: transaction. Received type: invalid'.`);
+          expect(response.body.issue[0].details.text).toEqual(
+            `Expected 'type: transaction'. Received 'type: invalid'.`
+          );
         });
     });
 

--- a/backend/test/services/BaseService.test.ts
+++ b/backend/test/services/BaseService.test.ts
@@ -1,0 +1,206 @@
+import { initialize, Server } from '@projecttacoma/node-fhir-server-core';
+import express from 'express';
+import supertest from 'supertest';
+import { serverConfig } from '../../src/config/serverConfig';
+import { uploadTransactionBundle } from '../../src/services/BaseService';
+import { cleanUpTestDatabase, setupTestDatabase } from '../utils';
+
+let server: Server;
+
+const INVALID_METHOD_REQ = {
+  resourceType: 'Bundle',
+  type: 'transaction',
+  entry: [
+    {
+      resource: {
+        resourceType: 'Measure',
+        id: 'test-measure',
+        library: ['Library/test-library']
+      },
+      request: {
+        method: 'GET',
+        url: 'Measure/test-measure'
+      }
+    }
+  ]
+};
+
+const INVALID_PUT_REQ = {
+  resourceType: 'Bundle',
+  type: 'transaction',
+  entry: [
+    {
+      resource: {
+        resourceType: 'Measure',
+        library: ['Library/test-library']
+      },
+      request: {
+        method: 'PUT',
+        url: 'Measure/test-measure'
+      }
+    }
+  ]
+};
+
+const INVALID_RESOURCE_REQ = {
+  resourceType: 'Bundle',
+  type: 'transaction',
+  entry: [
+    {
+      resource: {
+        resourceType: 'Invalid',
+        id: 'test-library'
+      },
+      request: {
+        method: 'POST',
+        url: 'Library/test-library'
+      }
+    }
+  ]
+};
+
+const VALID_PUT_REQ = {
+  resourceType: 'Bundle',
+  type: 'transaction',
+  entry: [
+    {
+      resource: {
+        resourceType: 'Measure',
+        id: 'test-measure',
+        library: ['Library/test-library']
+      },
+      request: {
+        method: 'PUT',
+        url: 'Measure/test-measure'
+      }
+    }
+  ]
+};
+
+const VALID_POST_REQ = {
+  resourceType: 'Bundle',
+  type: 'transaction',
+  entry: [
+    {
+      resource: {
+        resourceType: 'Library',
+        id: 'test-library'
+      },
+      request: {
+        method: 'POST',
+        url: 'Library/test-library'
+      }
+    }
+  ]
+};
+
+describe('BaseService', () => {
+  beforeAll(async () => {
+    const app = express();
+    app.use(express.json({ limit: '50mb', type: 'application/json+fhir' }));
+    app.use(express.json({ limit: '50mb', type: 'application/fhir+json' }));
+    app.post('/:base_version/', (req, res, next) => {
+      return uploadTransactionBundle(req, res)
+        .then(result => res.status(200).json(result))
+        .catch(err => next(err));
+    });
+    server = initialize(serverConfig, app);
+    return setupTestDatabase([]);
+  });
+
+  describe('uploadTransactionBundle', () => {
+    it('returns 200 and transaction-response bundle when a transaction bundle with correct resource, headers, and PUT request is uploaded', async () => {
+      await supertest(server.app)
+        .post('/4_0_1/')
+        .send(VALID_PUT_REQ)
+        .set('content-type', 'application/json+fhir')
+        .expect(200)
+        .then(response => {
+          expect(response.body.resourceType).toEqual('Bundle');
+          expect(response.body.type).toEqual('transaction-response');
+          expect(response.body.entry[0].response.status).toEqual('201 Created');
+          expect(response.body.entry[0].response.location).toEqual('4_0_1/Measure/test-measure');
+        });
+    });
+
+    it('returns 200 and transaction-response bundle when a transaction bundle with correct resource, headers, and POST request is uploaded', async () => {
+      await supertest(server.app)
+        .post('/4_0_1/')
+        .send(VALID_POST_REQ)
+        .set('content-type', 'application/json+fhir')
+        .expect(200)
+        .then(response => {
+          expect(response.body.resourceType).toEqual('Bundle');
+          expect(response.body.type).toEqual('transaction-response');
+          expect(response.body.entry[0].response.status).toEqual('201 Created');
+          expect(response.body.entry[0].response.location).toBeDefined();
+        });
+    });
+
+    it('returns 400 when the transaction bundle contains a resource that is not a Library or Measure', async () => {
+      await supertest(server.app)
+        .post('/4_0_1/')
+        .send(INVALID_RESOURCE_REQ)
+        .set('content-type', 'application/json+fhir')
+        .expect(400)
+        .then(response => {
+          expect(response.body.issue[0].details.text).toEqual(
+            'Resource in the entry must be of type Measure or Library.'
+          );
+        });
+    });
+
+    it('returns 400 when resource type is not Bundle', async () => {
+      await supertest(server.app)
+        .post('/4_0_1/')
+        .send({ resourceType: 'invalid', type: 'transaction' })
+        .set('content-type', 'application/json+fhir')
+        .expect(400)
+        .then(response => {
+          expect(response.body.issue[0].details.text).toEqual(
+            `Expected 'resourceType: Bundle'. Received 'resourceType: invalid'.`
+          );
+        });
+    });
+
+    it('returns 400 when Bundle is not of type transaction', async () => {
+      await supertest(server.app)
+        .post('/4_0_1/')
+        .send({ resourceType: 'Bundle', type: 'invalid' })
+        .set('content-type', 'application/json+fhir')
+        .expect(400)
+        .then(response => {
+          expect(response.body.issue[0].details.text).toEqual(`Expected 'type: transaction. Received type: invalid'.`);
+        });
+    });
+
+    it('returns 400 when transaction bundle has requests not of type PUT or POST', async () => {
+      await supertest(server.app)
+        .post('/4_0_1/')
+        .send(INVALID_METHOD_REQ)
+        .set('content-type', 'application/json+fhir')
+        .expect(400)
+        .then(response => {
+          expect(response.body.issue[0].details.text).toEqual(
+            `Expected requests of type PUT or POST, received GET for Measure/test-measure`
+          );
+        });
+    });
+
+    it('returns 400 when transaction bundle has a PUT request that does not contain an id for the resource', async () => {
+      await supertest(server.app)
+        .post('/4_0_1/')
+        .send(INVALID_PUT_REQ)
+        .set('content-type', 'application/json+fhir')
+        .expect(400)
+        .then(response => {
+          expect(response.body.issue[0].details.text).toEqual(
+            `Requests of type PUT must have an id associated with the resource.`
+          );
+        });
+    });
+  });
+  afterAll(() => {
+    return cleanUpTestDatabase();
+  });
+});

--- a/backend/test/services/BaseService.test.ts
+++ b/backend/test/services/BaseService.test.ts
@@ -59,6 +59,23 @@ const INVALID_RESOURCE_REQ = {
   ]
 };
 
+const INVALID_ENTRY_REQ = {
+  resourceType: 'Bundle',
+  type: 'transaction',
+  entry: [
+    {
+      invalid: {
+        resourceType: 'Invalid',
+        id: 'test-library'
+      },
+      request: {
+        method: 'POST',
+        url: 'Library/test-library'
+      }
+    }
+  ]
+};
+
 const VALID_PUT_REQ = {
   resourceType: 'Bundle',
   type: 'transaction',
@@ -145,7 +162,20 @@ describe('BaseService', () => {
         .expect(400)
         .then(response => {
           expect(response.body.issue[0].details.text).toEqual(
-            'Resource in the entry must be of type Measure or Library.'
+            `All resource entries must be of either resourceType 'Measure' or 'Library'. Received resourceType Invalid.`
+          );
+        });
+    });
+
+    it('returns 400 when the transaction bundle contains an entry where entry.resource is undefined', async () => {
+      await supertest(server.app)
+        .post('/4_0_1/')
+        .send(INVALID_ENTRY_REQ)
+        .set('content-type', 'application/json+fhir')
+        .expect(400)
+        .then(response => {
+          expect(response.body.issue[0].details.text).toEqual(
+            `All entries must contain resources of resourceType 'Measure' or 'Library'.`
           );
         });
     });


### PR DESCRIPTION
# Summary
This PR allows the measure-repository-service to accept artifacts (Libraries and Measure resources only) as transaction bundles. 

## New behavior
Creates the `/:base_version/` endpoint (`/4_0_1/`) for POST requests where the body of the request includes a transaction Bundle of entries that SHALL include a resource (Measure or Library) and request (PUT or POST). 

## Code changes
- `backend/src/index.ts` - `/:base_version/` transaction upload endpoint.
- `backend/src/services/BaseService.ts` - new file to hold all the functions associated with uploading a transaction bundle.
- `backend/src/util/baseUtils.ts` - new file to hold `replaceReferences()`. Let me know if this is unnecessary or if any other functions from `BaseService.ts` should reside here instead. Also includes the `DetailedEntry` type.
- `backend/test/services/BaseService.test.ts` - unit tests for the transaction upload functionality.

# Testing guidance
- `npm run check:all`
- `npm run start:backend`
- Send some transaction bundles to `http://localhost:3000/4_0_1/` through Insomnia or something else. Make sure the `content-type` header is set to `application/json+fhir`. 
- Make sure errors are thrown in the following cases:
1. Request body is not a Bundle
2. Request body is a Bundle but not of type transaction
3. Request body is a transaction bundle but includes an entry whose resource that is not Measure or Library.
4. Request body is a transaction bundle but includes an entry whose request is not PUT or POST.
5. Request body is a transaction bundle but includes an entry whose request is PUT but whose resource does not have an id.