### PR TITLE
Edit draft artifacts

### DIFF
--- a/app/src/components/ArtifactFieldInput.tsx
+++ b/app/src/components/ArtifactFieldInput.tsx
@@ -1,0 +1,30 @@
+import { ActionIcon, TextInput } from '@mantine/core';
+import { SetStateAction } from 'react';
+import { X } from 'tabler-icons-react';
+
+export interface ArtifactFieldInputProps {
+  label: string;
+  value: string;
+  setField: (value: SetStateAction<string>) => void;
+}
+
+export default function ArtifactFieldInput({ label, value, setField }: ArtifactFieldInputProps) {
+  return (
+    <div>
+      <TextInput
+        label={label}
+        value={value}
+        onChange={e => setField(e.target.value)}
+        rightSection={
+          <ActionIcon
+            onClick={() => {
+              setField('');
+            }}
+          >
+            <X size={16} />
+          </ActionIcon>
+        }
+      />
+    </div>
+  );
+}

--- a/app/src/components/ArtifactFieldInput.tsx
+++ b/app/src/components/ArtifactFieldInput.tsx
@@ -1,11 +1,10 @@
 import { ActionIcon, TextInput } from '@mantine/core';
-import { Dispatch, SetStateAction } from 'react';
 import { X } from 'tabler-icons-react';
 
 export interface ArtifactFieldInputProps {
   label: string;
   value: string;
-  setField: Dispatch<SetStateAction<string>>;
+  setField: (val: string) => void;
 }
 
 export default function ArtifactFieldInput({ label, value, setField }: ArtifactFieldInputProps) {

--- a/app/src/components/ArtifactFieldInput.tsx
+++ b/app/src/components/ArtifactFieldInput.tsx
@@ -4,15 +4,17 @@ import { X } from 'tabler-icons-react';
 export interface ArtifactFieldInputProps {
   label: string;
   value: string;
+  disabled?: boolean;
   setField: (val: string) => void;
 }
 
-export default function ArtifactFieldInput({ label, value, setField }: ArtifactFieldInputProps) {
+export default function ArtifactFieldInput({ label, value, disabled, setField }: ArtifactFieldInputProps) {
   return (
     <div>
       <TextInput
         label={label}
         value={value}
+        disabled={disabled}
         onChange={e => setField(e.target.value)}
         rightSection={
           <ActionIcon

--- a/app/src/components/ArtifactFieldInput.tsx
+++ b/app/src/components/ArtifactFieldInput.tsx
@@ -1,11 +1,11 @@
 import { ActionIcon, TextInput } from '@mantine/core';
-import { SetStateAction } from 'react';
+import { Dispatch, SetStateAction } from 'react';
 import { X } from 'tabler-icons-react';
 
 export interface ArtifactFieldInputProps {
   label: string;
   value: string;
-  setField: (value: SetStateAction<string>) => void;
+  setField: Dispatch<SetStateAction<string>>;
 }
 
 export default function ArtifactFieldInput({ label, value, setField }: ArtifactFieldInputProps) {

--- a/app/src/pages/authoring/[resourceType]/[id].tsx
+++ b/app/src/pages/authoring/[resourceType]/[id].tsx
@@ -126,7 +126,7 @@ export default function ResourceAuthoringPage() {
                     setUrl('');
                   }}
                 >
-                  <X />
+                  <X size={16} />
                 </ActionIcon>
               }
             />
@@ -140,7 +140,7 @@ export default function ResourceAuthoringPage() {
                     setIdentifier('');
                   }}
                 >
-                  <X />
+                  <X size={16} />
                 </ActionIcon>
               }
             />
@@ -154,7 +154,7 @@ export default function ResourceAuthoringPage() {
                     setName('');
                   }}
                 >
-                  <X />
+                  <X size={16} />
                 </ActionIcon>
               }
             />
@@ -168,7 +168,7 @@ export default function ResourceAuthoringPage() {
                     setTitle('');
                   }}
                 >
-                  <X />
+                  <X size={16} />
                 </ActionIcon>
               }
             />
@@ -182,7 +182,7 @@ export default function ResourceAuthoringPage() {
                     setDescription('');
                   }}
                 >
-                  <X />
+                  <X size={16} />
                 </ActionIcon>
               }
             />

