### PR TITLE
Show resources, operations, and search parameters that are part of th…

### DIFF
--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -41,7 +41,13 @@ export default function Home({ capabilityStatement }: InferGetServerSidePropsTyp
                 <th>Search Parameters</th>
               </tr>
             </thead>
-            <tbody>{capabilityStatement.rest?.[0]?.resource?.map(r => CapabilityRow(r))}</tbody>
+            <tbody>
+              {capabilityStatement.rest?.[0]?.resource
+                ?.sort((a, b) => {
+                  return a.type > b.type ? 1 : -1; // sort alphabetical by resource type
+                })
+                .map(r => CapabilityRow(r))}
+            </tbody>
           </Table>
         ) : (
           <Text c="red.7" style={{ marginBottom: '8px' }}>

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -117,6 +117,7 @@ export function CapabilityRow(resource: fhir4.CapabilityStatementRestResource) {
           ?.map(o => {
             return o.name;
           })
+          .sort()
           .join(', ')}
       </td>
       <td>
@@ -124,6 +125,7 @@ export function CapabilityRow(resource: fhir4.CapabilityStatementRestResource) {
           ?.map(sp => {
             return sp.name;
           })
+          .sort()
           .join(', ')}
       </td>
     </tr>

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,6 +1,7 @@
-import { Anchor, Divider, List, Text, Title } from '@mantine/core';
+import { Anchor, Divider, List, Table, Text, Title } from '@mantine/core';
+import { GetServerSideProps, InferGetServerSidePropsType } from 'next';
 
-export default function Home() {
+export default function Home({ capabilityStatement }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   return (
     <div style={{ display: 'flex', height: '100%', width: '100%', flexDirection: 'column', padding: '4px 20px' }}>
       <Title order={2} underline>
@@ -25,8 +26,29 @@ export default function Home() {
       <Text>More functionality coming soon!</Text>
       <Divider my="sm" variant="dotted" />
       <Title order={2} underline style={{ marginBottom: '8px' }}>
-        Capabilities
+        Capabilities:
       </Title>
+      <Title order={3} underline>
+        Capability Statement
+      </Title>
+      <div style={{ marginBottom: '8px' }}>
+        {capabilityStatement ? (
+          <Table>
+            <thead>
+              <tr>
+                <th>Resource</th>
+                <th>Operations</th>
+                <th>Search Parameters</th>
+              </tr>
+            </thead>
+            <tbody>{capabilityStatement.rest?.[0]?.resource?.map(r => CapabilityRow(r))}</tbody>
+          </Table>
+        ) : (
+          <Text c="red.7" style={{ marginBottom: '8px' }}>
+            Capability Statement Unavailable
+          </Text>
+        )}
+      </div>
       <Title order={3} underline>
         Resource Read and Search
       </Title>
@@ -40,7 +62,7 @@ export default function Home() {
         parameters on the search page.
       </Text>
       <Title order={3} underline>
-        Authoring Functionality:
+        Authoring Functionality
       </Title>
       <Text>
         This application will provide a FHIR Measure and Library authoring environment as outlined in the{' '}
@@ -85,3 +107,36 @@ export default function Home() {
     </div>
   );
 }
+
+export function CapabilityRow(resource: fhir4.CapabilityStatementRestResource) {
+  return (
+    <tr key={`row-${resource.type}`}>
+      <td>{resource.type}</td>
+      <td>
+        {resource.operation
+          ?.map(o => {
+            return o.name;
+          })
+          .join(', ')}
+      </td>
+      <td>
+        {resource.searchParam
+          ?.map(sp => {
+            return sp.name;
+          })
+          .join(', ')}
+      </td>
+    </tr>
+  );
+}
+
+export const getServerSideProps: GetServerSideProps<{
+  capabilityStatement: fhir4.CapabilityStatement | null;
+}> = async () => {
+  // Fetch resource data
+  const res = await fetch(`${process.env.NEXT_PUBLIC_MRS_SERVER}/metadata`);
+  const capabilityStatement = res.status === 200 ? ((await res.json()) as fhir4.CapabilityStatement) : null;
+
+  // Pass to the page via props
+  return { props: { capabilityStatement: capabilityStatement } };
+};

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -133,10 +133,10 @@ export function CapabilityRow(resource: fhir4.CapabilityStatementRestResource) {
 export const getServerSideProps: GetServerSideProps<{
   capabilityStatement: fhir4.CapabilityStatement | null;
 }> = async () => {
-  // Fetch resource data
+  // Fetch CapabilityStatement
   const res = await fetch(`${process.env.NEXT_PUBLIC_MRS_SERVER}/metadata`);
   const capabilityStatement = res.status === 200 ? ((await res.json()) as fhir4.CapabilityStatement) : null;
 
   // Pass to the page via props
-  return { props: { capabilityStatement: capabilityStatement } };
+  return { props: { capabilityStatement } };
 };


### PR DESCRIPTION
…e capability statement

# Summary
List resource types, operations, and search parameters that are supported, according to the capability statement. Suggested UI: tabular.

## New behavior
Shows the capability statement information on the home page under the capabilities section.

## Code changes
The main `index.tsx` uses getServerSideProps to populate a capability statement property, which is then used to create a capability statement table in a new Capability Statement titled section. Additionally, small changes to colons to make consistent across page.

# Testing guidance
- `npm run check:all`
- `npm run start:all`
- Navigate to http://localhost:3001/ and view new Capability Statement section on the homepage
- Also check behavior for backend not started with `npm run start:frontend` and navigate to http://localhost:3000/