### PR TITLE
Render draft artifacts in authoring mode

### DIFF
--- a/app/src/components/ResourceCards.tsx
+++ b/app/src/components/ResourceCards.tsx
@@ -29,7 +29,7 @@ export default function ResourceCards({ resourceInfo, resourceType, authoring }:
       <ScrollArea.Autosize mah={height * 0.8} type="scroll">
         {resourceInfo?.length > 0 ? (
           <Center>
-            <Stack align="stretch">
+            <Stack align="stretch" pb={2}>
               {resourceInfo.map(res => {
                 return (
                   <div key={res.id}>

--- a/app/src/components/ResourceCards.tsx
+++ b/app/src/components/ResourceCards.tsx
@@ -3,16 +3,17 @@ import { Center, ScrollArea, Stack, Text } from '@mantine/core';
 import { useEffect, useState } from 'react';
 import ResourceInfoCard from './ResourceInfoCard';
 
-interface ResourceButtonsProps {
+interface ResourceCardsProps {
   resourceInfo: ResourceInfo[];
   resourceType: ArtifactResourceType;
+  icon: JSX.Element;
 }
 
 /**
  * Component which displays all resources of a specified type and their ids
  * as buttons that link to that resource's page
  */
-export default function ResourceCards({ resourceInfo, resourceType }: ResourceButtonsProps) {
+export default function ResourceCards({ resourceInfo, resourceType, icon }: ResourceCardsProps) {
   const [height, setWindowHeight] = useState(0);
   useEffect(() => {
     const handleResize = () => {
@@ -26,7 +27,7 @@ export default function ResourceCards({ resourceInfo, resourceType }: ResourceBu
   return (
     <div>
       <ScrollArea.Autosize mah={height * 0.8} type="scroll">
-        {resourceInfo.length > 0 ? (
+        {resourceInfo?.length > 0 ? (
           <Stack
             style={{
               alignItems: 'center',
@@ -36,7 +37,7 @@ export default function ResourceCards({ resourceInfo, resourceType }: ResourceBu
             {resourceInfo.map(res => {
               return (
                 <div key={res.id}>
-                  <ResourceInfoCard resourceInfo={res} />
+                  <ResourceInfoCard resourceInfo={res} icon={icon} />
                 </div>
               );
             })}

--- a/app/src/components/ResourceCards.tsx
+++ b/app/src/components/ResourceCards.tsx
@@ -12,7 +12,7 @@ interface ResourceCardsProps {
 
 /**
  * Component which displays all resources of a specified type and their ids
- * as buttons that link to that resource's page
+ * as resource cards that link to that resource's page
  */
 export default function ResourceCards({ resourceInfo, resourceType, icon, authoring }: ResourceCardsProps) {
   const [height, setWindowHeight] = useState(0);
@@ -29,15 +29,17 @@ export default function ResourceCards({ resourceInfo, resourceType, icon, author
     <div>
       <ScrollArea.Autosize mah={height * 0.8} type="scroll">
         {resourceInfo?.length > 0 ? (
-          <Stack align="stretch">
-            {resourceInfo.map(res => {
-              return (
-                <div key={res.id}>
-                  <ResourceInfoCard resourceInfo={res} icon={icon} authoring={authoring} />
-                </div>
-              );
-            })}
-          </Stack>
+          <Center>
+            <Stack align="stretch">
+              {resourceInfo.map(res => {
+                return (
+                  <div key={res.id}>
+                    <ResourceInfoCard resourceInfo={res} icon={icon} authoring={authoring} />
+                  </div>
+                );
+              })}
+            </Stack>
+          </Center>
         ) : (
           <Center>
             <Text>

--- a/app/src/components/ResourceCards.tsx
+++ b/app/src/components/ResourceCards.tsx
@@ -6,7 +6,6 @@ import ResourceInfoCard from './ResourceInfoCard';
 interface ResourceCardsProps {
   resourceInfo: ResourceInfo[];
   resourceType: ArtifactResourceType;
-  icon: JSX.Element;
   authoring?: boolean;
 }
 
@@ -14,7 +13,7 @@ interface ResourceCardsProps {
  * Component which displays all resources of a specified type and their ids
  * as resource cards that link to that resource's page
  */
-export default function ResourceCards({ resourceInfo, resourceType, icon, authoring }: ResourceCardsProps) {
+export default function ResourceCards({ resourceInfo, resourceType, authoring }: ResourceCardsProps) {
   const [height, setWindowHeight] = useState(0);
   useEffect(() => {
     const handleResize = () => {
@@ -34,7 +33,7 @@ export default function ResourceCards({ resourceInfo, resourceType, icon, author
               {resourceInfo.map(res => {
                 return (
                   <div key={res.id}>
-                    <ResourceInfoCard resourceInfo={res} icon={icon} authoring={authoring} />
+                    <ResourceInfoCard resourceInfo={res} authoring={authoring} />
                   </div>
                 );
               })}

--- a/app/src/components/ResourceCards.tsx
+++ b/app/src/components/ResourceCards.tsx
@@ -29,12 +29,7 @@ export default function ResourceCards({ resourceInfo, resourceType, icon, author
     <div>
       <ScrollArea.Autosize mah={height * 0.8} type="scroll">
         {resourceInfo?.length > 0 ? (
-          <Stack
-            style={{
-              alignItems: 'center',
-              paddingBottom: '12px'
-            }}
-          >
+          <Stack align="stretch">
             {resourceInfo.map(res => {
               return (
                 <div key={res.id}>

--- a/app/src/components/ResourceCards.tsx
+++ b/app/src/components/ResourceCards.tsx
@@ -7,13 +7,14 @@ interface ResourceCardsProps {
   resourceInfo: ResourceInfo[];
   resourceType: ArtifactResourceType;
   icon: JSX.Element;
+  authoring?: boolean;
 }
 
 /**
  * Component which displays all resources of a specified type and their ids
  * as buttons that link to that resource's page
  */
-export default function ResourceCards({ resourceInfo, resourceType, icon }: ResourceCardsProps) {
+export default function ResourceCards({ resourceInfo, resourceType, icon, authoring }: ResourceCardsProps) {
   const [height, setWindowHeight] = useState(0);
   useEffect(() => {
     const handleResize = () => {
@@ -37,7 +38,7 @@ export default function ResourceCards({ resourceInfo, resourceType, icon }: Reso
             {resourceInfo.map(res => {
               return (
                 <div key={res.id}>
-                  <ResourceInfoCard resourceInfo={res} icon={icon} />
+                  <ResourceInfoCard resourceInfo={res} icon={icon} authoring={authoring} />
                 </div>
               );
             })}

--- a/app/src/components/ResourceInfoCard.tsx
+++ b/app/src/components/ResourceInfoCard.tsx
@@ -1,11 +1,11 @@
-import { Button, Grid, Paper, Text, createStyles, em, getBreakpointValue, rem } from '@mantine/core';
+import { ActionIcon, Grid, Paper, Text, createStyles, em, getBreakpointValue, rem } from '@mantine/core';
 import Link from 'next/link';
 import React from 'react';
 import { ResourceInfo } from '@/util/types/fhir';
-import { ExternalLink } from 'tabler-icons-react';
 
 export interface ResourceInfoCardProps {
   resourceInfo: ResourceInfo;
+  icon: JSX.Element;
 }
 
 const useStyles = createStyles(theme => ({
@@ -19,7 +19,7 @@ const useStyles = createStyles(theme => ({
   }
 }));
 
-export default function ResourceInfoCard({ resourceInfo }: ResourceInfoCardProps) {
+export default function ResourceInfoCard({ resourceInfo, icon }: ResourceInfoCardProps) {
   const { classes } = useStyles();
   return (
     <Paper className={classes.card} shadow="sm" p="md">
@@ -51,9 +51,9 @@ export default function ResourceInfoCard({ resourceInfo }: ResourceInfoCardProps
           )}
         </Grid.Col>
         <Link href={`/${resourceInfo.resourceType}/${resourceInfo.id}`} key={resourceInfo.id}>
-          <Button radius="md" size="md" variant="subtle" color="gray">
-            {<ExternalLink size="24" />}
-          </Button>
+          <ActionIcon radius="md" size="md" variant="subtle" color="gray">
+            {icon}
+          </ActionIcon>
         </Link>
       </Grid>
     </Paper>

--- a/app/src/components/ResourceInfoCard.tsx
+++ b/app/src/components/ResourceInfoCard.tsx
@@ -1,4 +1,4 @@
-import { ActionIcon, Grid, Paper, Text, createStyles, em, getBreakpointValue, rem } from '@mantine/core';
+import { ActionIcon, Grid, Paper, Text, createStyles, em, getBreakpointValue, rem, Tooltip } from '@mantine/core';
 import Link from 'next/link';
 import React from 'react';
 import { ResourceInfo } from '@/util/types/fhir';
@@ -59,9 +59,11 @@ export default function ResourceInfoCard({ resourceInfo, icon, authoring }: Reso
           }
           key={resourceInfo.id}
         >
-          <ActionIcon radius="md" size="md" variant="subtle" color="gray">
-            {icon}
-          </ActionIcon>
+          <Tooltip label={authoring ? 'Edit Draft Resource' : 'View Resource Contents'} openDelay={1000}>
+            <ActionIcon radius="md" size="md" variant="subtle" color="gray">
+              {icon}
+            </ActionIcon>
+          </Tooltip>
         </Link>
       </Grid>
     </Paper>

--- a/app/src/components/ResourceInfoCard.tsx
+++ b/app/src/components/ResourceInfoCard.tsx
@@ -2,7 +2,7 @@ import { ActionIcon, Grid, Paper, Text, createStyles, em, getBreakpointValue, re
 import Link from 'next/link';
 import React from 'react';
 import { ResourceInfo } from '@/util/types/fhir';
-import { Edit, ExternalLink } from 'tabler-icons-react';
+import { Edit, SquareArrowRight } from 'tabler-icons-react';
 
 export interface ResourceInfoCardProps {
   resourceInfo: ResourceInfo;
@@ -61,7 +61,7 @@ export default function ResourceInfoCard({ resourceInfo, authoring }: ResourceIn
         >
           <Tooltip label={authoring ? 'Edit Draft Resource' : 'View Resource Contents'} openDelay={1000}>
             <ActionIcon radius="md" size="md" variant="subtle" color="gray">
-              {authoring ? <Edit size="24" /> : <ExternalLink size="24" />}
+              {authoring ? <Edit size="24" /> : <SquareArrowRight size="24" />}
             </ActionIcon>
           </Tooltip>
         </Link>

--- a/app/src/components/ResourceInfoCard.tsx
+++ b/app/src/components/ResourceInfoCard.tsx
@@ -6,6 +6,7 @@ import { ResourceInfo } from '@/util/types/fhir';
 export interface ResourceInfoCardProps {
   resourceInfo: ResourceInfo;
   icon: JSX.Element;
+  authoring?: boolean;
 }
 
 const useStyles = createStyles(theme => ({
@@ -19,7 +20,7 @@ const useStyles = createStyles(theme => ({
   }
 }));
 
-export default function ResourceInfoCard({ resourceInfo, icon }: ResourceInfoCardProps) {
+export default function ResourceInfoCard({ resourceInfo, icon, authoring }: ResourceInfoCardProps) {
   const { classes } = useStyles();
   return (
     <Paper className={classes.card} shadow="sm" p="md">
@@ -50,7 +51,14 @@ export default function ResourceInfoCard({ resourceInfo, icon }: ResourceInfoCar
             </Text>
           )}
         </Grid.Col>
-        <Link href={`/${resourceInfo.resourceType}/${resourceInfo.id}`} key={resourceInfo.id}>
+        <Link
+          href={
+            authoring
+              ? `/authoring/${resourceInfo.resourceType}/${resourceInfo.id}`
+              : `/${resourceInfo.resourceType}/${resourceInfo.id}`
+          }
+          key={resourceInfo.id}
+        >
           <ActionIcon radius="md" size="md" variant="subtle" color="gray">
             {icon}
           </ActionIcon>

--- a/app/src/components/ResourceInfoCard.tsx
+++ b/app/src/components/ResourceInfoCard.tsx
@@ -2,10 +2,10 @@ import { ActionIcon, Grid, Paper, Text, createStyles, em, getBreakpointValue, re
 import Link from 'next/link';
 import React from 'react';
 import { ResourceInfo } from '@/util/types/fhir';
+import { Edit, ExternalLink } from 'tabler-icons-react';
 
 export interface ResourceInfoCardProps {
   resourceInfo: ResourceInfo;
-  icon: JSX.Element;
   authoring?: boolean;
 }
 
@@ -20,7 +20,7 @@ const useStyles = createStyles(theme => ({
   }
 }));
 
-export default function ResourceInfoCard({ resourceInfo, icon, authoring }: ResourceInfoCardProps) {
+export default function ResourceInfoCard({ resourceInfo, authoring }: ResourceInfoCardProps) {
   const { classes } = useStyles();
   return (
     <Paper className={classes.card} shadow="sm" p="md">
@@ -61,7 +61,7 @@ export default function ResourceInfoCard({ resourceInfo, icon, authoring }: Reso
         >
           <Tooltip label={authoring ? 'Edit Draft Resource' : 'View Resource Contents'} openDelay={1000}>
             <ActionIcon radius="md" size="md" variant="subtle" color="gray">
-              {icon}
+              {authoring ? <Edit size="24" /> : <ExternalLink size="24" />}
             </ActionIcon>
           </Tooltip>
         </Link>

--- a/app/src/pages/[resourceType].tsx
+++ b/app/src/pages/[resourceType].tsx
@@ -3,6 +3,7 @@ import { Text, Divider, Button, Center } from '@mantine/core';
 import { ArtifactResourceType, ResourceInfo, FhirArtifact } from '@/util/types/fhir';
 import ResourceCards from '@/components/ResourceCards';
 import Link from 'next/link';
+import { ExternalLink } from 'tabler-icons-react';
 
 /**
  * Component which displays list of all resources of some type as passed in by (serverside) props
@@ -27,7 +28,7 @@ export default function ResourceList({
           </Link>
         </Center>
         <div style={{ paddingTop: '18px' }}>
-          <ResourceCards resourceInfo={resourceInfo} resourceType={resourceType} />
+          <ResourceCards resourceInfo={resourceInfo} resourceType={resourceType} icon={<ExternalLink size="24" />} />
         </div>
       </div>
     </>

--- a/app/src/pages/[resourceType].tsx
+++ b/app/src/pages/[resourceType].tsx
@@ -27,9 +27,11 @@ export default function ResourceList({
             <Button>Search</Button>
           </Link>
         </Center>
-        <div style={{ paddingTop: '18px' }}>
-          <ResourceCards resourceInfo={resourceInfo} resourceType={resourceType} icon={<ExternalLink size="24" />} />
-        </div>
+        <Center>
+          <div style={{ paddingTop: '18px' }}>
+            <ResourceCards resourceInfo={resourceInfo} resourceType={resourceType} icon={<ExternalLink size="24" />} />
+          </div>
+        </Center>
       </div>
     </>
   );

--- a/app/src/pages/[resourceType].tsx
+++ b/app/src/pages/[resourceType].tsx
@@ -3,7 +3,6 @@ import { Text, Divider, Button, Center, Stack } from '@mantine/core';
 import { ArtifactResourceType, ResourceInfo, FhirArtifact } from '@/util/types/fhir';
 import ResourceCards from '@/components/ResourceCards';
 import Link from 'next/link';
-import { ExternalLink } from 'tabler-icons-react';
 import { extractResourceInfo } from '@/util/resourceCardUtils';
 
 /**
@@ -28,7 +27,7 @@ export default function ResourceList({
             <Button>Search</Button>
           </Link>
           <div style={{ paddingTop: '18px' }}>
-            <ResourceCards resourceInfo={resourceInfo} resourceType={resourceType} icon={<ExternalLink size="24" />} />
+            <ResourceCards resourceInfo={resourceInfo} resourceType={resourceType} />
           </div>
         </Stack>
       </div>

--- a/app/src/pages/[resourceType].tsx
+++ b/app/src/pages/[resourceType].tsx
@@ -1,9 +1,10 @@
 import { GetServerSideProps, InferGetServerSidePropsType } from 'next';
-import { Text, Divider, Button, Center } from '@mantine/core';
+import { Text, Divider, Button, Center, Stack } from '@mantine/core';
 import { ArtifactResourceType, ResourceInfo, FhirArtifact } from '@/util/types/fhir';
 import ResourceCards from '@/components/ResourceCards';
 import Link from 'next/link';
 import { ExternalLink } from 'tabler-icons-react';
+import { extractResourceInfo } from '@/util/resourceCardUtils';
 
 /**
  * Component which displays list of all resources of some type as passed in by (serverside) props
@@ -22,16 +23,14 @@ export default function ResourceList({
           </Text>
         </Center>
         <Divider my="md" />
-        <Center>
+        <Stack align="center">
           <Link href={`/search?resourceType=${resourceType}`}>
             <Button>Search</Button>
           </Link>
-        </Center>
-        <Center>
           <div style={{ paddingTop: '18px' }}>
             <ResourceCards resourceInfo={resourceInfo} resourceType={resourceType} icon={<ExternalLink size="24" />} />
           </div>
-        </Center>
+        </Stack>
       </div>
     </>
   );
@@ -64,16 +63,7 @@ export const getServerSideProps: GetServerSideProps<{
   const resources = bundle.entry;
   const resourceInfoArray = resources.reduce((acc: ResourceInfo[], entry) => {
     if (entry.resource && entry.resource.id) {
-      const identifier = entry.resource.identifier?.[0];
-      const resourceInfo: ResourceInfo = {
-        resourceType: checkedResourceType,
-        id: entry.resource.id,
-        identifier: identifier?.system && identifier?.value ? `${identifier.system}|${identifier.value}` : null,
-        name: entry.resource.name ?? null,
-        url: entry.resource.url ?? null,
-        version: entry.resource.version ?? null,
-        status: entry.resource.status ?? null
-      };
+      const resourceInfo = extractResourceInfo(entry.resource);
       acc.push(resourceInfo);
     }
     return acc;

--- a/app/src/pages/[resourceType]/search-result.tsx
+++ b/app/src/pages/[resourceType]/search-result.tsx
@@ -3,6 +3,7 @@ import { Center, Divider, Paper, Text } from '@mantine/core';
 import { ArtifactResourceType, FhirArtifact, ResourceInfo } from '@/util/types/fhir';
 import ResourceCards from '@/components/ResourceCards';
 import { ExternalLink } from 'tabler-icons-react';
+import { extractResourceInfo } from '@/util/resourceCardUtils';
 
 export default function ResourceSearchResultsPage({
   resourceInfo,
@@ -78,16 +79,7 @@ export const getServerSideProps: GetServerSideProps<{
     const resources = bundle.entry;
     const resourceInfoArray = resources.reduce((acc: ResourceInfo[], entry) => {
       if (entry.resource && entry.resource.id) {
-        const identifier = entry.resource.identifier?.[0];
-        const resourceInfo: ResourceInfo = {
-          resourceType: checkedResourceType,
-          id: entry.resource.id,
-          identifier: identifier?.system && identifier?.value ? `${identifier.system}|${identifier.value}` : null,
-          name: entry.resource.name ?? null,
-          url: entry.resource.url ?? null,
-          version: entry.resource.version ?? null,
-          status: entry.resource.status ?? null
-        };
+        const resourceInfo = extractResourceInfo(entry.resource);
         acc.push(resourceInfo);
       }
       return acc;

--- a/app/src/pages/[resourceType]/search-result.tsx
+++ b/app/src/pages/[resourceType]/search-result.tsx
@@ -2,6 +2,7 @@ import { GetServerSideProps, InferGetServerSidePropsType } from 'next';
 import { Center, Divider, Paper, Text } from '@mantine/core';
 import { ArtifactResourceType, FhirArtifact, ResourceInfo } from '@/util/types/fhir';
 import ResourceCards from '@/components/ResourceCards';
+import { ExternalLink } from 'tabler-icons-react';
 
 export default function ResourceSearchResultsPage({
   resourceInfo,
@@ -24,9 +25,11 @@ export default function ResourceSearchResultsPage({
       </Center>
       <Divider my="md" />
       {resourceInfo ? (
-        <div style={{ paddingTop: '18px' }}>
-          <ResourceCards resourceInfo={resourceInfo} resourceType={resourceType} />
-        </div>
+        <Center>
+          <div style={{ paddingTop: '18px' }}>
+            <ResourceCards resourceInfo={resourceInfo} resourceType={resourceType} icon={<ExternalLink size="24" />} />
+          </div>
+        </Center>
       ) : (
         <div
           style={{

--- a/app/src/pages/[resourceType]/search-result.tsx
+++ b/app/src/pages/[resourceType]/search-result.tsx
@@ -1,8 +1,7 @@
 import { GetServerSideProps, InferGetServerSidePropsType } from 'next';
-import { Center, Divider, Paper, Text } from '@mantine/core';
+import { Center, Divider, Paper, Text, Stack } from '@mantine/core';
 import { ArtifactResourceType, FhirArtifact, ResourceInfo } from '@/util/types/fhir';
 import ResourceCards from '@/components/ResourceCards';
-import { ExternalLink } from 'tabler-icons-react';
 import { extractResourceInfo } from '@/util/resourceCardUtils';
 
 export default function ResourceSearchResultsPage({
@@ -27,7 +26,7 @@ export default function ResourceSearchResultsPage({
       <Divider my="md" />
       {resourceInfo ? (
         <Stack align="center" pt={18}>
-            <ResourceCards resourceInfo={resourceInfo} resourceType={resourceType} icon={<ExternalLink size="24" />} />
+          <ResourceCards resourceInfo={resourceInfo} resourceType={resourceType} />
         </Stack>
       ) : (
         <div

--- a/app/src/pages/[resourceType]/search-result.tsx
+++ b/app/src/pages/[resourceType]/search-result.tsx
@@ -26,11 +26,9 @@ export default function ResourceSearchResultsPage({
       </Center>
       <Divider my="md" />
       {resourceInfo ? (
-        <Center>
-          <div style={{ paddingTop: '18px' }}>
+        <Stack align="center" pt={18}>
             <ResourceCards resourceInfo={resourceInfo} resourceType={resourceType} icon={<ExternalLink size="24" />} />
-          </div>
-        </Center>
+        </Stack>
       ) : (
         <div
           style={{

--- a/app/src/pages/authoring/[resourceType]/index.tsx
+++ b/app/src/pages/authoring/[resourceType]/index.tsx
@@ -1,10 +1,45 @@
-import { Center, Text } from '@mantine/core';
+import { trpc } from '@/util/trpc';
+import { Center, Text, Divider } from '@mantine/core';
+import { useRouter } from 'next/router';
+import { ArtifactResourceType, FhirArtifact, ResourceInfo } from '@/util/types/fhir';
+import ResourceCards from '@/components/ResourceCards';
+import { Edit } from 'tabler-icons-react';
+
 export default function ResourceAuthoringPage() {
+  const router = useRouter();
+  const { resourceType } = router.query;
+
+  const resourceTypeQuery = trpc.draft.getDrafts.useQuery(resourceType as ArtifactResourceType);
+
+  const resourceCardContent: ResourceInfo[] = (resourceTypeQuery.data as FhirArtifact[])?.map(resource => {
+    const identifier = resource.identifier?.[0];
+    const resourceInfo: ResourceInfo = {
+      resourceType: resourceType as ArtifactResourceType,
+      id: resource.id as string,
+      identifier: identifier?.system && identifier?.value ? `${identifier.system}|${identifier.value}` : null,
+      name: resource.name ?? null,
+      url: resource.url ?? null,
+      version: resource.version ?? null,
+      status: resource.status ?? null
+    };
+    return resourceInfo;
+  });
+
   return (
     <div>
       <Center>
-        <Text c="gray">Coming Soon</Text>
+        <Text c="gray" fz="xl">
+          Available Draft {resourceType} Resources
+        </Text>
       </Center>
+      <Divider my="md" />
+      <div style={{ paddingTop: '18px' }}>
+        <ResourceCards
+          resourceInfo={resourceCardContent}
+          resourceType={resourceType as ArtifactResourceType}
+          icon={<Edit size="24" />}
+        />
+      </div>
     </div>
   );
 }

--- a/app/src/pages/authoring/[resourceType]/index.tsx
+++ b/app/src/pages/authoring/[resourceType]/index.tsx
@@ -1,19 +1,20 @@
 import { trpc } from '@/util/trpc';
 import { Center, Text, Divider } from '@mantine/core';
 import { useRouter } from 'next/router';
-import { ArtifactResourceType, FhirArtifact, ResourceInfo } from '@/util/types/fhir';
+import { ArtifactResourceType, ResourceInfo } from '@/util/types/fhir';
 import ResourceCards from '@/components/ResourceCards';
 import { extractResourceInfo } from '@/util/resourceCardUtils';
+import { useMemo } from 'react';
 
 export default function ResourceAuthoringPage() {
   const router = useRouter();
   const { resourceType } = router.query;
 
-  const resourceTypeQuery = trpc.draft.getDrafts.useQuery(resourceType as ArtifactResourceType);
+  const { data: artifacts } = trpc.draft.getDrafts.useQuery(resourceType as ArtifactResourceType);
 
-  const resourceCardContent: ResourceInfo[] = (resourceTypeQuery.data as FhirArtifact[])?.map(resource => {
-    return extractResourceInfo(resource);
-  });
+  const resourceCardContent: ResourceInfo[] = useMemo(() => {
+    return (artifacts ?? []).map(a => extractResourceInfo(a));
+  }, [artifacts]);
 
   return (
     <div>

--- a/app/src/pages/authoring/[resourceType]/index.tsx
+++ b/app/src/pages/authoring/[resourceType]/index.tsx
@@ -3,7 +3,6 @@ import { Center, Text, Divider } from '@mantine/core';
 import { useRouter } from 'next/router';
 import { ArtifactResourceType, FhirArtifact, ResourceInfo } from '@/util/types/fhir';
 import ResourceCards from '@/components/ResourceCards';
-import { Edit } from 'tabler-icons-react';
 import { extractResourceInfo } from '@/util/resourceCardUtils';
 
 export default function ResourceAuthoringPage() {
@@ -28,7 +27,6 @@ export default function ResourceAuthoringPage() {
         <ResourceCards
           resourceInfo={resourceCardContent}
           resourceType={resourceType as ArtifactResourceType}
-          icon={<Edit size="24" />}
           authoring={true}
         />
       </div>

--- a/app/src/pages/authoring/[resourceType]/index.tsx
+++ b/app/src/pages/authoring/[resourceType]/index.tsx
@@ -34,12 +34,14 @@ export default function ResourceAuthoringPage() {
       </Center>
       <Divider my="md" />
       <div style={{ paddingTop: '18px' }}>
-        <ResourceCards
-          resourceInfo={resourceCardContent}
-          resourceType={resourceType as ArtifactResourceType}
-          icon={<Edit size="24" />}
-          authoring={true}
-        />
+        <Center>
+          <ResourceCards
+            resourceInfo={resourceCardContent}
+            resourceType={resourceType as ArtifactResourceType}
+            icon={<Edit size="24" />}
+            authoring={true}
+          />
+        </Center>
       </div>
     </div>
   );

--- a/app/src/pages/authoring/[resourceType]/index.tsx
+++ b/app/src/pages/authoring/[resourceType]/index.tsx
@@ -4,6 +4,7 @@ import { useRouter } from 'next/router';
 import { ArtifactResourceType, FhirArtifact, ResourceInfo } from '@/util/types/fhir';
 import ResourceCards from '@/components/ResourceCards';
 import { Edit } from 'tabler-icons-react';
+import { extractResourceInfo } from '@/util/resourceCardUtils';
 
 export default function ResourceAuthoringPage() {
   const router = useRouter();
@@ -12,17 +13,7 @@ export default function ResourceAuthoringPage() {
   const resourceTypeQuery = trpc.draft.getDrafts.useQuery(resourceType as ArtifactResourceType);
 
   const resourceCardContent: ResourceInfo[] = (resourceTypeQuery.data as FhirArtifact[])?.map(resource => {
-    const identifier = resource.identifier?.[0];
-    const resourceInfo: ResourceInfo = {
-      resourceType: resourceType as ArtifactResourceType,
-      id: resource.id as string,
-      identifier: identifier?.system && identifier?.value ? `${identifier.system}|${identifier.value}` : null,
-      name: resource.name ?? null,
-      url: resource.url ?? null,
-      version: resource.version ?? null,
-      status: resource.status ?? null
-    };
-    return resourceInfo;
+    return extractResourceInfo(resource);
   });
 
   return (
@@ -34,14 +25,12 @@ export default function ResourceAuthoringPage() {
       </Center>
       <Divider my="md" />
       <div style={{ paddingTop: '18px' }}>
-        <Center>
-          <ResourceCards
-            resourceInfo={resourceCardContent}
-            resourceType={resourceType as ArtifactResourceType}
-            icon={<Edit size="24" />}
-            authoring={true}
-          />
-        </Center>
+        <ResourceCards
+          resourceInfo={resourceCardContent}
+          resourceType={resourceType as ArtifactResourceType}
+          icon={<Edit size="24" />}
+          authoring={true}
+        />
       </div>
     </div>
   );

--- a/app/src/pages/authoring/[resourceType]/index.tsx
+++ b/app/src/pages/authoring/[resourceType]/index.tsx
@@ -38,6 +38,7 @@ export default function ResourceAuthoringPage() {
           resourceInfo={resourceCardContent}
           resourceType={resourceType as ArtifactResourceType}
           icon={<Edit size="24" />}
+          authoring={true}
         />
       </div>
     </div>

--- a/app/src/server/trpc/routers/draft.ts
+++ b/app/src/server/trpc/routers/draft.ts
@@ -16,8 +16,8 @@ export const draftRouter = router({
   }),
 
   getDrafts: publicProcedure
-    .input(z.enum(['Measure', 'Library']))
-    .query(async opts => getAllDraftsByType<FhirArtifact>(opts.input)),
+    .input(z.enum(['Measure', 'Library']).optional())
+    .query(async opts => (opts.input ? getAllDraftsByType<FhirArtifact>(opts.input) : null)),
 
   getDraftById: publicProcedure
     .input(z.object({ id: z.string().optional(), resourceType: z.enum(['Measure', 'Library']).optional() }))

--- a/app/src/util/resourceCardUtils.ts
+++ b/app/src/util/resourceCardUtils.ts
@@ -1,0 +1,20 @@
+import { FhirArtifact, ResourceInfo } from './types/fhir';
+
+/**
+ * Extracts fields from the resource to be rendered onto the resource's card.
+ * @param resource Measure of Library resource
+ * @returns object containing extracted info from resource
+ */
+export function extractResourceInfo(resource: FhirArtifact) {
+  const identifier = resource.identifier?.[0];
+  const resourceInfo: ResourceInfo = {
+    resourceType: resource.resourceType,
+    id: resource.id as string,
+    identifier: identifier?.system && identifier?.value ? `${identifier.system}|${identifier.value}` : null,
+    name: resource.name ?? null,
+    url: resource.url ?? null,
+    version: resource.version ?? null,
+    status: resource.status ?? null
+  };
+  return resourceInfo;
+}

--- a/app/src/util/resourceCardUtils.ts
+++ b/app/src/util/resourceCardUtils.ts
@@ -2,7 +2,7 @@ import { FhirArtifact, ResourceInfo } from './types/fhir';
 
 /**
  * Extracts fields from the resource to be rendered onto the resource's card.
- * @param resource Measure of Library resource
+ * @param resource Measure or Library resource
  * @returns object containing extracted info from resource
  */
 export function extractResourceInfo(resource: FhirArtifact) {


### PR DESCRIPTION
# Summary
Builds out the `/authoring/[resourceType].tsx` page, allowing the user to view draft artifacts as cards that route to the editing page.

## New behavior
The user can now view resources cards of the available draft artifacts that are stored in the mongo database, which contain identifying fields like `url` and `identifier`. To do so, from authoring “mode,” select a resource type. Then, the contents of each draft resource should be rendered as a resource card. Each resource card also contains an edit button that routes to the editing page so that the user can edit the selected resource.
<img width="1410" alt="Screenshot 2023-06-12 at 3 00 11 PM" src="https://github.com/projecttacoma/measure-repository/assets/87094479/711ce68c-f793-4e39-b47f-14394e0825e9">


## Code changes
* `app/src/pages/authoring/[resourceType]/index.tsx` —> builds out the `[resourceType]` page by getting the resources using a `trpc` query, mapping the resources to the resource card content (`id`, `identifier`, etc.), and rendering the resource cards on the page
* `app/src/components/ResourceCards.tsx` —> changed styling on the `Stack` so that the cards have uniform width with different screen sizes (previously this wasn’t the case)
* Changes to the resource card props
    * Added an `icon` field for the icon to render on each card — should be an external link for the repository “mode” and a pencil/edit icon for the authoring “mode”
    * Added an `authoring` boolean field that gets checked to determine what page to route to (depending on the mode) and what tooltip text to render
* Added tooltip for editing a draft resource/viewing resource contents (depending on the mode)
* `app/src/util/resourceCardUtils.ts` —> new file with a function for extracting the fields that we want to render on a resource card. I noticed that we do this extraction in multiple places, so moving this into a helper seemed like a good improvement

# Testing guidance
Test the various scenarios:
* Clear the `Measure` and `Library` collections on the `draft-repository` database so that each resource type button is at “0.” There should be no resource cards on the page - you should see “No <resourceType> resources available.”
<img width="182" alt="Screenshot 2023-06-12 at 2 57 47 PM" src="https://github.com/projecttacoma/measure-repository/assets/87094479/0466f98d-ffc8-468a-85f5-feb7bee5c049">

* Create a few draft resources for each resource type. Then, click on the resource type button. You should see a resource card of reach draft resource.
* Try creating a few resources that have a `url` and/or `identifier` field - these fields will be reflected on the resource cards when they are defined.
* Hover over the “edit” button - you should see the text “Edit Draft Resource”
* Click on the “edit” button and check that you get routed to the editing page, and that the resource corresponds to the resource card that was clicked on. Try editing a field and check that the change is reflected on the card
* Change the window size and check the responsiveness of the resource cards - they should now be of the same width
<img width="711" alt="Screenshot 2023-06-12 at 3 00 31 PM" src="https://github.com/projecttacoma/measure-repository/assets/87094479/dd368c4b-b67c-4149-b9b7-0a336c1459f4">