--- a/app/src/pages/authoring/[resourceType]/[id].tsx
+++ b/app/src/pages/authoring/[resourceType]/[id].tsx
@@ -13,6 +13,10 @@ export default function ResourceAuthoringPage() {
 
   const [url, setUrl] = useState('');
   const [identifier, setIdentifier] = useState('');
+  const [name, setName] = useState('');
+  const [title, setTitle] = useState('');
+  const [version, setVersion] = useState('');
+  const [description, setDescription] = useState('');
 
   const ctx = trpc.useContext();
 
@@ -58,8 +62,23 @@ export default function ResourceAuthoringPage() {
     }
   });
 
-  function parseUpdate(url: string, identifier: string) {
-    const update: { url?: string; identifier?: fhir4.Identifier[] } = {};
+  function parseUpdate(
+    url: string,
+    identifier: string,
+    name: string,
+    title: string,
+    version: string,
+    description: string
+  ) {
+    const update: {
+      url?: string;
+      identifier?: fhir4.Identifier[];
+      name?: string;
+      title?: string;
+      version?: string;
+      description?: string;
+    } = {};
+
     if (url !== '') {
       update['url'] = url;
     }
@@ -70,6 +89,18 @@ export default function ResourceAuthoringPage() {
       } else {
         update['identifier'] = [{ value: splitIden[0] }];
       }
+    }
+    if (name !== '') {
+      update['name'] = name;
+    }
+    if (title !== '') {
+      update['title'] = title;
+    }
+    if (version !== '') {
+      update['version'] = version;
+    }
+    if (description !== '') {
+      update['description'] = description;
     }
 
     return update;
@@ -88,16 +119,22 @@ export default function ResourceAuthoringPage() {
           <Stack spacing="md">
             <TextInput label="url" value={url} onChange={e => setUrl(e.target.value)} />
             <TextInput label="identifier" value={identifier} onChange={e => setIdentifier(e.target.value)} />
+            <TextInput label="name" value={name} onChange={e => setName(e.target.value)} />
+            <TextInput label="title" value={title} onChange={e => setTitle(e.target.value)} />
+            <TextInput label="version" value={version} onChange={e => setVersion(e.target.value)} />
+            <TextInput label="description" value={description} onChange={e => setDescription(e.target.value)} />
             <Button
               w={120}
               onClick={() =>
                 resourceUpdate.mutate({
                   resourceType: resourceType as ArtifactResourceType,
                   id: id as string,
-                  draft: parseUpdate(url, identifier)
+                  draft: parseUpdate(url, identifier, name, title, version, description)
                 })
               }
-              disabled={identifier === '' && url === ''}
+              disabled={
+                identifier === '' && url === '' && name === '' && title === '' && version === '' && description === ''
+              }
             >
               Submit
             </Button>

--- a/app/src/pages/authoring/[resourceType]/[id].tsx
+++ b/app/src/pages/authoring/[resourceType]/[id].tsx
@@ -84,7 +84,7 @@ export default function ResourceAuthoringPage() {
       } else if (resource.identifier[0].value) {
         setIdentifierValue(resource.identifier[0].value);
         if (resource.identifier[0].system) {
-          setIdentifierSystem(resource.identifier[0].value);
+          setIdentifierSystem(resource.identifier[0].system);
         }
       }
     }

--- a/app/src/pages/authoring/[resourceType]/[id].tsx
+++ b/app/src/pages/authoring/[resourceType]/[id].tsx
@@ -25,6 +25,31 @@ export default function ResourceAuthoringPage() {
     resourceType: resourceType as ArtifactResourceType
   });
 
+  // checks if the field inputs have been changed by the user by checking
+  // that they are different from the saved field values on the draft artifact
+  // if the input is undefined on the draft artifact, then it is treated as
+  // an empty string
+  const isChanged = () => {
+    let savedIdentifier = '';
+    if (resource?.identifier) {
+      const cmsIdentifier = resource.identifier.find(
+        identifier => identifier.system === 'http://hl7.org/fhir/cqi/ecqm/Measure/Identifier/cms'
+      );
+      if (cmsIdentifier?.value) {
+        savedIdentifier = cmsIdentifier.value;
+      } else if (resource.identifier[0].value) {
+        savedIdentifier = resource.identifier[0].value;
+      }
+    }
+    return (
+      url !== (resource?.url ?? '') ||
+      identifier !== savedIdentifier ||
+      name !== (resource?.name ?? '') ||
+      title !== (resource?.title ?? '') ||
+      description !== (resource?.description ?? '')
+    );
+  };
+
   // useEffect to check if the resource has any fields already defined
   useEffect(() => {
     if (resource?.url) {
@@ -133,6 +158,7 @@ export default function ResourceAuthoringPage() {
                   deletions: deletions
                 });
               }}
