### PR TITLE
Added view of resource narrative if it exists on resources

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,7 @@
     "@mantine/notifications": "^6.0.6",
     "@mantine/prism": "^6.0.7",
     "@types/fhir": "^0.0.36",
+    "html-react-parser": "^3.0.15",
     "next": "13.2.4",
     "prism-react-renderer": "^1.3.5",
     "react": "18.2.0",

--- a/frontend/pages/[resourceType]/[id].tsx
+++ b/frontend/pages/[resourceType]/[id].tsx
@@ -1,11 +1,12 @@
 import { Prism } from '@mantine/prism';
-import { Divider, Group, Stack, Tabs, Text } from '@mantine/core';
+import { Divider, Group, Space, Stack, Tabs, Text } from '@mantine/core';
 import { GetServerSideProps, InferGetServerSidePropsType } from 'next';
 import { FhirArtifact } from '@/util/types/fhir';
 import BackButton from '../../components/BackButton';
 import { useEffect, useMemo } from 'react';
 import CQLRegex from '../../util/prismCQL';
 import { Prism as PrismRenderer } from 'prism-react-renderer';
+import parse from 'html-react-parser';
 
 /**
  * Component which displays the JSON/ELM/CQL/narrative content of an individual resource using
@@ -46,9 +47,7 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
               ELM
             </Tabs.Tab>
             {decodedCql != null && <Tabs.Tab value="cql">CQL</Tabs.Tab>}
-            <Tabs.Tab value="narrative" disabled>
-              Narrative
-            </Tabs.Tab>
+            {jsonData.text && <Tabs.Tab value="narrative">Narrative</Tabs.Tab>}
           </Tabs.List>
           <Tabs.Panel value="json" pt="xs">
             <Prism language="json" colorScheme="light">
@@ -62,6 +61,12 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
                 {/* eslint-enable  @typescript-eslint/no-explicit-any */}
                 {decodedCql}
               </Prism>
+            </Tabs.Panel>
+          )}
+          {jsonData.text && (
+            <Tabs.Panel value="narrative">
+              <Space h="sm" />
+              {parse(jsonData.text.div)}
             </Tabs.Panel>
           )}
         </Tabs>

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -19,3 +19,7 @@ a {
   color: inherit;
   text-decoration: none;
 }
+
+th {
+  text-align: left;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -6961,6 +6961,7 @@
         "@mantine/notifications": "^6.0.6",
         "@mantine/prism": "^6.0.7",
         "@types/fhir": "^0.0.36",
+        "html-react-parser": "^3.0.15",
         "next": "13.2.4",
         "prism-react-renderer": "^1.3.5",
         "react": "18.2.0",
@@ -7306,6 +7307,46 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "frontend/node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "frontend/node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "frontend/node_modules/domutils": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
+      "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "frontend/node_modules/emoji-regex": {
       "version": "9.2.2",
       "dev": true,
@@ -7321,6 +7362,17 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "frontend/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "frontend/node_modules/es-abstract": {
@@ -7890,6 +7942,47 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "frontend/node_modules/html-dom-parser": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-3.1.7.tgz",
+      "integrity": "sha512-cDgNF4YgF6J3H+d9mcldGL19p0GzVdS3iGuDNzYWQpU47q3+IRM85X3Xo07E+nntF4ek4s78A9V24EwxlPTjig==",
+      "dependencies": {
+        "domhandler": "5.0.3",
+        "htmlparser2": "8.0.2"
+      }
+    },
+    "frontend/node_modules/html-react-parser": {
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-3.0.15.tgz",
+      "integrity": "sha512-iM2KUVhNoeIsezbpO6xwOHlFqWH+EYaCGwWWeX7R+jvrgc+mbnuouWaCU8GZRRbPKDD0eJXPZwLoeGVft84QXw==",
+      "dependencies": {
+        "domhandler": "5.0.3",
+        "html-dom-parser": "3.1.7",
+        "react-property": "2.0.0",
+        "style-to-js": "1.1.3"
+      },
+      "peerDependencies": {
+        "react": "0.14 || 15 || 16 || 17 || 18"
+      }
+    },
+    "frontend/node_modules/htmlparser2": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "entities": "^4.4.0"
+      }
+    },
     "frontend/node_modules/internal-slot": {
       "version": "1.0.5",
       "dev": true,
@@ -8432,6 +8525,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "frontend/node_modules/style-to-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.3.tgz",
+      "integrity": "sha512-zKI5gN/zb7LS/Vm0eUwjmjrXWw8IMtyA8aPBJZdYiQTXj4+wQ3IucOLIOnF7zCHxvW8UhIGh/uZh/t9zEHXNTQ==",
+      "dependencies": {
+        "style-to-object": "0.4.1"
+      }
+    },
+    "frontend/node_modules/style-to-object": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.4.1.tgz",
+      "integrity": "sha512-HFpbb5gr2ypci7Qw+IOhnP2zOU7e77b+rzM+wTzXzfi1PrtBCX0E7Pk4wL4iTLnhzZ+JgEGAhX81ebTg/aYjQw==",
+      "dependencies": {
+        "inline-style-parser": "0.1.1"
       }
     },
     "frontend/node_modules/synckit": {
@@ -13776,9 +13885,10 @@
         "eslint": "^8.28.0",
         "eslint-config-next": "13.2.4",
         "eslint-config-prettier": "^8.5.0",
+        "html-react-parser": "*",
         "next": "13.2.4",
         "prettier": "^2.8.5",
-        "prism-react-renderer": "*",
+        "prism-react-renderer": "^1.3.5",
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "tabler-icons-react": "^1.56.0",
@@ -14016,6 +14126,34 @@
             "object-keys": "^1.1.1"
           }
         },
