### PR TITLE
Renders ELM for selected Library resource

### DIFF
--- a/app/src/pages/[resourceType]/[id].tsx
+++ b/app/src/pages/[resourceType]/[id].tsx
@@ -21,8 +21,8 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
     /* eslint-enable @typescript-eslint/no-explicit-any */
   }, []);
 
-  const decodedCql = decode('text/cql', jsonData);
-  const decodedElm = decode('application/elm+json', jsonData);
+  const decodedCql = Decode('text/cql', jsonData);
+  const decodedElm = Decode('application/elm+json', jsonData);
 
   return (
     <div>
@@ -76,17 +76,16 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
 }
 
 /**
- *
- * Function which extracts a specific language from the fhir artifact and then returns the decoded
- * version of that language
+ * Function which extracts specified content from JSON data and then returns the decoded
+ * version of that content (in this case the ELM/CQL)
  * @returns The decoded version of the ELM/CQL content
  */
-function decode(link: String, jsonData: FhirArtifact) {
+function Decode(link: string, jsonData: FhirArtifact) {
   const decodedLanguage = useMemo(() => {
     if (jsonData.resourceType === 'Measure') return null;
     const encodedLanguage = (jsonData as fhir4.Library).content?.find(e => e.contentType === link)?.data;
     return encodedLanguage ? Buffer.from(encodedLanguage, 'base64').toString() : null;
-  }, [jsonData]);
+  }, [jsonData, link]);
   return decodedLanguage;
 }
 

--- a/app/src/pages/[resourceType]/[id].tsx
+++ b/app/src/pages/[resourceType]/[id].tsx
@@ -21,8 +21,13 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
     /* eslint-enable @typescript-eslint/no-explicit-any */
   }, []);
 