+              disabled={!isChanged()} // only enable the submit button when a field has changed
             >
               Submit
             </Button>

--- a/app/src/pages/authoring/[resourceType]/[id].tsx
+++ b/app/src/pages/authoring/[resourceType]/[id].tsx
@@ -25,7 +25,7 @@ export default function ResourceAuthoringPage() {
     resourceType: resourceType as ArtifactResourceType
   });
 
-  // useEffect to check if the resource has an identifier and url defined
+  // useEffect to check if the resource has any fields already defined
   useEffect(() => {
     if (resource?.url) {
       setUrl(resource.url);

--- a/app/src/pages/authoring/[resourceType]/[id].tsx
+++ b/app/src/pages/authoring/[resourceType]/[id].tsx
@@ -87,12 +87,8 @@ export default function ResourceAuthoringPage() {
       description?: string;
     } = {};
 
-    if (url !== '') {
-      additions['url'] = url;
-    } else {
-      deletions['url'] = '';
-    }
-    if (identifier !== '') {
+    url.trim() !== '' ? (additions['url'] = url) : (deletions['url'] = '');
+    if (identifier.trim() !== '') {
       const splitIden = identifier.split('|');
       if (splitIden.length > 1) {
         additions['identifier'] = [{ system: splitIden[0], value: splitIden[1] }];
@@ -102,21 +98,9 @@ export default function ResourceAuthoringPage() {
     } else {
       deletions['identifier'] = [{ system: '', value: '' }];
     }
-    if (name !== '') {
-      additions['name'] = name;
-    } else {
-      deletions['name'] = '';
-    }
-    if (title !== '') {
-      additions['title'] = title;
-    } else {
-      deletions['title'] = '';
-    }
-    if (description !== '') {
-      additions['description'] = description;
-    } else {
-      deletions['description'] = '';
-    }
+    name.trim() !== '' ? (additions['name'] = name) : (deletions['name'] = '');
+    title.trim() !== '' ? (additions['title'] = title) : (deletions['title'] = '');
+    description.trim() !== '' ? (additions['description'] = description) : (deletions['description'] = '');
 
     return [additions, deletions];
   }

--- a/app/src/pages/authoring/[resourceType]/[id].tsx
+++ b/app/src/pages/authoring/[resourceType]/[id].tsx
@@ -40,6 +40,18 @@ export default function ResourceAuthoringPage() {
         setIdentifier(resource.identifier[0].value);
       }
     }
+    if (resource?.name) {
+      setName(resource.name);
+    }
+    if (resource?.title) {
+      setTitle(resource.title);
+    }
+    if (resource?.version) {
+      setVersion(resource.version);
+    }
+    if (resource?.description) {
+      setDescription(resource.description);
+    }
   }, [resource]);
 
   const resourceUpdate = trpc.draft.updateDraft.useMutation({

--- a/app/src/pages/authoring/[resourceType]/[id].tsx
+++ b/app/src/pages/authoring/[resourceType]/[id].tsx
@@ -8,6 +8,14 @@ import { AlertCircle, CircleCheck } from 'tabler-icons-react';
 import { ArtifactResourceType } from '@/util/types/fhir';
 import ArtifactFieldInput from '@/components/ArtifactFieldInput';
 
+interface DraftArtifactUpdates {
+  url?: string;
+  identifier?: fhir4.Identifier[];
+  name?: string;
+  title?: string;
+  description?: string;
+}
+
 export default function ResourceAuthoringPage() {
   const router = useRouter();
   const { resourceType, id } = router.query;
@@ -97,21 +105,8 @@ export default function ResourceAuthoringPage() {
   });
 
   function parseUpdate(url: string, identifier: string, name: string, title: string, description: string) {
-    const additions: {
-      url?: string;
-      identifier?: fhir4.Identifier[];
-      name?: string;
-      title?: string;
-      description?: string;
-    } = {};
-
-    const deletions: {
-      url?: string;
-      identifier?: fhir4.Identifier[];
-      name?: string;
-      title?: string;
-      description?: string;
-    } = {};
+    const additions: DraftArtifactUpdates = {};
+    const deletions: DraftArtifactUpdates = {};
 
     url.trim() !== '' ? (additions['url'] = url) : (deletions['url'] = '');
     if (identifier.trim() !== '') {

--- a/app/src/pages/authoring/[resourceType]/[id].tsx
+++ b/app/src/pages/authoring/[resourceType]/[id].tsx
@@ -1,11 +1,12 @@
 import { trpc } from '@/util/trpc';
-import { ActionIcon, Button, Center, Divider, Grid, Paper, Stack, Text, TextInput } from '@mantine/core';
+import { Button, Center, Divider, Grid, Paper, Stack, Text } from '@mantine/core';
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/router';
 import { Prism } from '@mantine/prism';
 import { notifications } from '@mantine/notifications';
-import { AlertCircle, CircleCheck, X } from 'tabler-icons-react';
+import { AlertCircle, CircleCheck } from 'tabler-icons-react';
 import { ArtifactResourceType } from '@/util/types/fhir';
+import ArtifactFieldInput from '@/components/ArtifactFieldInput';
 
 export default function ResourceAuthoringPage() {
   const router = useRouter();
@@ -116,76 +117,11 @@ export default function ResourceAuthoringPage() {
       <Grid>
         <Grid.Col span={6}>
           <Stack spacing="md">
-            <TextInput
-              label="url"
-              value={url}
-              onChange={e => setUrl(e.target.value)}
-              rightSection={
-                <ActionIcon
-                  onClick={() => {
-                    setUrl('');
-                  }}
-                >
-                  <X size={16} />
-                </ActionIcon>
-              }
-            />
-            <TextInput
-              label="identifier"
-              value={identifier}
-              onChange={e => setIdentifier(e.target.value)}
-              rightSection={
-                <ActionIcon
-                  onClick={() => {
-                    setIdentifier('');
-                  }}
-                >
-                  <X size={16} />
-                </ActionIcon>
-              }
-            />
-            <TextInput
-              label="name"
-              value={name}
-              onChange={e => setName(e.target.value)}
-              rightSection={
-                <ActionIcon
-                  onClick={() => {
-                    setName('');
-                  }}
-                >
-                  <X size={16} />
-                </ActionIcon>
-              }
-            />
-            <TextInput
-              label="title"
-              value={title}
-              onChange={e => setTitle(e.target.value)}
-              rightSection={
-                <ActionIcon
-                  onClick={() => {
-                    setTitle('');
-                  }}
-                >
-                  <X size={16} />
-                </ActionIcon>
-              }
-            />
-            <TextInput
-              label="description"
-              value={description}
-              onChange={e => setDescription(e.target.value)}
-              rightSection={
-                <ActionIcon
-                  onClick={() => {
-                    setDescription('');
-                  }}
-                >
-                  <X size={16} />
-                </ActionIcon>
-              }
-            />
+            <ArtifactFieldInput label="url" value={url} setField={setUrl} />
+            <ArtifactFieldInput label="identifier" value={identifier} setField={setIdentifier} />
+            <ArtifactFieldInput label="name" value={name} setField={setName} />
+            <ArtifactFieldInput label="title" value={title} setField={setTitle} />
+            <ArtifactFieldInput label="description" value={description} setField={setDescription} />
             <Button
               w={120}
               onClick={() => {

--- a/app/src/pages/authoring/[resourceType]/[id].tsx
+++ b/app/src/pages/authoring/[resourceType]/[id].tsx
@@ -60,7 +60,8 @@ export default function ResourceAuthoringPage() {
     return (
       url !== (resource?.url ?? '') ||
       identifierValue !== savedIdentifierValue ||
-      identifierSystem !== savedIdentifierSystem ||
+      (identifierSystem !== savedIdentifierSystem && savedIdentifierValue) ||
+      (identifierValue.trim() !== '' && identifierSystem !== savedIdentifierSystem) ||
       name !== (resource?.name ?? '') ||
       title !== (resource?.title ?? '') ||
       description !== (resource?.description ?? '')
@@ -160,7 +161,12 @@ export default function ResourceAuthoringPage() {
           <Stack spacing="md">
             <ArtifactFieldInput label="url" value={url} setField={setUrl} />
             <ArtifactFieldInput label="identifier value" value={identifierValue} setField={setIdentifierValue} />
-            <ArtifactFieldInput label="identifier system" value={identifierSystem} setField={setIdentifierSystem} />
+            <ArtifactFieldInput
+              disabled={!identifierValue}
+              label="identifier system"
+              value={identifierSystem}
+              setField={setIdentifierSystem}
+            />
             <ArtifactFieldInput label="name" value={name} setField={setName} />
             <ArtifactFieldInput label="title" value={title} setField={setTitle} />
             <ArtifactFieldInput label="description" value={description} setField={setDescription} />

--- a/app/src/server/db/dbOperations.ts
+++ b/app/src/server/db/dbOperations.ts
@@ -31,10 +31,10 @@ export async function createDraft(resourceType: ArtifactResourceType, draft: any
 /**
  * Updates the resource of the given type with the given id
  */
-export async function updateDraft(resourceType: ArtifactResourceType, id: string, update: any) {
+export async function updateDraft(resourceType: ArtifactResourceType, id: string, additions: any, deletions: any) {
   const client = await clientPromise;
   const collection = client.db().collection(resourceType);
-  return collection.updateOne({ id }, { $set: update });
+  return collection.updateOne({ id }, { $set: additions, $unset: deletions });
 }
 
 /*

--- a/app/src/server/trpc/routers/draft.ts
+++ b/app/src/server/trpc/routers/draft.ts
@@ -33,8 +33,10 @@ export const draftRouter = router({
     }),
 
   updateDraft: publicProcedure
-    .input(z.object({ resourceType: z.enum(['Measure', 'Library']), draft: z.any(), id: z.string() }))
+    .input(
+      z.object({ resourceType: z.enum(['Measure', 'Library']), additions: z.any(), deletions: z.any(), id: z.string() })
+    )
     .mutation(async ({ input }) => {
-      return updateDraft(input.resourceType, input.id, input.draft);
+      return updateDraft(input.resourceType, input.id, input.additions, input.deletions);
     })
 });

--- a/app/src/util/resourceCardUtils.ts
+++ b/app/src/util/resourceCardUtils.ts
@@ -10,7 +10,12 @@ export function extractResourceInfo(resource: FhirArtifact) {
   const resourceInfo: ResourceInfo = {
     resourceType: resource.resourceType,
     id: resource.id as string,
-    identifier: identifier?.system && identifier?.value ? `${identifier.system}|${identifier.value}` : null,
+    identifier:
+      identifier?.system && identifier?.value
+        ? `${identifier.system}|${identifier.value}`
+        : identifier?.value
+        ? `${identifier.value}`
+        : '',
     name: resource.name ?? null,
     url: resource.url ?? null,
     version: resource.version ?? null,


### PR DESCRIPTION
# Summary
This PR allows the user to be able to edit/modify existing draft artifacts and save those edits to the local database.

## New behavior
When a user creates or selects a draft artifact, a list of text inputs for the following fields are displayed next to the JSON of the artifact: `url`, `identifier`, `name`, `title`, and `description`. If any of these fields already exists on the artifact, then the text inputs will be populated with their current values. The user can edit or delete the content of these fields, but artifact in the local database will only be updated when the user clicks "Submit". 

## Code changes
- `app/src/pages/authoring/[resourceType]/[id].tsx` - Add inputs for `name`, `title`, and `description`, modified the `parseUpdate` function to return additions and deletions that we want to update the artifact with, rather than just additions, add an 'X' ActionIcon to the inputs to clear the contents of the field. 
- `app/src/server/db/dbOperations.ts` - modified the `updateDraft` function to take `additions` and `deletions` rather than just one `update` parameter. This seemed like the best approach in order to utilize `$unset` for deletions, but let me know if you have a way that it can be done with just the `update` input.
- `app/src/server/trpc/routers/draft.ts` - updated the input of the `updateDraft` procedure to align with changes in the above two files.

# Testing guidance
- `npm run check:all`
- `npm run start:all`
- Navigate to the authoring tab.
- Create a new Library/Measure through both of the ways (starting from scratch and starting from an existing artifact)
- Make sure that the text inputs are populated correctly if the fields are already defined on the artifact.
- Try deleting/editing the inputs and clicking submit to ensure that they have been updated.
- Do the same but from the route of just viewing the existing artifacts in the local database.
- Make sure changes are only saved when the user clicks "Submit".

Open Questions for the Reviewers:
- When the user deletes the contents of an inputs (for example, `url`), the `url` field is removed from the artifact. If the user then adds something back, then the `url` is added back to the artifact with the new value, but it is added to the bottom of the JSON. Is that okay? 
- Are there any fields that should _always_ exist on the artifact even though it is just a draft? Maybe this is something we want to do later? But for example, should we even make it possible for the user to remove a url from the artifact? When a user creates a new artifact from scratch, the only things that are populated are the url, identifier, and status, so I think this is okay?
- Is there a better way to remove the properties from a Mongo collection? I added the `additions` and `deletions` inputs and used `$set` and `$unset` but wasn't sure if there was a better way.