### PR TITLE
Draft existing artifacts

### DIFF
--- a/app/src/pages/[resourceType]/[id].tsx
+++ b/app/src/pages/[resourceType]/[id].tsx
@@ -63,6 +63,7 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
   const cloneResource = () => {
     const newClonedResource = jsonData;
     newClonedResource.id = uuidv4();
+    newClonedResource.status = 'draft';
     draftMutation.mutate({ resourceType, draft: newClonedResource });
   };
 

--- a/app/src/pages/[resourceType]/[id].tsx
+++ b/app/src/pages/[resourceType]/[id].tsx
@@ -42,7 +42,7 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
     onSuccess: data => {
       notifications.show({
         title: `Draft ${jsonData.resourceType} Created!`,
-        message: `Draft ${jsonData.resourceType} successfully created from ${jsonData.resourceType}/${jsonData.id}`,
+        message: `Draft ${jsonData.resourceType}/${jsonData.id} successfully created`,
         icon: <CircleCheck />,
         color: 'green'
       });
@@ -52,7 +52,7 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
     onError: e => {
       notifications.show({
         title: `Draft ${jsonData.resourceType} Creation Failed!`,
-        message: `Attempt to create draft ${jsonData.resourceType} from ${jsonData.resourceType}/${jsonData.id} failed with message: ${e.message}`,
+        message: `Attempt to create draft of ${jsonData.resourceType}/${jsonData.id} failed with message: ${e.message}`,
         icon: <AlertCircle />,
         color: 'red'
       });

--- a/app/src/pages/[resourceType]/[id].tsx
+++ b/app/src/pages/[resourceType]/[id].tsx
@@ -11,6 +11,7 @@ import { AlertCircle, CircleCheck } from 'tabler-icons-react';
 import { notifications } from '@mantine/notifications';
 import { trpc } from '../../util/trpc';
 import { useRouter } from 'next/router';
+
 /**
  * Component which displays the JSON/ELM/CQL/narrative content of an individual resource using
  * Mantine tabs
@@ -40,8 +41,8 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
   const draftMutation = trpc.draft.createDraft.useMutation({
     onSuccess: data => {
       notifications.show({
-        title: `${jsonData.resourceType} Cloned!`,
-        message: `${jsonData.resourceType} successfully cloned`,
+        title: `${jsonData.resourceType} Created!`,
+        message: `${jsonData.resourceType} successfully created from ${jsonData.resourceType}/${jsonData.id}`,
         icon: <CircleCheck />,
         color: 'green'
       });
@@ -50,8 +51,8 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
     },
     onError: e => {
       notifications.show({
-        title: `${jsonData.resourceType} Clone Failed!`,
-        message: `Attempt to clone ${jsonData.resourceType} failed with message: ${e.message}`,
+        title: `${jsonData.resourceType} Creation Failed!`,
+        message: `Attempt to create ${jsonData.resourceType} from ${jsonData.resourceType}/${jsonData.id} failed with message: ${e.message}`,
         icon: <AlertCircle />,
         color: 'red'
       });
@@ -60,11 +61,11 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
 
   const router = useRouter();
 
-  const cloneResource = () => {
-    const newClonedResource = jsonData;
-    newClonedResource.id = uuidv4();
-    newClonedResource.status = 'draft';
-    draftMutation.mutate({ resourceType, draft: newClonedResource });
+  const createDraftOfArtifact = () => {
+    const draftOfArtifact = jsonData;
+    draftOfArtifact.id = uuidv4();
+    draftOfArtifact.status = 'draft';
+    draftMutation.mutate({ resourceType, draft: draftOfArtifact });
   };
 
   return (
@@ -75,8 +76,8 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
             <Text size="xl" color="gray">
               {jsonData.resourceType}/{jsonData.id}
             </Text>
-            <Button w={240} loading={draftMutation.isLoading} onClick={cloneResource}>
-              Clone to Draft Artifact
+            <Button w={240} loading={draftMutation.isLoading} onClick={createDraftOfArtifact}>
+              Create Draft of {jsonData.resourceType}
             </Button>
           </Group>
         </div>

--- a/app/src/pages/[resourceType]/[id].tsx
+++ b/app/src/pages/[resourceType]/[id].tsx
@@ -64,6 +64,7 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
     const draftOfArtifact = jsonData;
     draftOfArtifact.id = uuidv4();
     draftOfArtifact.status = 'draft';
+    delete draftOfArtifact.version;
     draftMutation.mutate({ resourceType, draft: draftOfArtifact });
   };
 

--- a/app/src/pages/[resourceType]/[id].tsx
+++ b/app/src/pages/[resourceType]/[id].tsx
@@ -6,11 +6,11 @@ import { useEffect, useMemo } from 'react';
 import CQLRegex from '../../util/prismCQL';
 import { Prism as PrismRenderer } from 'prism-react-renderer';
 import parse from 'html-react-parser';
-import { v4 as uuidv4 } from 'uuid';
 import { AlertCircle, CircleCheck } from 'tabler-icons-react';
 import { notifications } from '@mantine/notifications';
 import { trpc } from '../../util/trpc';
 import { useRouter } from 'next/router';
+import { modifyResourceToDraft } from '@/util/modifyResourceFields';
 
 /**
  * Component which displays the JSON/ELM/CQL/narrative content of an individual resource using
@@ -61,10 +61,7 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
   });
 
   const createDraftOfArtifact = () => {
-    const draftOfArtifact = jsonData;
-    draftOfArtifact.id = uuidv4();
-    draftOfArtifact.status = 'draft';
-    delete draftOfArtifact.version;
+    const draftOfArtifact = modifyResourceToDraft(jsonData);
     draftMutation.mutate({ resourceType, draft: draftOfArtifact });
   };
 

--- a/app/src/pages/[resourceType]/[id].tsx
+++ b/app/src/pages/[resourceType]/[id].tsx
@@ -41,8 +41,8 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
   const draftMutation = trpc.draft.createDraft.useMutation({
     onSuccess: data => {
       notifications.show({
-        title: `${jsonData.resourceType} Created!`,
-        message: `${jsonData.resourceType} successfully created from ${jsonData.resourceType}/${jsonData.id}`,
+        title: `Draft ${jsonData.resourceType} Created!`,
+        message: `Draft ${jsonData.resourceType} successfully created from ${jsonData.resourceType}/${jsonData.id}`,
         icon: <CircleCheck />,
         color: 'green'
       });
@@ -51,8 +51,8 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
     },
     onError: e => {
       notifications.show({
-        title: `${jsonData.resourceType} Creation Failed!`,
-        message: `Attempt to create ${jsonData.resourceType} from ${jsonData.resourceType}/${jsonData.id} failed with message: ${e.message}`,
+        title: `Draft ${jsonData.resourceType} Creation Failed!`,
+        message: `Attempt to create draft ${jsonData.resourceType} from ${jsonData.resourceType}/${jsonData.id} failed with message: ${e.message}`,
         icon: <AlertCircle />,
         color: 'red'
       });

--- a/app/src/pages/[resourceType]/[id].tsx
+++ b/app/src/pages/[resourceType]/[id].tsx
@@ -1,18 +1,24 @@
 import { Prism } from '@mantine/prism';
-import { Divider, Group, Space, Stack, Tabs, Text } from '@mantine/core';
+import { Button, Divider, Group, Space, Stack, Tabs, Text } from '@mantine/core';
 import { GetServerSideProps, InferGetServerSidePropsType } from 'next';
 import { FhirArtifact } from '@/util/types/fhir';
 import { useEffect, useMemo } from 'react';
 import CQLRegex from '../../util/prismCQL';
 import { Prism as PrismRenderer } from 'prism-react-renderer';
 import parse from 'html-react-parser';
-
+import { v4 as uuidv4 } from 'uuid';
+import { AlertCircle, CircleCheck } from 'tabler-icons-react';
+import { notifications } from '@mantine/notifications';
+import { trpc } from '../../util/trpc';
+import { useRouter } from 'next/router';
 /**
  * Component which displays the JSON/ELM/CQL/narrative content of an individual resource using
  * Mantine tabs
  * @returns JSON/ELM/CQL/narrative content of the individual resource in a Prism component
  */
 export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  const resourceType = jsonData.resourceType;
+
   // Overwrite Prism with our custom Prism that includes CQL as a language
   useEffect(() => {
     /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -29,14 +35,48 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
     return decode('application/elm+json', jsonData);
   }, [jsonData]);
 
+  const ctx = trpc.useContext();
+
+  const draftMutation = trpc.draft.createDraft.useMutation({
+    onSuccess: data => {
+      notifications.show({
+        title: `${jsonData.resourceType} Cloned!`,
+        message: `${jsonData.resourceType} successfully cloned`,
+        icon: <CircleCheck />,
+        color: 'green'
+      });
+      router.push(`/authoring/${jsonData.resourceType}/${data.draftId}`);
+      ctx.draft.getDraftCounts.invalidate();
+    },
+    onError: e => {
+      notifications.show({
+        title: `${jsonData.resourceType} Clone Failed!`,
+        message: `Attempt to clone ${jsonData.resourceType} failed with message: ${e.message}`,
+        icon: <AlertCircle />,
+        color: 'red'
+      });
+    }
+  });
+
+  const router = useRouter();
+
+  const cloneResource = () => {
+    const newClonedResource = jsonData;
+    newClonedResource.id = uuidv4();
+    draftMutation.mutate({ resourceType, draft: newClonedResource });
+  };
+
   return (
     <div>
       <Stack spacing="xs">
         <div>
-          <Group>
+          <Group position="apart">
             <Text size="xl" color="gray">
               {jsonData.resourceType}/{jsonData.id}
             </Text>
+            <Button w={240} loading={draftMutation.isLoading} onClick={cloneResource}>
+              Clone to Draft Artifact
+            </Button>
           </Group>
         </div>
         <Divider my="sm" pb={6} />

--- a/app/src/pages/[resourceType]/[id].tsx
+++ b/app/src/pages/[resourceType]/[id].tsx
@@ -37,6 +37,7 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
   }, [jsonData]);
 
   const ctx = trpc.useContext();
+  const router = useRouter();
 
   const draftMutation = trpc.draft.createDraft.useMutation({
     onSuccess: data => {
@@ -58,8 +59,6 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
       });
     }
   });