+        "dom-serializer": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+          "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+          "requires": {
+            "domelementtype": "^2.3.0",
+            "domhandler": "^5.0.2",
+            "entities": "^4.2.0"
+          }
+        },
+        "domhandler": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+          "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+          "requires": {
+            "domelementtype": "^2.3.0"
+          }
+        },
+        "domutils": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
+          "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
+          "requires": {
+            "dom-serializer": "^2.0.0",
+            "domelementtype": "^2.3.0",
+            "domhandler": "^5.0.1"
+          }
+        },
         "emoji-regex": {
           "version": "9.2.2",
           "dev": true
@@ -14027,6 +14165,11 @@
             "graceful-fs": "^4.2.4",
             "tapable": "^2.2.0"
           }
+        },
+        "entities": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+          "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="
         },
         "es-abstract": {
           "version": "1.21.2",
@@ -14406,6 +14549,37 @@
             "has-symbols": "^1.0.2"
           }
         },
+        "html-dom-parser": {
+          "version": "3.1.7",
+          "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-3.1.7.tgz",
+          "integrity": "sha512-cDgNF4YgF6J3H+d9mcldGL19p0GzVdS3iGuDNzYWQpU47q3+IRM85X3Xo07E+nntF4ek4s78A9V24EwxlPTjig==",
+          "requires": {
+            "domhandler": "5.0.3",
+            "htmlparser2": "8.0.2"
+          }
+        },
+        "html-react-parser": {
+          "version": "3.0.15",
+          "resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-3.0.15.tgz",
+          "integrity": "sha512-iM2KUVhNoeIsezbpO6xwOHlFqWH+EYaCGwWWeX7R+jvrgc+mbnuouWaCU8GZRRbPKDD0eJXPZwLoeGVft84QXw==",
+          "requires": {
+            "domhandler": "5.0.3",
+            "html-dom-parser": "3.1.7",
+            "react-property": "2.0.0",
+            "style-to-js": "1.1.3"
+          }
+        },
+        "htmlparser2": {
+          "version": "8.0.2",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+          "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+          "requires": {
+            "domelementtype": "^2.3.0",
+            "domhandler": "^5.0.3",
+            "domutils": "^3.0.1",
+            "entities": "^4.4.0"
+          }
+        },
         "internal-slot": {
           "version": "1.0.5",
           "dev": true,
@@ -14725,6 +14899,22 @@
         "strip-bom": {
           "version": "3.0.0",
           "dev": true
+        },
+        "style-to-js": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.3.tgz",
+          "integrity": "sha512-zKI5gN/zb7LS/Vm0eUwjmjrXWw8IMtyA8aPBJZdYiQTXj4+wQ3IucOLIOnF7zCHxvW8UhIGh/uZh/t9zEHXNTQ==",
+          "requires": {
+            "style-to-object": "0.4.1"
+          }
+        },
+        "style-to-object": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.4.1.tgz",
+          "integrity": "sha512-HFpbb5gr2ypci7Qw+IOhnP2zOU7e77b+rzM+wTzXzfi1PrtBCX0E7Pk4wL4iTLnhzZ+JgEGAhX81ebTg/aYjQw==",
+          "requires": {
+            "inline-style-parser": "0.1.1"
+          }
         },
         "synckit": {
           "version": "0.8.5",


### PR DESCRIPTION
# Summary

Adds a tab to the resource page for the narrative if it exists.

## New behavior

Shows the narrative by pulling the HTML from the narrative right into the view.

## Code changes

New dependency `html-react-parser` to parse HTML string into react components. In `[id].tsx` add the tab and display of narrative. `global.css` add some override of default `th` elements to make it look better.

# Testing guidance

Load up resources into measure repository. In ecqm-content-r4-2021 the Library FHIR-ModelInfo has a narrative (i.e. `text`), ensure it shows up in the page for the resource. For other resources that do not have the `text` narrative field, ensure the "Narrative" tab does not appear.