-  const decodedCql = Decode('text/cql', jsonData);
-  const decodedElm = Decode('application/elm+json', jsonData);
+  const decodedCql = useMemo(() => {
+    return Decode('text/cql', jsonData);
+  }, [jsonData]);
+
+  const decodedElm = useMemo(() => {
+    return Decode('application/elm+json', jsonData);
+  }, [jsonData]);
 
   return (
     <div>
@@ -81,12 +86,9 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
  * @returns The decoded version of the ELM/CQL content
  */
 function Decode(link: string, jsonData: FhirArtifact) {
-  const decodedLanguage = useMemo(() => {
-    if (jsonData.resourceType === 'Measure') return null;
-    const encodedLanguage = (jsonData as fhir4.Library).content?.find(e => e.contentType === link)?.data;
-    return encodedLanguage ? Buffer.from(encodedLanguage, 'base64').toString() : null;
-  }, [jsonData, link]);
-  return decodedLanguage;
+  if (jsonData.resourceType === 'Measure') return null;
+  const encodedLanguage = (jsonData as fhir4.Library).content?.find(e => e.contentType === link)?.data;
+  return encodedLanguage ? Buffer.from(encodedLanguage, 'base64').toString() : null;
 }
 
 /**

--- a/app/src/pages/[resourceType]/[id].tsx
+++ b/app/src/pages/[resourceType]/[id].tsx
@@ -22,11 +22,11 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
   }, []);
 
   const decodedCql = useMemo(() => {
-    return Decode('text/cql', jsonData);
+    return decode('text/cql', jsonData);
   }, [jsonData]);
 
   const decodedElm = useMemo(() => {
-    return Decode('application/elm+json', jsonData);
+    return decode('application/elm+json', jsonData);
   }, [jsonData]);
 
   return (
@@ -85,7 +85,7 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
  * version of that content (in this case the ELM/CQL)
  * @returns The decoded version of the ELM/CQL content
  */
-function Decode(link: string, jsonData: FhirArtifact) {
+function decode(link: string, jsonData: FhirArtifact) {
   if (jsonData.resourceType === 'Measure') return null;
   const encodedLanguage = (jsonData as fhir4.Library).content?.find(e => e.contentType === link)?.data;
   return encodedLanguage ? Buffer.from(encodedLanguage, 'base64').toString() : null;

--- a/app/src/pages/[resourceType]/[id].tsx
+++ b/app/src/pages/[resourceType]/[id].tsx
@@ -68,7 +68,7 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
           {decodedELM != null && (
             <Tabs.Panel value="elm" pt="xs">
               {/* eslint-disable  @typescript-eslint/no-explicit-any */}
-              <Prism language={'elm' as any} colorScheme="light">
+              <Prism language="json" colorScheme="light">
                 {/* eslint-enable  @typescript-eslint/no-explicit-any */}
                 {decodedELM}
               </Prism>

--- a/app/src/pages/[resourceType]/[id].tsx
+++ b/app/src/pages/[resourceType]/[id].tsx
@@ -21,17 +21,8 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
     /* eslint-enable @typescript-eslint/no-explicit-any */
   }, []);
 
-  const decodedCql = useMemo(() => {
-    if (jsonData.resourceType === 'Measure') return null;
-    const encodedCql = (jsonData as fhir4.Library).content?.find(e => e.contentType === 'text/cql')?.data;
-    return encodedCql ? Buffer.from(encodedCql, 'base64').toString() : null;
-  }, [jsonData]);
-
-  const decodedELM = useMemo(() => {
-    if (jsonData.resourceType === 'Measure') return null;
-    const encodedELM = (jsonData as fhir4.Library).content?.find(e => e.contentType === 'application/elm+json')?.data;
-    return encodedELM ? Buffer.from(encodedELM, 'base64').toString() : null;
-  }, [jsonData]);
+  const decodedCql = decode('text/cql', jsonData);
+  const decodedElm = decode('application/elm+json', jsonData);
 
   return (
     <div>
@@ -47,7 +38,7 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
         <Tabs variant="outline" defaultValue="json">
           <Tabs.List>
             <Tabs.Tab value="json">JSON</Tabs.Tab>
-            {decodedELM != null && <Tabs.Tab value="elm">ELM</Tabs.Tab>}
+            {decodedElm != null && <Tabs.Tab value="elm">ELM</Tabs.Tab>}
             {decodedCql != null && <Tabs.Tab value="cql">CQL</Tabs.Tab>}
             {jsonData.text && <Tabs.Tab value="narrative">Narrative</Tabs.Tab>}
           </Tabs.List>
@@ -65,12 +56,10 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
               </Prism>
             </Tabs.Panel>
           )}
-          {decodedELM != null && (
+          {decodedElm != null && (
             <Tabs.Panel value="elm" pt="xs">
-              {/* eslint-disable  @typescript-eslint/no-explicit-any */}
               <Prism language="json" colorScheme="light">
-                {/* eslint-enable  @typescript-eslint/no-explicit-any */}
-                {decodedELM}
+                {decodedElm}
               </Prism>
             </Tabs.Panel>
           )}
@@ -84,6 +73,21 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
       </Stack>
     </div>
   );
+}
+
+/**
+ *
+ * Function which extracts a specific language from the fhir artifact and then returns the decoded
+ * version of that language
+ * @returns The decoded version of the ELM/CQL content
+ */
+function decode(link: String, jsonData: FhirArtifact) {
+  const decodedLanguage = useMemo(() => {
+    if (jsonData.resourceType === 'Measure') return null;
+    const encodedLanguage = (jsonData as fhir4.Library).content?.find(e => e.contentType === link)?.data;
+    return encodedLanguage ? Buffer.from(encodedLanguage, 'base64').toString() : null;
+  }, [jsonData]);
+  return decodedLanguage;
 }
 
 /**

--- a/app/src/pages/[resourceType]/[id].tsx
+++ b/app/src/pages/[resourceType]/[id].tsx
@@ -27,6 +27,12 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
     return encodedCql ? Buffer.from(encodedCql, 'base64').toString() : null;
   }, [jsonData]);
 
+  const decodedELM = useMemo(() => {
+    if (jsonData.resourceType === 'Measure') return null;
+    const encodedELM = (jsonData as fhir4.Library).content?.find(e => e.contentType === 'application/elm+json')?.data;
+    return encodedELM ? Buffer.from(encodedELM, 'base64').toString() : null;
+  }, [jsonData]);
+
   return (
     <div>
       <Stack spacing="xs">
@@ -41,9 +47,7 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
         <Tabs variant="outline" defaultValue="json">
           <Tabs.List>
             <Tabs.Tab value="json">JSON</Tabs.Tab>
-            <Tabs.Tab value="elm" disabled>
-              ELM
-            </Tabs.Tab>
+            {decodedELM != null && <Tabs.Tab value="elm">ELM</Tabs.Tab>}
             {decodedCql != null && <Tabs.Tab value="cql">CQL</Tabs.Tab>}
             {jsonData.text && <Tabs.Tab value="narrative">Narrative</Tabs.Tab>}
           </Tabs.List>
@@ -58,6 +62,15 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
               <Prism language={'cql' as any} colorScheme="light">
                 {/* eslint-enable  @typescript-eslint/no-explicit-any */}
                 {decodedCql}
+              </Prism>
+            </Tabs.Panel>
+          )}
+          {decodedELM != null && (
+            <Tabs.Panel value="elm" pt="xs">
+              {/* eslint-disable  @typescript-eslint/no-explicit-any */}
+              <Prism language={'elm' as any} colorScheme="light">
+                {/* eslint-enable  @typescript-eslint/no-explicit-any */}
+                {decodedELM}
               </Prism>
             </Tabs.Panel>
           )}


### PR DESCRIPTION
# Summary 
Renders ELM for selected Library resource

## New behavior
Users can now see the rendered ELM for a selected Library resource upon clicking the ELM tab.

## Code changes
`app/src/pages/[resourceType]/[id].tsx` - I enabled the ELM tab so that users can actually click on it when it appears. I added a new Prism component in the ELM tab and make the ELM tab appear/disappear whenever appropriate.

# Testing guidance
`npm run check:all`
`npm run start:all`
Navigate to http://localhost:3001/ and select both Measure and Library packages. Check that the ELM tab appears whenever the CQL tab appears, and likewise disappears if the CQL tab isn't present. The ELM tab should not appear for any Measures. Additionally, check that the ELM tab is enabled whenever it appears on the screen and that it appropriately renders ELM whenever it is selected by the user.