-
-  const router = useRouter();
 
   const createDraftOfArtifact = () => {
     const draftOfArtifact = jsonData;

--- a/app/src/pages/api/trpc/[trpc].ts
+++ b/app/src/pages/api/trpc/[trpc].ts
@@ -7,3 +7,11 @@ export default trpcNext.createNextApiHandler({
   router: appRouter,
   createContext: () => ({})
 });
+
+export const config = {
+  api: {
+    bodyParser: {
+      sizeLimit: '4mb'
+    }
+  }
+};

--- a/app/src/pages/authoring/[resourceType]/[id].tsx
+++ b/app/src/pages/authoring/[resourceType]/[id].tsx
@@ -1,5 +1,5 @@
 import { trpc } from '@/util/trpc';
-import { Button, Center, Divider, Grid, Paper, Stack, Text, TextInput, createStyles } from '@mantine/core';
+import { Button, Center, Divider, Grid, Paper, Stack, Text, TextInput } from '@mantine/core';
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/router';
 import { Prism } from '@mantine/prism';
@@ -7,15 +7,7 @@ import { notifications } from '@mantine/notifications';
 import { AlertCircle, CircleCheck } from 'tabler-icons-react';
 import { ArtifactResourceType } from '@/util/types/fhir';
 
-const useStyles = createStyles(() => ({
-  json: {
-    maxHeight: 'calc(100vh - 150px)',
-    overflowY: 'scroll'
-  }
-}));
-
 export default function ResourceAuthoringPage() {
-  const { classes } = useStyles();
   const router = useRouter();
   const { resourceType, id } = router.query;
 
@@ -113,11 +105,9 @@ export default function ResourceAuthoringPage() {
         </Grid.Col>
         <Grid.Col span={6}>
           <Paper withBorder>
-            <div className={classes.json}>
-              <Prism language="json" colorScheme="light">
-                {resource ? JSON.stringify(resource, null, 2) : ''}
-              </Prism>
-            </div>
+            <Prism language="json" colorScheme="light" styles={{ scrollArea: { height: 'calc(100vh - 150px)' } }}>
+              {resource ? JSON.stringify(resource, null, 2) : ''}
+            </Prism>
           </Paper>
         </Grid.Col>
       </Grid>

--- a/app/src/pages/authoring/[resourceType]/[id].tsx
+++ b/app/src/pages/authoring/[resourceType]/[id].tsx
@@ -21,7 +21,7 @@ export default function ResourceAuthoringPage() {
     resourceType: resourceType as ArtifactResourceType
   });
 
-  // useEffect to check if it has an identifier and url
+  // useEffect to check if the resource has an identifier and url defined
   useEffect(() => {
     if (resource?.url) {
       setUrl(resource.url);

--- a/app/src/pages/authoring/[resourceType]/[id].tsx
+++ b/app/src/pages/authoring/[resourceType]/[id].tsx
@@ -36,7 +36,7 @@ export default function ResourceAuthoringPage() {
         setIdentifier(resource.identifier[0].value);
       }
     }
-  }, [resource?.url, resource?.identifier]);
+  }, [resource]);
 
   const resourceUpdate = trpc.draft.updateDraft.useMutation({
     onSuccess: () => {

--- a/app/src/pages/authoring/[resourceType]/[id].tsx
+++ b/app/src/pages/authoring/[resourceType]/[id].tsx
@@ -1,6 +1,6 @@
 import { trpc } from '@/util/trpc';
 import { Button, Center, Divider, Grid, Paper, Stack, Text, TextInput } from '@mantine/core';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useRouter } from 'next/router';
 import { Prism } from '@mantine/prism';
 import { notifications } from '@mantine/notifications';
@@ -16,10 +16,27 @@ export default function ResourceAuthoringPage() {
 
   const ctx = trpc.useContext();
 
-  const resourceQuery = trpc.draft.getDraftById.useQuery({
+  const { data: resource } = trpc.draft.getDraftById.useQuery({
     id: id as string,
     resourceType: resourceType as ArtifactResourceType
   });
+
+  // useEffect to check if it has an identifier and url
+  useEffect(() => {
+    if (resource?.url) {
+      setUrl(resource.url);
+    }
+    if (resource?.identifier) {
+      const cmsIdentifier = resource.identifier.find(
+        identifier => identifier.system === 'http://hl7.org/fhir/cqi/ecqm/Measure/Identifier/cms'
+      );
+      if (cmsIdentifier?.value) {
+        setIdentifier(cmsIdentifier.value);
+      } else if (resource.identifier[0].value) {
+        setIdentifier(resource.identifier[0].value);
+      }
+    }
+  }, [resource?.url, resource?.identifier]);
 
   const resourceUpdate = trpc.draft.updateDraft.useMutation({
     onSuccess: () => {
@@ -89,7 +106,7 @@ export default function ResourceAuthoringPage() {
         <Grid.Col span={6}>
           <Paper withBorder>
             <Prism language="json" colorScheme="light">
-              {resourceQuery.data ? JSON.stringify(resourceQuery.data, null, 2) : ''}
+              {resource ? JSON.stringify(resource, null, 2) : ''}
             </Prism>
           </Paper>
         </Grid.Col>

--- a/app/src/pages/authoring/[resourceType]/[id].tsx
+++ b/app/src/pages/authoring/[resourceType]/[id].tsx
@@ -1,5 +1,5 @@
 import { trpc } from '@/util/trpc';
-import { Button, Center, Divider, Grid, Paper, Stack, Text, TextInput } from '@mantine/core';
+import { Button, Center, Divider, Grid, Paper, ScrollArea, Stack, Text, TextInput, createStyles } from '@mantine/core';
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/router';
 import { Prism } from '@mantine/prism';
@@ -7,7 +7,15 @@ import { notifications } from '@mantine/notifications';
 import { AlertCircle, CircleCheck } from 'tabler-icons-react';
 import { ArtifactResourceType } from '@/util/types/fhir';
 
+const useStyles = createStyles(() => ({
+  json: {
+    maxHeight: 'calc(100vh - 150px)',
+    overflowY: 'scroll'
+  }
+}));
+
 export default function ResourceAuthoringPage() {
+  const { classes } = useStyles();
   const router = useRouter();
   const { resourceType, id } = router.query;
 
@@ -105,9 +113,11 @@ export default function ResourceAuthoringPage() {
         </Grid.Col>
         <Grid.Col span={6}>
           <Paper withBorder>
-            <Prism language="json" colorScheme="light">
-              {resource ? JSON.stringify(resource, null, 2) : ''}
-            </Prism>
+            <div className={classes.json}>
+              <Prism language="json" colorScheme="light">
+                {resource ? JSON.stringify(resource, null, 2) : ''}
+              </Prism>
+            </div>
           </Paper>
         </Grid.Col>
       </Grid>

--- a/app/src/pages/authoring/[resourceType]/[id].tsx
+++ b/app/src/pages/authoring/[resourceType]/[id].tsx
@@ -1,5 +1,5 @@
 import { trpc } from '@/util/trpc';
-import { Button, Center, Divider, Grid, Paper, ScrollArea, Stack, Text, TextInput, createStyles } from '@mantine/core';
+import { Button, Center, Divider, Grid, Paper, Stack, Text, TextInput, createStyles } from '@mantine/core';
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/router';
 import { Prism } from '@mantine/prism';

--- a/app/src/pages/authoring/index.tsx
+++ b/app/src/pages/authoring/index.tsx
@@ -37,6 +37,7 @@ export default function AuthoringPage() {
 
   const ctx = trpc.useContext();
   const { classes } = useStyles();
+  const router = useRouter();
 
   const successNotification = (data: { draftId: string }, createdFromArtifact: boolean) => {
     const message = createdFromArtifact
@@ -81,8 +82,6 @@ export default function AuthoringPage() {
       errorNotification(e.message, true);
     }
   });
-
-  const router = useRouter();
 
   const createResource = () => {
     const newResource = resourceType === 'Measure' ? { ...MeasureSkeleton } : { ...LibrarySkeleton };

--- a/app/src/pages/authoring/index.tsx
+++ b/app/src/pages/authoring/index.tsx
@@ -1,4 +1,15 @@
-import { Button, Center, Paper, SegmentedControl, Select, Stack, Title, createStyles, Loader } from '@mantine/core';
+import {
+  Button,
+  Center,
+  Paper,
+  SegmentedControl,
+  Select,
+  Stack,
+  Text,
+  Title,
+  createStyles,
+  Loader
+} from '@mantine/core';
 import { v4 as uuidv4 } from 'uuid';
 import { useState } from 'react';
 import { trpc } from '../../util/trpc';
@@ -18,7 +29,11 @@ export default function AuthoringPage() {
   const [resourceType, setResourceType] = useState<ArtifactResourceType>('Measure');
   const [selectedArtifact, setSelectedArtifact] = useState<string | null>(null);
 
-  const { data: artifacts } = trpc.service.getArtifactsByResource.useQuery({ resourceType });
+  const {
+    data: artifacts,
+    isLoading: artifactsLoading,
+    error: artifactError
+  } = trpc.service.getArtifactsByResource.useQuery({ resourceType });
 
   const ctx = trpc.useContext();
   const { classes } = useStyles();
@@ -97,8 +112,14 @@ export default function AuthoringPage() {
           <Button w={240} loading={draftMutation.isLoading} onClick={createResource}>
             {`Create New Draft ${resourceType}`}
           </Button>
-          <Title order={3}>Start From an Existing ${resourceType}:</Title>
-          {artifacts ? (
+          <Title order={3}>Start From an Existing {resourceType}:</Title>
+          {artifactsLoading ? (
+            <Loader />
+          ) : artifactError ? (
+            <Text c="red">Artifacts could not be displayed due to an error: {artifactError.message}</Text>
+          ) : artifacts?.length === 0 ? (
+            <Text c="red">There are no {resourceType} artifacts in the repository at this time</Text>
+          ) : artifacts ? (
             <Select
               label={`Select an existing ${resourceType} to create a draft from`}
               data={artifacts}
@@ -106,7 +127,7 @@ export default function AuthoringPage() {
               onChange={setSelectedArtifact}
             />
           ) : (
-            <Loader />
+            <Text c="red">An unknown error occurred fetching artifacts</Text>
           )}
           <Button
             w={240}

--- a/app/src/pages/authoring/index.tsx
+++ b/app/src/pages/authoring/index.tsx
@@ -40,7 +40,7 @@ export default function AuthoringPage() {
 
   const successNotification = (data: { draftId: string }, createdFromArtifact: boolean) => {
     const message = createdFromArtifact
-      ? `Draft ${resourceType} successfully created from ${resourceType}/${selectedArtifact}`
+      ? `Draft of ${resourceType}/${selectedArtifact} successfully created`
       : `${resourceType} successfully created`;
     notifications.show({
       title: `${resourceType} Created!`,
@@ -54,7 +54,7 @@ export default function AuthoringPage() {
 
   const errorNotification = (errorMessage: string, createdFromArtifact: boolean) => {
     const message = createdFromArtifact
-      ? `Attempt to create draft ${resourceType} from ${resourceType}/${selectedArtifact} failed with message: ${errorMessage}`
+      ? `Attempt to create draft of ${resourceType}/${selectedArtifact} failed with message: ${errorMessage}`
       : `Attempt to create ${resourceType} failed with message: ${errorMessage}`;
     notifications.show({
       title: `${resourceType} Creation Failed!`,

--- a/app/src/pages/authoring/index.tsx
+++ b/app/src/pages/authoring/index.tsx
@@ -1,15 +1,4 @@
-import {
-  Button,
-  Center,
-  Paper,
-  SegmentedControl,
-  Select,
-  Stack,
-  Title,
-  Text,
-  createStyles,
-  Loader
-} from '@mantine/core';
+import { Button, Center, Paper, SegmentedControl, Select, Stack, Title, createStyles, Loader } from '@mantine/core';
 import { v4 as uuidv4 } from 'uuid';
 import { useState } from 'react';
 import { trpc } from '../../util/trpc';

--- a/app/src/pages/authoring/index.tsx
+++ b/app/src/pages/authoring/index.tsx
@@ -89,7 +89,7 @@ export default function AuthoringPage() {
     draftMutation.mutate({ resourceType, draft: newResource });
   };
 
-  const createDraftArtifactOf = () => {
+  const createDraftArtifact = () => {
     if (selectedArtifact !== null) {
       draftFromArtifactMutation.mutate({ resourceType, id: selectedArtifact });
     }
@@ -101,7 +101,10 @@ export default function AuthoringPage() {
         <Stack>
           <SegmentedControl
             value={resourceType}
-            onChange={val => setResourceType(val as ArtifactResourceType)}
+            onChange={val => {
+              setResourceType(val as ArtifactResourceType);
+              setSelectedArtifact(null);
+            }}
             data={[
               { label: 'Measure', value: 'Measure' },
               { label: 'Library', value: 'Library' }
@@ -131,8 +134,8 @@ export default function AuthoringPage() {
           <Button
             w={240}
             loading={draftFromArtifactMutation.isLoading}
-            onClick={createDraftArtifactOf}
-            disabled={!selectedArtifact}
+            onClick={createDraftArtifact}
+            disabled={!artifacts || !selectedArtifact}
           >
             Create Draft of {resourceType}
           </Button>

--- a/app/src/pages/authoring/index.tsx
+++ b/app/src/pages/authoring/index.tsx
@@ -1,4 +1,15 @@
-import { Button, Center, Paper, SegmentedControl, Select, Stack, Title, Text, createStyles } from '@mantine/core';
+import {
+  Button,
+  Center,
+  Paper,
+  SegmentedControl,
+  Select,
+  Stack,
+  Title,
+  Text,
+  createStyles,
+  Loader
+} from '@mantine/core';
 import { v4 as uuidv4 } from 'uuid';
 import { useState } from 'react';
 import { trpc } from '../../util/trpc';
@@ -106,7 +117,7 @@ export default function AuthoringPage() {
               onChange={setSelectedArtifact}
             />
           ) : (
-            <Text>No artifacts</Text>
+            <Loader />
           )}
           <Button
             w={240}

--- a/app/src/pages/authoring/index.tsx
+++ b/app/src/pages/authoring/index.tsx
@@ -33,14 +33,14 @@ export default function AuthoringPage() {
     data: artifacts,
     isLoading: artifactsLoading,
     error: artifactError
-  } = trpc.service.getArtifactsByResource.useQuery({ resourceType });
+  } = trpc.service.getArtifactsByType.useQuery({ resourceType });
 
   const ctx = trpc.useContext();
   const { classes } = useStyles();
 
   const successNotification = (data: { draftId: string }, createdFromArtifact: boolean) => {
     const message = createdFromArtifact
-      ? `${resourceType} successfully created from ${resourceType}/${selectedArtifact}`
+      ? `Draft ${resourceType} successfully created from ${resourceType}/${selectedArtifact}`
       : `${resourceType} successfully created`;
     notifications.show({
       title: `${resourceType} Created!`,
@@ -54,7 +54,7 @@ export default function AuthoringPage() {
 
   const errorNotification = (errorMessage: string, createdFromArtifact: boolean) => {
     const message = createdFromArtifact
-      ? `Attempt to create ${resourceType} from ${resourceType}/${selectedArtifact} failed with message: ${errorMessage}`
+      ? `Attempt to create draft ${resourceType} from ${resourceType}/${selectedArtifact} failed with message: ${errorMessage}`
       : `Attempt to create ${resourceType} failed with message: ${errorMessage}`;
     notifications.show({
       title: `${resourceType} Creation Failed!`,

--- a/app/src/pages/authoring/index.tsx
+++ b/app/src/pages/authoring/index.tsx
@@ -97,7 +97,7 @@ export default function AuthoringPage() {
           <Button w={240} loading={draftMutation.isLoading} onClick={createResource}>
             {`Create New Draft ${resourceType}`}
           </Button>
-          <Title order={3}>{`Start From an Existing ${resourceType}:`}</Title>
+          <Title order={3}>Start From an Existing ${resourceType}:</Title>
           {artifacts ? (
             <Select
               label={`Select an existing ${resourceType} to create a draft from`}

--- a/app/src/pages/authoring/index.tsx
+++ b/app/src/pages/authoring/index.tsx
@@ -23,11 +23,12 @@ export default function AuthoringPage() {
   const ctx = trpc.useContext();
   const { classes } = useStyles();
 
-  const successNotification = (data: { draftId: string }, cloned: boolean) => {
-    const title = cloned ? `${resourceType} Cloned!` : `${resourceType} Created!`;
-    const message = cloned ? `${resourceType} successfully cloned` : `${resourceType} successfully created`;
+  const successNotification = (data: { draftId: string }, createdFromArtifact: boolean) => {
+    const message = createdFromArtifact
+      ? `${resourceType} successfully created from ${resourceType}/${selectedArtifact}`
+      : `${resourceType} successfully created`;
     notifications.show({
-      title: title,
+      title: `${resourceType} Created!`,
       message: message,
       icon: <CircleCheck />,
       color: 'green'
@@ -36,13 +37,12 @@ export default function AuthoringPage() {
     ctx.draft.getDraftCounts.invalidate();
   };
 
-  const errorNotification = (errorMessage: string, cloned: boolean) => {
-    const title = cloned ? `${resourceType} Clone Failed!` : `${resourceType} Creation Failed!`;
-    const message = cloned
-      ? `Attempt to clone ${resourceType} failed with message: ${errorMessage}`
+  const errorNotification = (errorMessage: string, createdFromArtifact: boolean) => {
+    const message = createdFromArtifact
+      ? `Attempt to create ${resourceType} from ${resourceType}/${selectedArtifact} failed with message: ${errorMessage}`
       : `Attempt to create ${resourceType} failed with message: ${errorMessage}`;
     notifications.show({
-      title: title,
+      title: `${resourceType} Creation Failed!`,
       message: message,
       icon: <AlertCircle />,
       color: 'red'
@@ -58,7 +58,7 @@ export default function AuthoringPage() {
     }
   });
 
-  const draftCloneMutation = trpc.service.convertArtifactById.useMutation({
+  const draftFromArtifactMutation = trpc.service.convertArtifactById.useMutation({
     onSuccess: data => {
       successNotification(data, true);
     },
@@ -75,9 +75,9 @@ export default function AuthoringPage() {
     draftMutation.mutate({ resourceType, draft: newResource });
   };
 
-  const cloneResource = () => {
+  const createDraftArtifactOf = () => {
     if (selectedArtifact !== null) {
-      draftCloneMutation.mutate({ resourceType, id: selectedArtifact });
+      draftFromArtifactMutation.mutate({ resourceType, id: selectedArtifact });
     }
   };
 
@@ -100,7 +100,7 @@ export default function AuthoringPage() {
           <Title order={3}>{`Start From an Existing ${resourceType}:`}</Title>
           {artifacts ? (
             <Select
-              label={`Select an existing ${resourceType} to clone`}
+              label={`Select an existing ${resourceType} to create a draft from`}
               data={artifacts}
               value={selectedArtifact}
               onChange={setSelectedArtifact}
@@ -110,10 +110,12 @@ export default function AuthoringPage() {
           )}
           <Button
             w={240}
-            loading={draftCloneMutation.isLoading}
-            onClick={cloneResource}
+            loading={draftFromArtifactMutation.isLoading}
+            onClick={createDraftArtifactOf}
             disabled={!selectedArtifact}
-          >{`Clone Draft ${resourceType}`}</Button>
+          >
+            Create Draft of {resourceType}
+          </Button>
         </Stack>
       </Paper>
     </Center>

--- a/app/src/server/trpc/routers/draft.ts
+++ b/app/src/server/trpc/routers/draft.ts
@@ -23,16 +23,6 @@ export const draftRouter = router({
     .input(z.object({ id: z.string(), resourceType: z.enum(['Measure', 'Library']) }).optional())
     .query(async ({ input }) => (input ? getDraftById<FhirArtifact>(input.id, input.resourceType) : null)),
 
-  // getDraftById: publicProcedure
-  // .input(z.object({ id: z.string(), resourceType: z.enum(['Measure', 'Library']) }).optional())
-  // .query(async ({ input }) => {
-  //   if (input !== undefined) {
-  //     getDraftById<FhirArtifact>(input.id, input.resourceType);
-  //   } else {
-  //     return null;
-  //   }
-  // }),
-
   createDraft: publicProcedure
     .input(z.object({ resourceType: z.enum(['Measure', 'Library']), draft: z.any() }))
     .mutation(async ({ input }) => {

--- a/app/src/server/trpc/routers/draft.ts
+++ b/app/src/server/trpc/routers/draft.ts
@@ -20,8 +20,18 @@ export const draftRouter = router({
     .query(async opts => getAllDraftsByType<FhirArtifact>(opts.input)),
 
   getDraftById: publicProcedure
-    .input(z.object({ id: z.string(), resourceType: z.enum(['Measure', 'Library']) }))
-    .query(async ({ input }) => getDraftById<FhirArtifact>(input.id, input.resourceType)),
+    .input(z.object({ id: z.string(), resourceType: z.enum(['Measure', 'Library']) }).optional())
+    .query(async ({ input }) => (input ? getDraftById<FhirArtifact>(input.id, input.resourceType) : null)),
+
+  // getDraftById: publicProcedure
+  // .input(z.object({ id: z.string(), resourceType: z.enum(['Measure', 'Library']) }).optional())
+  // .query(async ({ input }) => {
+  //   if (input !== undefined) {
+  //     getDraftById<FhirArtifact>(input.id, input.resourceType);
+  //   } else {
+  //     return null;
+  //   }
+  // }),
 
   createDraft: publicProcedure
     .input(z.object({ resourceType: z.enum(['Measure', 'Library']), draft: z.any() }))

--- a/app/src/server/trpc/routers/draft.ts
+++ b/app/src/server/trpc/routers/draft.ts
@@ -20,8 +20,10 @@ export const draftRouter = router({
     .query(async opts => getAllDraftsByType<FhirArtifact>(opts.input)),
 
   getDraftById: publicProcedure
-    .input(z.object({ id: z.string(), resourceType: z.enum(['Measure', 'Library']) }).optional())
-    .query(async ({ input }) => (input ? getDraftById<FhirArtifact>(input.id, input.resourceType) : null)),
+    .input(z.object({ id: z.string().optional(), resourceType: z.enum(['Measure', 'Library']).optional() }))
+    .query(async ({ input }) =>
+      input.id && input.resourceType ? getDraftById<FhirArtifact>(input.id, input.resourceType) : null
+    ),
 
   createDraft: publicProcedure
     .input(z.object({ resourceType: z.enum(['Measure', 'Library']), draft: z.any() }))

--- a/app/src/server/trpc/routers/service.ts
+++ b/app/src/server/trpc/routers/service.ts
@@ -1,8 +1,8 @@
 import { FhirArtifact } from '@/util/types/fhir';
 import { publicProcedure, router } from '../trpc';
 import { z } from 'zod';
-import { draftRouter } from './draft';
 import { v4 as uuidv4 } from 'uuid';
+import { createDraft } from '@/server/db/dbOperations';
 
 /**
  * Endpoints dealing with outgoing calls to the central measure repository service
@@ -44,9 +44,9 @@ export const serviceRouter = router({
       const draftArtifact = (await draftRes.json()) as FhirArtifact;
       draftArtifact.id = uuidv4();
       draftArtifact.status = 'draft';
+      delete draftArtifact.version;
 
-      const draftCaller = draftRouter.createCaller({});
-      const res = await draftCaller.createDraft({ resourceType: input.resourceType, draft: draftArtifact });
-      return res;
+      const res = await createDraft(input.resourceType, draftArtifact);
+      return { draftId: draftArtifact.id, ...res };
     })
 });

--- a/app/src/server/trpc/routers/service.ts
+++ b/app/src/server/trpc/routers/service.ts
@@ -1,4 +1,8 @@
+import { FhirArtifact } from '@/util/types/fhir';
 import { publicProcedure, router } from '../trpc';
+import { z } from 'zod';
+import { draftRouter } from './draft';
+import { v4 as uuidv4 } from 'uuid';
 
 /**
  * Endpoints dealing with outgoing calls to the central measure repository service
@@ -16,5 +20,33 @@ export const serviceRouter = router({
       Measure: measureBundle.total ?? 0,
       Library: libraryBundle.total ?? 0
     } as const;
-  })
+  }),
+
+  getArtifactsByResource: publicProcedure
+    .input(z.object({ resourceType: z.enum(['Measure', 'Library']) }))
+    .query(async ({ input }) => {
+      const artifactBundle = await fetch(`${process.env.NEXT_PUBLIC_MRS_SERVER}/${input.resourceType}`).then(
+        resArtifacts => resArtifacts.json() as Promise<fhir4.Bundle<FhirArtifact>>
+      );
+
+      const artifactList = artifactBundle.entry?.map(entry => ({
+        label: entry.resource?.name || entry.resource?.id || '',
+        value: entry.resource?.id || `${entry.resource?.resourceType}` || ''
+      }));
+
+      return artifactList;
+    }),
+
+  convertArtifactById: publicProcedure
+    .input(z.object({ resourceType: z.enum(['Measure', 'Library']), id: z.string() }))
+    .mutation(async ({ input }) => {
+      const draftRes = await fetch(`${process.env.NEXT_PUBLIC_MRS_SERVER}/${input.resourceType}/${input.id}`);
+      const draftArtifact = (await draftRes.json()) as FhirArtifact;
+      draftArtifact.id = uuidv4();
+      draftArtifact.status = 'draft';
+
+      const draftCaller = draftRouter.createCaller({});
+      const res = await draftCaller.createDraft({ resourceType: input.resourceType, draft: draftArtifact });
+      return res;
+    })
 });

--- a/app/src/server/trpc/routers/service.ts
+++ b/app/src/server/trpc/routers/service.ts
@@ -22,7 +22,7 @@ export const serviceRouter = router({
     } as const;
   }),
 
-  getArtifactsByResource: publicProcedure
+  getArtifactsByType: publicProcedure
     .input(z.object({ resourceType: z.enum(['Measure', 'Library']) }))
     .query(async ({ input }) => {
       const artifactBundle = await fetch(`${process.env.NEXT_PUBLIC_MRS_SERVER}/${input.resourceType}`).then(

--- a/app/src/util/modifyResourceFields.ts
+++ b/app/src/util/modifyResourceFields.ts
@@ -1,0 +1,13 @@
+import { FhirArtifact } from './types/fhir';
+import { v4 as uuidv4 } from 'uuid';
+
+/**
+ * Helper function that takes an artifact and returns it with a new id,
+ * draft status, and no version
+ */
+export function modifyResourceToDraft(artifact: FhirArtifact) {
+  artifact.id = uuidv4();
+  artifact.status = 'draft';
+  delete artifact.version;
+  return { id: artifact.id, ...artifact };
+}


### PR DESCRIPTION
# Summary
This PR allows the user to pull an existing artifact (Measure or Library) from the measure repository service and clone it with a "draft" status instead of "active" status. This adds this new cloned artifact to the local database.

## New behavior
Before, the user could only create new artifacts from scratch and add it to the local database. Now the user can do so using an existing artifact on the measure repository service. The user can do this in the application in one of two ways: navigate to an existing artifact and click "Clone to Draft Artifact" OR go to the authoring page and under "Start From Existing Measure" the user can select a resource to clone.

## Code changes
- `app/src/pages/[resourceType]/[id].tsx` - new button on a specified measure repository service resource page to clone the artifact to a draft.
- `app/src/pages/api/trpc/[trpc].ts` - increased the NextJS body parser limit (errored out when I tried to clone the MATGlobalCommonFunctionsFHIR4 Library).
- `app/src/pages/authoring/[resourceType]/[id].tsx` - fills the inputs with the correct url and identifier when an artifact is cloned.
- `app/src/pages/authoring/index.tsx` - Added a dropdown on the authoring page for a user to clone an existing artifact.
- `app/src/server/trpc/routers/service.ts` - added two new endpoints: `getArtifactsByResource` (returns all of the artifacts of a certain resourceType) and `convertArtifactById` (takes in a resourceType and an id and calls `createDraft` on that artifact).

# Testing guidance
- `npm run check:all`
- Try cloning Library and Measure artifacts in the MRS through the two ways- directly from the artifact and through the dropdown on the authoring page. Things to look out for:
   - Make sure the number of Library and Measure artifacts increases in the Authoring page nav bar.
   - Go into studio 3T and make sure the artifacts are indeed in the local database once they are cloned.
   - Make sure the status of the cloned artifact is `draft` and not `active`.
   - Make sure that the `url` and `identifier` inputs are populated with the correct values once an artifact is cloned.
   - Make sure the success/error notifications work and are correct based on whether a resource was created or cloned.