### PR TITLE
Render data requirements

### DIFF
--- a/app/src/pages/[resourceType]/[id].tsx
+++ b/app/src/pages/[resourceType]/[id].tsx
@@ -1,11 +1,17 @@
 import { Prism } from '@mantine/prism';
-import { Divider, Group, Space, Stack, Tabs, Text } from '@mantine/core';
+import { Divider, Group, Space, Stack, Tabs, Text, Button } from '@mantine/core';
+import { IconAbacus, IconAbacusOff, IconCheck } from '@tabler/icons-react';
+import { notifications } from '@mantine/notifications';
+import React from 'react';
 import { GetServerSideProps, InferGetServerSidePropsType } from 'next';
 import { FhirArtifact } from '@/util/types/fhir';
 import { useEffect, useMemo } from 'react';
 import CQLRegex from '../../util/prismCQL';
 import { Prism as PrismRenderer } from 'prism-react-renderer';
 import parse from 'html-react-parser';
+import { useState } from 'react';
+import { DataRequirement } from 'fhir/r3';
+import { teal } from '@mui/material/colors';
 
 /**
  * Component which displays the JSON/ELM/CQL/narrative content of an individual resource using
@@ -20,6 +26,10 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
     (window as any).Prism = PrismRenderer;
     /* eslint-enable @typescript-eslint/no-explicit-any */
   }, []);
+
+  const [requirementTabVisible, setTabVisible] = useState(false);
+  const [load, setLoading] = useState(false);
+  const [dataRequirementsVisible, setDataReqsVisible] = useState<DataRequirement[] | undefined>(undefined);
 
   const decodedCql = useMemo(() => {
     if (jsonData.resourceType === 'Measure') return null;
@@ -38,36 +48,100 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
           </Group>
         </div>
         <Divider my="sm" pb={6} />
-        <Tabs variant="outline" defaultValue="json">
-          <Tabs.List>
-            <Tabs.Tab value="json">JSON</Tabs.Tab>
-            <Tabs.Tab value="elm" disabled>
-              ELM
-            </Tabs.Tab>
-            {decodedCql != null && <Tabs.Tab value="cql">CQL</Tabs.Tab>}
-            {jsonData.text && <Tabs.Tab value="narrative">Narrative</Tabs.Tab>}
-          </Tabs.List>
-          <Tabs.Panel value="json" pt="xs">
-            <Prism language="json" colorScheme="light">
-              {JSON.stringify(jsonData, null, 2)}
-            </Prism>
-          </Tabs.Panel>
-          {decodedCql != null && (
-            <Tabs.Panel value="cql" pt="xs">
-              {/* eslint-disable  @typescript-eslint/no-explicit-any */}
-              <Prism language={'cql' as any} colorScheme="light">
-                {/* eslint-enable  @typescript-eslint/no-explicit-any */}
-                {decodedCql}
+        <div>
+          <Tabs variant="outline" defaultValue="json">
+            <Tabs.List>
+              <Tabs.Tab value="json">JSON</Tabs.Tab>
+              <Tabs.Tab value="elm" disabled>
+                ELM
+              </Tabs.Tab>
+              {decodedCql != null && <Tabs.Tab value="cql">CQL</Tabs.Tab>}
+              {jsonData.text && <Tabs.Tab value="narrative">Narrative</Tabs.Tab>}
+
+              {requirementTabVisible != false && dataRequirementsVisible != null && (
+                <Tabs.Tab value="datarequirements">Data Requirements</Tabs.Tab>
+              )}
+            </Tabs.List>
+            <Tabs.Panel value="json" pt="xs">
+              <Prism language="json" colorScheme="light">
+                {JSON.stringify(jsonData, null, 2)}
               </Prism>
             </Tabs.Panel>
-          )}
-          {jsonData.text && (
-            <Tabs.Panel value="narrative">
-              <Space h="sm" />
-              {parse(jsonData.text.div)}
-            </Tabs.Panel>
-          )}
-        </Tabs>
+            {decodedCql != null && (
+              <Tabs.Panel value="cql" pt="xs">
+                {/* eslint-disable  @typescript-eslint/no-explicit-any */}
+                <Prism language={'cql' as any} colorScheme="light">
+                  {/* eslint-enable  @typescript-eslint/no-explicit-any */}
+                  {decodedCql}
+                </Prism>
+              </Tabs.Panel>
+            )}
+            {jsonData.text && (
+              <Tabs.Panel value="narrative">
+                <Space h="sm" />
+                {parse(jsonData.text.div)}
+              </Tabs.Panel>
+            )}
+            {requirementTabVisible && dataRequirementsVisible != null && (
+              <Tabs.Panel value="datarequirements">
+                <Prism language="json" colorScheme="light">
+                  {JSON.stringify(dataRequirementsVisible, null, 2)}
+                </Prism>
+              </Tabs.Panel>
+            )}
+          </Tabs>
+        </div>
+        <div style={{ position: 'absolute', left: '85vw', top: '16vh' }}>
+          <Button
+            id="btn"
+            loading={load}
+            loaderPosition="center"
+            style={{ display: 'flex', float: 'right', justifyContent: 'space-between' }}
+            onClick={event => {
+              setLoading(true);
+              setTimeout(() => {
+                if ((jsonData as fhir4.Library).dataRequirement != undefined) {
+                  const dr = (jsonData as fhir4.Library).dataRequirement;
+                  setDataReqsVisible(dr);
+                  notifications.show({
+                    id: 'requirements',
+                    withCloseButton: true,
+                    onClose: () => console.log('unmounted'),
+                    onOpen: () => console.log('mounted'),
+                    autoClose: 3000,
+                    title: 'Successful Fetch',
+                    message: 'Data Requirements successfully fetched for this package',
+                    color: 'teal',
+                    icon: <IconCheck />,
+                    // color: teal,
+                    className: 'my-notification-class',
+                    style: { backgroundColor: 'white' },
+                    loading: false
+                  });
+                } else {
+                  notifications.show({
+                    id: 'no-requirements',
+                    withCloseButton: true,
+                    onClose: () => console.log('unmounted'),
+                    onOpen: () => console.log('mounted'),
+                    autoClose: 5000,
+                    title: 'No Data Requirements found',
+                    message: 'No data requirements were found for this package',
+                    color: 'white',
+                    icon: <IconAbacusOff />,
+                    className: 'my-notification-class',
+                    style: { backgroundColor: 'white' },
+                    loading: false
+                  });
+                }
+                setLoading(false);
+                setTabVisible(true);
+              }, 1000);
+            }}
+          >
+            Get Data Requirements
+          </Button>
+        </div>
       </Stack>
     </div>
   );

--- a/app/src/pages/[resourceType]/[id].tsx
+++ b/app/src/pages/[resourceType]/[id].tsx
@@ -27,7 +27,7 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
   }, []);
 
   const [loadingVisible, setLoading] = useState(false);
