### PR TITLE
Make Data Requirements Human Readable

### DIFF
--- a/app/src/components/DataRequirements.tsx
+++ b/app/src/components/DataRequirements.tsx
@@ -54,12 +54,12 @@ function DataRequirements({ type, extension, dateFilter, codeFilter }: fhir4.Dat
                 <List withPadding>
                   {extension?.map(e => (
                     <>
-                      <List.Item>
+                      <List.Item key={e.url}>
                         <b>URL:</b>
                         {e.url}
                       </List.Item>
-                      {e?.valueString && (
-                        <List.Item>
+                      {e.valueString && (
+                        <List.Item key={e.valueString}>
                           <b> ValueString: </b>
                           {e.valueString}
                         </List.Item>
@@ -74,14 +74,14 @@ function DataRequirements({ type, extension, dateFilter, codeFilter }: fhir4.Dat
                       <b>DateFilter(s):</b>
                     </List.Item>
                     <List withPadding>
-                      {dateFilter?.map(data => (
+                      {dateFilter.map(date => (
                         <>
-                          <List.Item>
+                          <List.Item key={date?.valuePeriod?.start}>
                             <b> Start Date: </b>
-                            {data?.valuePeriod?.start} <br />
+                            {date?.valuePeriod?.start} <br />
                           </List.Item>
-                          <List.Item>
-                            <b> End Date: </b> {data?.valuePeriod?.end} <br />
+                          <List.Item key={date?.valuePeriod?.end}>
+                            <b> End Date: </b> {date?.valuePeriod?.end} <br />
                           </List.Item>
                         </>
                       ))}
@@ -101,12 +101,12 @@ function DataRequirements({ type, extension, dateFilter, codeFilter }: fhir4.Dat
                       {codes.map(codeInterface => (
                         <>
                           {codeInterface.code && (
-                            <List.Item>
-                              <b> Code: </b> {codeInterface?.code} <br />
+                            <List.Item key={codeInterface.code}>
+                              <b> Code: </b> {codeInterface.code} <br />
                             </List.Item>
                           )}
                           {codeInterface.system && (
-                            <List.Item>
+                            <List.Item key={codeInterface.system}>
                               <b> System: </b> {codeInterface?.system} <br />
                             </List.Item>
                           )}
@@ -122,8 +122,8 @@ function DataRequirements({ type, extension, dateFilter, codeFilter }: fhir4.Dat
                       <b>Value Set(s):</b>
                     </List.Item>
                     <List withPadding>
-                      {codeFiltersWithVS.map(c => (
-                        <List.Item>
+                      {codeFiltersWithVS.map((c, index) => (
+                        <List.Item key={index}>
                           {c.valueSet} <br />
                         </List.Item>
                       ))}

--- a/app/src/components/DataRequirements.tsx
+++ b/app/src/components/DataRequirements.tsx
@@ -1,6 +1,6 @@
 import { Accordion, Center, createStyles, em, getBreakpointValue, List, Paper, rem } from '@mantine/core';
 
-interface codeInterface {
+interface CodeInterface {
   code: string | undefined;
   system: string | undefined;
 }
@@ -22,15 +22,15 @@ const useStyles = createStyles(theme => ({
  */
 function DataRequirements({ type, extension, dateFilter, codeFilter }: fhir4.DataRequirement) {
   const { classes } = useStyles();
-  const codes: codeInterface[] = [];
+  const codes: CodeInterface[] = [];
 
-  const valueSets = codeFilter?.filter(function (x: fhir4.DataRequirementCodeFilter) {
-    return x?.valueSet !== undefined;
+  const codeFiltersWithVS = codeFilter?.filter(cf => {
+    return cf?.valueSet !== undefined;
   });
 
-  codeFilter?.forEach((arr: fhir4.DataRequirementCodeFilter) => {
-    arr?.code?.forEach((element: fhir4.Coding) => {
-      const code: codeInterface = { code: element?.code, system: element?.system };
+  codeFilter?.forEach(cf => {
+    cf?.code?.forEach(c => {
+      const code: CodeInterface = { code: c.code, system: c.system };
       codes.push(code);
     });
   });
@@ -41,7 +41,6 @@ function DataRequirements({ type, extension, dateFilter, codeFilter }: fhir4.Dat
         <Accordion variant="contained" radius="lg" defaultValue="customization">
           <Accordion.Item value="customization">
             <Accordion.Control>
-              {' '}
               <Center>
                 <h2>{type} </h2>
               </Center>
@@ -53,18 +52,16 @@ function DataRequirements({ type, extension, dateFilter, codeFilter }: fhir4.Dat
                   <br />
                 </List.Item>
                 <List withPadding>
-                  {extension?.map((item: any, index: any, index2: any) => (
+                  {extension?.map(e => (
                     <>
-                      {item?.url != undefined && (
-                        <List.Item key={index}>
-                          <b> URL: </b>
-                          {item.url}{' '}
-                        </List.Item>
-                      )}
-                      {item?.valueString != undefined && (
-                        <List.Item key={index2}>
+                      <List.Item>
+                        <b>URL:</b>
+                        {e.url}
+                      </List.Item>
+                      {e?.valueString && (
+                        <List.Item>
                           <b> ValueString: </b>
-                          {item.valueString}{' '}
+                          {e.valueString}
                         </List.Item>
                       )}
                       <br />
@@ -77,14 +74,14 @@ function DataRequirements({ type, extension, dateFilter, codeFilter }: fhir4.Dat
                       <b>DateFilter(s):</b>
                     </List.Item>
                     <List withPadding>
-                      {dateFilter?.map((item: fhir4.DataRequirementDateFilter, index: any, index2: any) => (
+                      {dateFilter?.map(data => (
                         <>
-                          <List.Item key={index}>
+                          <List.Item>
                             <b> Start Date: </b>
-                            {item?.valuePeriod?.start} <br />
+                            {data?.valuePeriod?.start} <br />
                           </List.Item>
-                          <List.Item key={index2}>
-                            <b> End Date: </b> {item?.valuePeriod?.end} <br />
+                          <List.Item>
+                            <b> End Date: </b> {data?.valuePeriod?.end} <br />
                           </List.Item>
                         </>
                       ))}
@@ -101,16 +98,16 @@ function DataRequirements({ type, extension, dateFilter, codeFilter }: fhir4.Dat
                       <b>Code(s):</b>
                     </List.Item>
                     <List withPadding>
-                      {codes?.map((item: any, index: any, index2: any) => (
+                      {codes.map(codeInterface => (
                         <>
-                          {item?.code && (
-                            <List.Item key={index}>
-                              <b> Code: </b> {item?.code} <br />
+                          {codeInterface.code && (
+                            <List.Item>
+                              <b> Code: </b> {codeInterface?.code} <br />
                             </List.Item>
                           )}
-                          {item?.system && (
-                            <List.Item key={index2}>
-                              <b> System: </b> {item?.system} <br />
+                          {codeInterface.system && (
+                            <List.Item>
+                              <b> System: </b> {codeInterface?.system} <br />
                             </List.Item>
                           )}
                           <br />
@@ -119,15 +116,15 @@ function DataRequirements({ type, extension, dateFilter, codeFilter }: fhir4.Dat
                     </List>
                   </List>
                 )}
-                {valueSets && valueSets.length > 0 && (
+                {codeFiltersWithVS && codeFiltersWithVS.length > 0 && (
                   <List withPadding>
                     <List.Item>
                       <b>Value Set(s):</b>
                     </List.Item>
                     <List withPadding>
-                      {valueSets?.map((item: any, index3: any) => (
-                        <List.Item key={index3}>
-                          {item?.valueSet} <br />
+                      {codeFiltersWithVS.map(c => (
+                        <List.Item>
+                          {c.valueSet} <br />
                         </List.Item>
                       ))}
                     </List>

--- a/app/src/components/DataRequirements.tsx
+++ b/app/src/components/DataRequirements.tsx
@@ -24,9 +24,7 @@ function DataRequirements({ type, extension, dateFilter, codeFilter }: fhir4.Dat
   const { classes } = useStyles();
   const codes: CodeInterface[] = [];
 
-  const codeFiltersWithVS = codeFilter?.filter(cf => {
-    return cf?.valueSet !== undefined;
-  });
+  const codeFiltersWithVS = codeFilter?.filter(cf => cf?.valueSet);
 
   codeFilter?.forEach(cf => {
     cf?.code?.forEach(c => {
@@ -38,8 +36,8 @@ function DataRequirements({ type, extension, dateFilter, codeFilter }: fhir4.Dat
   return (
     <Center>
       <Paper className={classes.card} shadow="sm" p="md">
-        <Accordion variant="contained" radius="lg" defaultValue="customization">
-          <Accordion.Item value="customization">
+        <Accordion variant="contained" radius="lg" defaultValue="data-req-card">
+          <Accordion.Item value="data-req-card">
             <Accordion.Control>
               <Center>
                 <h2>{type} </h2>
@@ -76,12 +74,12 @@ function DataRequirements({ type, extension, dateFilter, codeFilter }: fhir4.Dat
                     <List withPadding>
                       {dateFilter.map(date => (
                         <>
-                          <List.Item key={date?.valuePeriod?.start}>
+                          <List.Item key={date.valuePeriod?.start}>
                             <b> Start Date: </b>
-                            {date?.valuePeriod?.start} <br />
+                            {date.valuePeriod?.start} <br />
                           </List.Item>
-                          <List.Item key={date?.valuePeriod?.end}>
-                            <b> End Date: </b> {date?.valuePeriod?.end} <br />
+                          <List.Item key={date.valuePeriod?.end}>
+                            <b> End Date: </b> {date.valuePeriod?.end} <br />
                           </List.Item>
                         </>
                       ))}
@@ -107,7 +105,7 @@ function DataRequirements({ type, extension, dateFilter, codeFilter }: fhir4.Dat
                           )}
                           {codeInterface.system && (
                             <List.Item key={codeInterface.system}>
-                              <b> System: </b> {codeInterface?.system} <br />
+                              <b> System: </b> {codeInterface.system} <br />
                             </List.Item>
                           )}
                           <br />

--- a/app/src/components/DataRequirements.tsx
+++ b/app/src/components/DataRequirements.tsx
@@ -1,0 +1,174 @@
+import { Button, Center, Collapse, createStyles, em, getBreakpointValue, List, Paper, rem } from '@mantine/core';
+import { useDisclosure } from '@mantine/hooks';
+import { ArrowsMaximize, ArrowsMinimize } from 'tabler-icons-react';
+import { useState } from 'react';
+
+const useStyles = createStyles(theme => ({
+  card: {
+    borderRadius: 12,
+    border: `${rem(2)} solid ${theme.colors.gray[3]}`,
+    width: '1200px',
+    [`@media (max-width: ${em(getBreakpointValue(theme.breakpoints.lg) - 1)})`]: {
+      width: '100%'
+    }
+  }
+}));
+
+interface codeInterface {
+  code: string;
+  system: string;
+}
+
+/**
+ * Component which takes in data requirements and then reformats it in a new div element
+ */
+function DataRequirements({ props }: any) {
+  const [opened, { toggle }] = useDisclosure(false);
+  // const [buttonIcon, setButtonicon] = useState(<ArrowsMaximize />);
+  const { classes } = useStyles();
+
+  const type = props.type;
+  const extensions = props.extension;
+  const dateFilters = props.dateFilter;
+  const codeFilters = props.codeFilter;
+  const codes: codeInterface[] = [];
+  const valueSets = props.codeFilter.filter(function (x: any) {
+    return x?.valueSet !== undefined;
+  });
+
+  codeFilters?.forEach((arr: { code: { code: any; system: any }[] }) => {
+    arr?.code?.forEach((element: { code: any; system: any }) => {
+      let code: codeInterface = { code: element?.code, system: element?.system };
+      codes.push(code);
+    });
+  });
+
+  return (
+    <>
+      {/* <Center>
+        <Paper className={classes.card} shadow="sm" p="md">
+          <Group position="center" mb={5}>
+            <Button onClick={toggle}>Toggle with linear transition</Button>
+          </Group>
+        </Paper>
+      </Center> */}
+
+      <Center>
+        <Paper className={classes.card} shadow="sm" p="md">
+          <div>
+            {/* <Group> */}
+            <Center>
+              {/* <h2>Requirements</h2> */}
+              <Button variant="default" color="green" size="lg" leftIcon={<ArrowsMaximize />} onClick={toggle}>
+                Click to Expand
+              </Button>
+            </Center>
+            {/* </Group> */}
+            <Collapse in={opened} transitionDuration={500} transitionTimingFunction="linear">
+              <br />
+              <List>
+                <List.Item>
+                  <b>Type: </b>
+                  {type}
+                </List.Item>
+                <br />
+                <List.Item>
+                  <b>Extension: </b>
+                  <br />
+                </List.Item>
+                <List withPadding>
+                  {extensions.map((item: any, index: any, index2: any) => (
+                    <>
+                      {item?.url != undefined && (
+                        <List.Item key={index}>
+                          <b> URL: </b>
+                          {item.url}{' '}
+                        </List.Item>
+                      )}
+                      {item?.valueString != undefined && (
+                        <List.Item key={index2}>
+                          <b> ValueString: </b>
+                          {item.valueString}{' '}
+                        </List.Item>
+                      )}
+                      <br />
+                    </>
+                  ))}
+                </List>
+                {dateFilters?.length > 0 && (
+                  <>
+                    <List.Item>
+                      <b>DateFilter(s):</b>
+                    </List.Item>
+                    <List withPadding>
+                      {dateFilters?.map((item: any, index: any, index2: any) => (
+                        <>
+                          <List.Item key={index}>
+                            <b> Start Date: </b>
+                            {new Date(item.valuePeriod.start).getUTCMonth() + 1}/
+                            {new Date(item.valuePeriod.start).getUTCDate()}/
+                            {new Date(item.valuePeriod.start).getUTCFullYear()} <br />
+                          </List.Item>
+                          <List.Item key={index2}>
+                            <b> End Date: </b> {new Date(item.valuePeriod.end).getUTCMonth() + 1}/
+                            {new Date(item.valuePeriod.end).getUTCDate()}/
+                            {new Date(item.valuePeriod.end).getUTCFullYear()} <br />
+                          </List.Item>
+                        </>
+                      ))}
+                    </List>
+                  </>
+                )}
+                <br />
+                <List.Item>
+                  <b>CodeFilter(s):</b>
+                </List.Item>
+                {/* ))} */}
+                {codes.length > 0 && (
+                  <List withPadding>
+                    <List.Item>
+                      <b>Code(s):</b>
+                    </List.Item>
+                    <List withPadding>
+                      {codes?.map((item: any, index: any, index2: any) => (
+                        <>
+                          {item?.code && (
+                            <List.Item key={index}>
+                              <b> Code: </b> {item?.code} <br />
+                            </List.Item>
+                          )}
+                          {item?.system && (
+                            <List.Item key={index2}>
+                              <b> System: </b> {item?.system} <br />
+                            </List.Item>
+                          )}
+                          <br />
+                        </>
+                      ))}
+                    </List>
+                  </List>
+                )}
+                {valueSets.length > 0 && (
+                  <List withPadding>
+                    <List.Item>
+                      <b>Value Set(s):</b>
+                    </List.Item>
+                    <List withPadding>
+                      {valueSets?.map((item: any, index3: any) => (
+                        <List.Item key={index3}>
+                          {item?.valueSet} <br />
+                        </List.Item>
+                      ))}
+                    </List>
+                  </List>
+                )}
+              </List>
+            </Collapse>
+          </div>
+        </Paper>
+      </Center>
+    </>
+  );
+}
+
+export default DataRequirements;

--- a/app/src/components/DataRequirements.tsx
+++ b/app/src/components/DataRequirements.tsx
@@ -1,8 +1,8 @@
 import { Accordion, Center, createStyles, em, getBreakpointValue, List, Paper, rem } from '@mantine/core';
 
 interface codeInterface {
-  code: string;
-  system: string;
+  code: string | undefined;
+  system: string | undefined;
 }
 
 const useStyles = createStyles(theme => ({
@@ -20,21 +20,16 @@ const useStyles = createStyles(theme => ({
  * Component which displays all data requirements of a specified resource and displays them
  * as resource cards that contain all required information
  */
-function DataRequirements({ props }: any) {
+function DataRequirements({ type, extension, dateFilter, codeFilter }: fhir4.DataRequirement) {
   const { classes } = useStyles();
-
-  const type = props.type;
-  const extensions = props.extension;
-  const dateFilters = props.dateFilter;
-  const codeFilters = props.codeFilter;
   const codes: codeInterface[] = [];
 
-  const valueSets = props.codeFilter.filter(function (x: any) {
+  const valueSets = codeFilter?.filter(function (x: fhir4.DataRequirementCodeFilter) {
     return x?.valueSet !== undefined;
   });
 
-  codeFilters?.forEach((arr: { code: { code: any; system: any }[] }) => {
-    arr?.code?.forEach((element: { code: any; system: any }) => {
+  codeFilter?.forEach((arr: fhir4.DataRequirementCodeFilter) => {
+    arr?.code?.forEach((element: fhir4.Coding) => {
       const code: codeInterface = { code: element?.code, system: element?.system };
       codes.push(code);
     });
@@ -54,16 +49,11 @@ function DataRequirements({ props }: any) {
             <Accordion.Panel>
               <List>
                 <List.Item>
-                  <b>Type: </b>
-                  {type}
-                </List.Item>
-                <br />
-                <List.Item>
-                  <b>Extension: </b>
+                  <b>Extension(s): </b>
                   <br />
                 </List.Item>
                 <List withPadding>
-                  {extensions.map((item: any, index: any, index2: any) => (
+                  {extension?.map((item: any, index: any, index2: any) => (
                     <>
                       {item?.url != undefined && (
                         <List.Item key={index}>
@@ -81,24 +71,20 @@ function DataRequirements({ props }: any) {
                     </>
                   ))}
                 </List>
-                {dateFilters?.length > 0 && (
+                {dateFilter && dateFilter?.length > 0 && (
                   <>
                     <List.Item>
-                      <b>DateFilter:</b>
+                      <b>DateFilter(s):</b>
                     </List.Item>
                     <List withPadding>
-                      {dateFilters?.map((item: any, index: any, index2: any) => (
+                      {dateFilter?.map((item: fhir4.DataRequirementDateFilter, index: any, index2: any) => (
                         <>
                           <List.Item key={index}>
                             <b> Start Date: </b>
-                            {new Date(item.valuePeriod.start).getUTCMonth() + 1}/
-                            {new Date(item.valuePeriod.start).getUTCDate()}/
-                            {new Date(item.valuePeriod.start).getUTCFullYear()} <br />
+                            {item?.valuePeriod?.start} <br />
                           </List.Item>
                           <List.Item key={index2}>
-                            <b> End Date: </b> {new Date(item.valuePeriod.end).getUTCMonth() + 1}/
-                            {new Date(item.valuePeriod.end).getUTCDate()}/
-                            {new Date(item.valuePeriod.end).getUTCFullYear()} <br />
+                            <b> End Date: </b> {item?.valuePeriod?.end} <br />
                           </List.Item>
                         </>
                       ))}
@@ -133,7 +119,7 @@ function DataRequirements({ props }: any) {
                     </List>
                   </List>
                 )}
-                {valueSets.length > 0 && (
+                {valueSets && valueSets.length > 0 && (
                   <List withPadding>
                     <List.Item>
                       <b>Value Set(s):</b>

--- a/app/src/components/DataRequirements.tsx
+++ b/app/src/components/DataRequirements.tsx
@@ -1,7 +1,9 @@
-import { Button, Center, Collapse, createStyles, em, getBreakpointValue, List, Paper, rem } from '@mantine/core';
-import { useDisclosure } from '@mantine/hooks';
-import { ArrowsMaximize, ArrowsMinimize } from 'tabler-icons-react';
-import { useState } from 'react';
+import { Accordion, Center, createStyles, em, getBreakpointValue, List, Paper, rem } from '@mantine/core';
+
+interface codeInterface {
+  code: string;
+  system: string;
+}
 
 const useStyles = createStyles(theme => ({
   card: {
@@ -14,17 +16,11 @@ const useStyles = createStyles(theme => ({
   }
 }));
 
-interface codeInterface {
-  code: string;
-  system: string;
-}
-
 /**
- * Component which takes in data requirements and then reformats it in a new div element
+ * Component which displays all data requirements of a specified resource and displays them
+ * as resource cards that contain all required information
  */
 function DataRequirements({ props }: any) {
-  const [opened, { toggle }] = useDisclosure(false);
-  // const [buttonIcon, setButtonicon] = useState(<ArrowsMaximize />);
   const { classes } = useStyles();
 
   const type = props.type;
@@ -32,40 +28,30 @@ function DataRequirements({ props }: any) {
   const dateFilters = props.dateFilter;
   const codeFilters = props.codeFilter;
   const codes: codeInterface[] = [];
+
   const valueSets = props.codeFilter.filter(function (x: any) {
     return x?.valueSet !== undefined;
   });
 
   codeFilters?.forEach((arr: { code: { code: any; system: any }[] }) => {
     arr?.code?.forEach((element: { code: any; system: any }) => {
-      let code: codeInterface = { code: element?.code, system: element?.system };
+      const code: codeInterface = { code: element?.code, system: element?.system };
       codes.push(code);
     });
   });
 
   return (
-    <>
-      {/* <Center>
-        <Paper className={classes.card} shadow="sm" p="md">
-          <Group position="center" mb={5}>
-            <Button onClick={toggle}>Toggle with linear transition</Button>
-          </Group>
-        </Paper>
-      </Center> */}
-
-      <Center>
-        <Paper className={classes.card} shadow="sm" p="md">
-          <div>
-            {/* <Group> */}
-            <Center>
-              {/* <h2>Requirements</h2> */}
-              <Button variant="default" color="green" size="lg" leftIcon={<ArrowsMaximize />} onClick={toggle}>
-                Click to Expand
-              </Button>
-            </Center>
-            {/* </Group> */}
-            <Collapse in={opened} transitionDuration={500} transitionTimingFunction="linear">
-              <br />
+    <Center>
+      <Paper className={classes.card} shadow="sm" p="md">
+        <Accordion variant="contained" radius="lg" defaultValue="customization">
+          <Accordion.Item value="customization">
+            <Accordion.Control>
+              {' '}
+              <Center>
+                <h2>{type} </h2>
+              </Center>
+            </Accordion.Control>
+            <Accordion.Panel>
               <List>
                 <List.Item>
                   <b>Type: </b>
@@ -98,7 +84,7 @@ function DataRequirements({ props }: any) {
                 {dateFilters?.length > 0 && (
                   <>
                     <List.Item>
-                      <b>DateFilter(s):</b>
+                      <b>DateFilter:</b>
                     </List.Item>
                     <List withPadding>
                       {dateFilters?.map((item: any, index: any, index2: any) => (
@@ -123,7 +109,6 @@ function DataRequirements({ props }: any) {
                 <List.Item>
                   <b>CodeFilter(s):</b>
                 </List.Item>
-                {/* ))} */}
                 {codes.length > 0 && (
                   <List withPadding>
                     <List.Item>
@@ -163,11 +148,11 @@ function DataRequirements({ props }: any) {
                   </List>
                 )}
               </List>
-            </Collapse>
-          </div>
-        </Paper>
-      </Center>
-    </>
+            </Accordion.Panel>
+          </Accordion.Item>
+        </Accordion>
+      </Paper>
+    </Center>
   );
 }
 

--- a/app/src/pages/[resourceType]/[id].tsx
+++ b/app/src/pages/[resourceType]/[id].tsx
@@ -170,15 +170,11 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
               {parse(jsonData.text.div)}
             </Tabs.Panel>
           )}
-          {dataRequirements?.resourceType === 'Library' && dataRequirements?.dataRequirement && (
+          {dataRequirements?.dataRequirement && (
             <Tabs.Panel value="data-requirements">
               {dataRequirements?.dataRequirement.length > 0 && (
                 <>
                   <Space h="md" />
-                  <Text c="dimmed">
-                    {' '}
-                    Number of Requirements:<b> {dataRequirements?.dataRequirement.length} </b>
-                  </Text>
                   <Center>
                     <SegmentedControl
                       fullWidth
@@ -190,7 +186,6 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
                       ]}
                     />
                   </Center>
-                  <Space h="md" />
                 </>
               )}
               {dataReqsView === 'raw' && (
@@ -199,6 +194,11 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
                 </Prism>
               )}
               <ScrollArea.Autosize mah={height * 0.8} type="always">
+                <Space h="md" />
+                <Text c="dimmed">
+                  Number of Requirements:<b> {dataRequirements?.dataRequirement.length} </b>
+                </Text>
+                <Space h="md" />
                 {dataReqsView === 'formatted' &&
                   dataRequirements?.dataRequirement.map((data: fhir4.DataRequirement, index: any) => (
                     <DataReqs

--- a/app/src/pages/[resourceType]/[id].tsx
+++ b/app/src/pages/[resourceType]/[id].tsx
@@ -20,7 +20,7 @@ import DataReqs from '@/components/DataRequirements';
  */
 export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const resourceType = jsonData.resourceType;
-  const [value, setValue] = useState('raw');
+  const [dataReqsView, setDataReqsView] = useState('raw');
 
   const decodedCql = useMemo(() => {
     return decode('text/cql', jsonData);
@@ -160,15 +160,14 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
               {parse(jsonData.text.div)}
             </Tabs.Panel>
           )}
-          {dataRequirements?.resourceType === 'Library' && dataRequirements?.dataRequirement != undefined && (
+          {dataRequirements?.resourceType === 'Library' && dataRequirements?.dataRequirement && (
             <Tabs.Panel value="data-requirements">
               <Center>
                 {dataRequirements?.dataRequirement.length > 0 && (
                   <SegmentedControl
                     fullWidth
-                    color="blue"
-                    value={value}
-                    onChange={setValue}
+                    value={dataReqsView}
+                    onChange={setDataReqsView}
                     data={[
                       { label: 'Raw Data Requirements', value: 'raw' },
                       { label: 'Readable Data Requirements', value: 'readable' }
@@ -176,14 +175,20 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
                   />
                 )}
               </Center>
-              {value == 'raw' && (
+              {dataReqsView === 'raw' && (
                 <Prism language="json" colorScheme="light">
                   {JSON.stringify(dataRequirements, null, 2)}
                 </Prism>
               )}
-              {value == 'readable' &&
-                dataRequirements?.dataRequirement.map((item: any, index: any) => (
-                  <DataReqs key={index} props={item}></DataReqs>
+              {dataReqsView === 'readable' &&
+                dataRequirements?.dataRequirement.map((item: fhir4.DataRequirement, index: any) => (
+                  <DataReqs
+                    key={index}
+                    type={item?.type}
+                    codeFilter={item?.codeFilter}
+                    dateFilter={item?.dateFilter}
+                    extension={item?.extension}
+                  ></DataReqs>
                 ))}
             </Tabs.Panel>
           )}

--- a/app/src/pages/[resourceType]/[id].tsx
+++ b/app/src/pages/[resourceType]/[id].tsx
@@ -1,7 +1,7 @@
 import { Prism } from '@mantine/prism';
-import { Button, Divider, Group, Space, Stack, Tabs, Text } from '@mantine/core';
+import { Button, Center, Divider, Group, SegmentedControl, Space, Stack, Tabs, Text } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { GetServerSideProps, InferGetServerSidePropsType } from 'next';
 import { FhirArtifact } from '@/util/types/fhir';
 import CQLRegex from '../../util/prismCQL';
@@ -20,6 +20,7 @@ import DataReqs from '@/components/DataRequirements';
  */
 export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const resourceType = jsonData.resourceType;
+  const [value, setValue] = useState('raw');
 
   const decodedCql = useMemo(() => {
     return decode('text/cql', jsonData);
@@ -161,12 +162,29 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
           )}
           {dataRequirements?.resourceType === 'Library' && dataRequirements?.dataRequirement != undefined && (
             <Tabs.Panel value="data-requirements">
-              <Prism language="json" colorScheme="light">
-                {JSON.stringify(dataRequirements, null, 2)}
-              </Prism>
-              {dataRequirements?.dataRequirement.map((item: any, index: any) => (
-                <DataReqs key={index} props={item}></DataReqs>
-              ))}
+              <Center>
+                {dataRequirements?.dataRequirement.length > 0 && (
+                  <SegmentedControl
+                    fullWidth
+                    color="blue"
+                    value={value}
+                    onChange={setValue}
+                    data={[
+                      { label: 'Raw Data Requirements', value: 'raw' },
+                      { label: 'Readable Data Requirements', value: 'readable' }
+                    ]}
+                  />
+                )}
+              </Center>
+              {value == 'raw' && (
+                <Prism language="json" colorScheme="light">
+                  {JSON.stringify(dataRequirements, null, 2)}
+                </Prism>
+              )}
+              {value == 'readable' &&
+                dataRequirements?.dataRequirement.map((item: any, index: any) => (
+                  <DataReqs key={index} props={item}></DataReqs>
+                ))}
             </Tabs.Panel>
           )}
         </Tabs>

--- a/app/src/pages/[resourceType]/[id].tsx
+++ b/app/src/pages/[resourceType]/[id].tsx
@@ -200,8 +200,9 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
               )}
               <ScrollArea.Autosize mah={height * 0.8} type="always">
                 {dataReqsView === 'formatted' &&
-                  dataRequirements?.dataRequirement.map(data => (
+                  dataRequirements?.dataRequirement.map((data: fhir4.DataRequirement, index: any) => (
                     <DataReqs
+                      key={index}
                       type={data.type}
                       codeFilter={data.codeFilter}
                       dateFilter={data.dateFilter}

--- a/app/src/pages/[resourceType]/[id].tsx
+++ b/app/src/pages/[resourceType]/[id].tsx
@@ -48,7 +48,6 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
     };
     handleResize();
     window.addEventListener('resize', handleResize);
-    return window.removeEventListener('resize', handleResize);
   }, []);
 
   const {
@@ -200,7 +199,7 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
                 </Text>
                 <Space h="md" />
                 {dataReqsView === 'formatted' &&
-                  dataRequirements?.dataRequirement.map((data: fhir4.DataRequirement, index: any) => (
+                  dataRequirements?.dataRequirement.map((data: fhir4.DataRequirement, index) => (
                     <DataReqs
                       key={index}
                       type={data.type}

--- a/app/src/pages/[resourceType]/[id].tsx
+++ b/app/src/pages/[resourceType]/[id].tsx
@@ -11,6 +11,7 @@ import { AlertCircle, CircleCheck, AbacusOff } from 'tabler-icons-react';
 import { useRouter } from 'next/router';
 import { modifyResourceToDraft } from '@/util/modifyResourceFields';
 import { trpc } from '@/util/trpc';
+import DataReqs from '@/components/DataRequirements';
 
 /**
  * Component which displays the JSON/ELM/CQL/narrative/Data Requirements content of an individual resource using
@@ -158,11 +159,14 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
               {parse(jsonData.text.div)}
             </Tabs.Panel>
           )}
-          {dataRequirements?.resourceType === 'Library' && (
+          {dataRequirements?.resourceType === 'Library' && dataRequirements?.dataRequirement != undefined && (
             <Tabs.Panel value="data-requirements">
               <Prism language="json" colorScheme="light">
                 {JSON.stringify(dataRequirements, null, 2)}
               </Prism>
+              {dataRequirements?.dataRequirement.map((item: any, index: any) => (
+                <DataReqs key={index} props={item}></DataReqs>
+              ))}
             </Tabs.Panel>
           )}
         </Tabs>


### PR DESCRIPTION
# Summary
This PR allows users to toggle between two different views for the data requirements of a specified resource: The raw version of the data requirements and a readable version of the data requirements array.

## New behavior
The data requirements panel now populates with a `Segment Controller` mantine component at the top of the panel where the user can manually toggle between two different displays of the data requirements. The panel should always initially start out on the raw data requirements view. If the user manually selects the " readable data requirements" view they will then see a series of data requirement cards. Each card has an icon in the upper right hand corner the user can click to expand/constrict the card. Each card should display specific information of one element from the data requirements array. Specifically, it's fields should include any of it's `code filters, dateFilters, extensions, and types`. There are some resources for which the raw data requirements should appear but the readable version shouldn’t because the data requirements array doesn’t have any elements. In these instances, the Segment Control component which allows the user to slide between different views should also not appear.

## Code changes
` <SegmentedControl>` —> I use a segmented control component in `app/src/pages/repository/[resourceType]/[id].tsx` to allow the user to choose between the two different views of the data requirements
`app/src/components/DataRequirements.tsx` —> Extracts the different data requirements fields and displays them in a card component that it returns
`Accordion` --> The Accordion component in `app/src/components/DataRequirements.tsx` is what allows the cards to be collapsible upon a user's click.

# Testing guidance
```
 npm run check:all
 npm run start:all
```
Navigate to the repository tab and select a library or measure resource. Then request data requirements for the resource. If the data requirements exist the data requirement's tab/panel should appear populated with a segment controller component at the top. The user should initially see the raw data requirements and it should look like the following:
![Screenshot 2023-06-27 at 2 21 09 PM](https://github.com/projecttacoma/measure-repository/assets/98363677/625b7560-43f1-4f02-b0c4-c905ff184b42)

Following this, toggle the segment controller so that "Readable Data Requirements" is now selected and the cards should appear looking like the following: 
![Screenshot 2023-06-27 at 4 20 53 PM](https://github.com/projecttacoma/measure-repository/assets/98363677/200e0ccb-c232-4d4e-b73d-ff7c573b19ad)

To make sure they are correct, you can toggle back and forth between the two views to ensure that each of the element's in the data requirements array accurately reflects what each of the card data requirements are displaying.In the raw data requirements tab, the data requirements array should have the exact same number of elements as the readable version has cards. You can also compare the contents of both the cards and each element of the data requirements array to make sure they match, and this should be made easier given that they both are in the same order.  Some resources (`Library/CumulativeMedicationDurationFHIR4` for instance) should not have readable data requirements, even if they have the raw data requirements. In instances like these, the Segment Controller should not appear for the user to toggle between them. 