### PR TITLE
Added id to core search args

### DIFF
--- a/backend/src/requestSchemas.ts
+++ b/backend/src/requestSchemas.ts
@@ -172,6 +172,7 @@ export const CoreSearchArgs = z
     'derived-from': z.string(),
     description: z.string(),
     effective: z.string(),
+    id: z.string(),
     identifier: z.string(),
     jurisdiction: z.string(),
     name: z.string(),


### PR DESCRIPTION
# Summary
Id was left out of the core search args. This adds it.

## New behavior
We can now do queries including `id=resourceId`. Previously, we could only search by id in the url args like `localhost:3000/4_0_1/Measure/resourceId`

## Code changes
added id to core search args

# Testing guidance
- `npm run check`
- Test search functionality and make sure queries including and excluding `id` work as expected.