-  const [dataReqsVisible, setDataReqsVisible] = useState<DataRequirement[] | undefined>(undefined);
+  const [dataRequirements, setDataRequirements] = useState<DataRequirement[] | undefined>(undefined);
 
   const decodedCql = useMemo(() => {
     if (jsonData.resourceType === 'Measure') return null;
@@ -55,7 +55,7 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
               </Tabs.Tab>
               {decodedCql != null && <Tabs.Tab value="cql">CQL</Tabs.Tab>}
               {jsonData.text && <Tabs.Tab value="narrative">Narrative</Tabs.Tab>}
-              {dataReqsVisible != null && <Tabs.Tab value="datarequirements">Data Requirements</Tabs.Tab>}
+              {dataRequirements != null && <Tabs.Tab value="datarequirements">Data Requirements</Tabs.Tab>}
             </Tabs.List>
             <Tabs.Panel value="json" pt="xs">
               <Prism language="json" colorScheme="light">
@@ -77,10 +77,10 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
                 {parse(jsonData.text.div)}
               </Tabs.Panel>
             )}
-            {dataReqsVisible != null && (
+            {dataRequirements != null && (
               <Tabs.Panel value="datarequirements">
                 <Prism language="json" colorScheme="light">
-                  {JSON.stringify(dataReqsVisible, null, 2)}
+                  {JSON.stringify(dataRequirements, null, 2)}
                 </Prism>
               </Tabs.Panel>
             )}
@@ -91,18 +91,18 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
             id="btn"
             loading={loadingVisible}
             loaderPosition="center"
-            onClick={event => {
+            onClick={() => {
               setLoading(true);
               setTimeout(() => {
                 if ((jsonData as fhir4.Library).dataRequirement != undefined) {
                   const dataReqs = (jsonData as fhir4.Library).dataRequirement;
-                  setDataReqsVisible(dataReqs);
+                  setDataRequirements(dataReqs);
                   notifications.show({
                     id: 'requirements',
                     withCloseButton: true,
                     autoClose: 3000,
                     title: 'Successful Fetch',
-                    message: 'Data Requirements successfully fetched',
+                    message: 'Data requirements successfully fetched',
                     color: 'teal',
                     icon: <IconCheck />,
                     style: { backgroundColor: 'white' },
@@ -112,8 +112,8 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
                   notifications.show({
                     id: 'no-requirements',
                     withCloseButton: true,
-                    autoClose: 5000,
-                    title: 'No Data Requirements found',
+                    autoClose: 3000,
+                    title: 'No Data Requirements Found',
                     message: 'No data requirements were found for this package',
                     color: 'white',
                     icon: <IconAbacusOff />,


### PR DESCRIPTION
# Summary
Renders the data requirements tab and populates the panel of the selected resource when a button is clicked

## New behavior
Users can now click a button and render a data requirements tab with a specified resource's respective data requirements. If the fetch was successful, a drop down notification will appear to inform the user of the success and the tab/panel will render on the page. Otherwise, if no data requirements exist for the resource, a drop down notification will appear informing the user of this and the tab should not appear. 

## Code changes

- I imported several new mantine features such as:  `IconAbacusOff,` `IconCheck,` and `notifications` so I could utilize these features in the UI.
- I also imported `useState` from react so I could update different features in real time. 
- Added a mantine Button which, when clicked, fetches the data requirements, displays a notification on whether the fetch was successful or not, and renders the tab/panel on the page.

# Testing guidance
```
npm run check:all
 npm run start:all 
```
Navigate to `http://localhost:3001/` and select both Measure and Library packages. For any measure/library resource, click the `Get Data Requirements button`. For resources without data requirements (FHIR Library for instance), a notification should appear informing the user that there are no data requirements and the new tab should NOT render. Now, select a library with data requirements such as HospiceFHIR4 and click the `get Data requirements button`. The tab should render with the populated information and another drop down notification should inform the user of the successful fetch.

