### PR TITLE
Render Resource Dependencies

### DIFF
--- a/app/src/components/DependencyCards.tsx
+++ b/app/src/components/DependencyCards.tsx
@@ -47,9 +47,10 @@ function Dependencies(props: myComponentProps) {
   let dependencyInfo: DependencyInformation = {};
 
   // TODO
-  //Theoretically, canonicals for FHIR resources should be formatted in a way such that this code will work
-  //to get the proper url to route to. However, this might not always be the case and so we should add
-  //some logic to to handle trying to view resource details using the canoncical URL fo the resource as
+  //Canonicals for FHIR resources should be formatted in such a way that this code will work
+  //to get the proper url that routes the user to the new page.
+  // However, they can technically be anything and so we should potentially add
+  //some logic that handles viewing resource details using the canoncical URL of the resource as
   //the identifying information
   if (resourceLink?.includes('Library')) {
     const resourceArr: string[] = resourceLink.substring(resourceLink.indexOf('Library')).split('|');

--- a/app/src/components/DependencyCards.tsx
+++ b/app/src/components/DependencyCards.tsx
@@ -1,0 +1,84 @@
+import {
+  ActionIcon,
+  Center,
+  createStyles,
+  em,
+  Grid,
+  Paper,
+  Text,
+  Tooltip,
+  getBreakpointValue,
+  rem
+} from '@mantine/core';
+import Link from 'next/link';
+import React from 'react';
+import { SquareArrowRight } from 'tabler-icons-react';
+
+export interface ResourceInformation {
+  type?: string;
+  link?: string;
+}
+
+const useStyles = createStyles(theme => ({
+  card: {
+    borderRadius: 6,
+    border: `${rem(2)} solid ${theme.colors.gray[3]}`,
+    width: '800px',
+    [`@media (max-width: ${em(getBreakpointValue(theme.breakpoints.lg) - 1)})`]: {
+      width: '100%'
+    }
+  }
+}));
+function Dependencies(props: { value: fhir4.RelatedArtifact; sourceName: string | undefined }) {
+  const { classes } = useStyles();
+  const type = props.value.type;
+  const display = props.value.display;
+  const resource = props.value.resource;
+  const sourceName = JSON.stringify(props.sourceName);
+
+  let resourceInfo: ResourceInformation = {};
+
+  if (resource?.includes('Library')) {
+    let substr = resource.substring(resource.indexOf('Library'));
+    let myArray: string[] = substr?.split('|');
+    resourceInfo = { type: 'Library', link: myArray[0] };
+  } else if (resource?.includes('Measure')) {
+    let substr = resource.substring(resource.indexOf('Measure'));
+    let myArray: string[] = substr?.split('|');
+    resourceInfo = { type: 'Measure', link: myArray[0] };
+  }
+
+  return (
+    <>
+      <Center>
+        <Paper className={classes.card} shadow="sm" p="md">
+          <Grid align="center">
+            <Grid.Col span={10}>
+              <div>
+                <Text size="lg" fw={700}>
+                  {display}
+                </Text>
+              </div>
+              <div>
+                <Text size="sm" fw={500}>
+                  {resource}
+                </Text>
+              </div>
+            </Grid.Col>
+            {resourceInfo?.type && (
+              <Link href={`http://localhost:3001/${resourceInfo?.link}#JSON`} key={1}>
+                <Tooltip label={'Open to Resource'} openDelay={1000}>
+                  <ActionIcon radius="md" size="md" variant="subtle" color="gray">
+                    {<SquareArrowRight size="24" />}
+                  </ActionIcon>
+                </Tooltip>
+              </Link>
+            )}
+          </Grid>
+        </Paper>
+      </Center>
+    </>
+  );
+}
+
+export default Dependencies;

--- a/app/src/components/DependencyCards.tsx
+++ b/app/src/components/DependencyCards.tsx
@@ -1,5 +1,4 @@
 import {
-  Anchor,
   ActionIcon,
   Center,
   createStyles,
@@ -11,6 +10,7 @@ import {
   getBreakpointValue,
   rem
 } from '@mantine/core';
+import Link from 'next/link';
 import React from 'react';
 import { SquareArrowRight } from 'tabler-icons-react';
 
@@ -68,13 +68,13 @@ function Dependencies(props: { relatedArtifact: fhir4.RelatedArtifact }) {
               </div>
             </Grid.Col>
             {dependencyInfo.type && (
-              <Anchor href={`/${dependencyInfo.link}`}>
+              <Link href={`/${dependencyInfo.link}`}>
                 <Tooltip label={'Open Dependency Resource'} openDelay={1000}>
                   <ActionIcon radius="md" size="md" variant="subtle" color="gray">
                     {<SquareArrowRight size="24" />}
                   </ActionIcon>
                 </Tooltip>
-              </Anchor>
+              </Link>
             )}
           </Grid>
         </Paper>

--- a/app/src/components/DependencyCards.tsx
+++ b/app/src/components/DependencyCards.tsx
@@ -1,4 +1,5 @@
 import {
+  Anchor,
   ActionIcon,
   Center,
   createStyles,
@@ -10,11 +11,10 @@ import {
   getBreakpointValue,
   rem
 } from '@mantine/core';
-import Link from 'next/link';
 import React from 'react';
 import { SquareArrowRight } from 'tabler-icons-react';
 
-export interface ResourceInformation {
+interface DependencyInformation {
   type?: string;
   link?: string;
 }
@@ -29,23 +29,25 @@ const useStyles = createStyles(theme => ({
     }
   }
 }));
-function Dependencies(props: { value: fhir4.RelatedArtifact; sourceName: string | undefined }) {
+
+/**
+ * Component which displays all data requirement dependencies for a specified resource
+ * and displays them as resource cards that contain all required information and link to their
+ * respective resources if a link exists
+ */
+function Dependencies(props: { relatedArtifact: fhir4.RelatedArtifact }) {
   const { classes } = useStyles();
-  const type = props.value.type;
-  const display = props.value.display;
-  const resource = props.value.resource;
-  const sourceName = JSON.stringify(props.sourceName);
+  const display = props.relatedArtifact.display;
+  const resourceLink = props.relatedArtifact.resource;
 
-  let resourceInfo: ResourceInformation = {};
+  let dependencyInfo: DependencyInformation = {};
 
-  if (resource?.includes('Library')) {
-    let substr = resource.substring(resource.indexOf('Library'));
-    let myArray: string[] = substr?.split('|');
-    resourceInfo = { type: 'Library', link: myArray[0] };
-  } else if (resource?.includes('Measure')) {
-    let substr = resource.substring(resource.indexOf('Measure'));
-    let myArray: string[] = substr?.split('|');
-    resourceInfo = { type: 'Measure', link: myArray[0] };
+  if (resourceLink?.includes('Library')) {
+    const resourceArr: string[] = resourceLink.substring(resourceLink.indexOf('Library')).split('|');
+    dependencyInfo = { type: 'Library', link: resourceArr[0] };
+  } else if (resourceLink?.includes('Measure')) {
+    const resourceArr: string[] = resourceLink.substring(resourceLink.indexOf('Measure')).split('|');
+    dependencyInfo = { type: 'Measure', link: resourceArr[0] };
   }
 
   return (
@@ -61,18 +63,18 @@ function Dependencies(props: { value: fhir4.RelatedArtifact; sourceName: string 
               </div>
               <div>
                 <Text size="sm" fw={500}>
-                  {resource}
+                  {resourceLink}
                 </Text>
               </div>
             </Grid.Col>
-            {resourceInfo?.type && (
-              <Link href={`http://localhost:3001/${resourceInfo?.link}#JSON`} key={1}>
-                <Tooltip label={'Open to Resource'} openDelay={1000}>
+            {dependencyInfo.type && (
+              <Anchor href={`/${dependencyInfo.link}`}>
+                <Tooltip label={'Open Dependency Resource'} openDelay={1000}>
                   <ActionIcon radius="md" size="md" variant="subtle" color="gray">
                     {<SquareArrowRight size="24" />}
                   </ActionIcon>
                 </Tooltip>
-              </Link>
+              </Anchor>
             )}
           </Grid>
         </Paper>

--- a/app/src/components/DependencyCards.tsx
+++ b/app/src/components/DependencyCards.tsx
@@ -19,6 +19,10 @@ interface DependencyInformation {
   link?: string;
 }
 
+interface myComponentProps {
+  relatedArtifact: fhir4.RelatedArtifact;
+}
+
 const useStyles = createStyles(theme => ({
   card: {
     borderRadius: 6,
@@ -35,13 +39,18 @@ const useStyles = createStyles(theme => ({
  * and displays them as resource cards that contain all required information and link to their
  * respective resources if a link exists
  */
-function Dependencies(props: { relatedArtifact: fhir4.RelatedArtifact }) {
+function Dependencies(props: myComponentProps) {
   const { classes } = useStyles();
   const display = props.relatedArtifact.display;
   const resourceLink = props.relatedArtifact.resource;
 
   let dependencyInfo: DependencyInformation = {};
 
+  // TODO
+  //Theoretically, canonicals for FHIR resources should be formatted in a way such that this code will work
+  //to get the proper url to route to. However, this might not always be the case and so we should add
+  //some logic to to handle trying to view resource details using the canoncical URL fo the resource as
+  //the identifying information
   if (resourceLink?.includes('Library')) {
     const resourceArr: string[] = resourceLink.substring(resourceLink.indexOf('Library')).split('|');
     dependencyInfo = { type: 'Library', link: resourceArr[0] };

--- a/app/src/pages/[resourceType]/[id].tsx
+++ b/app/src/pages/[resourceType]/[id].tsx
@@ -98,7 +98,7 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
     }
   );
 
-  //Sorts dependencies alphabetically based on their display property. If the the
+  //Sorts dependencies alphabetically based on their display property. If the
   //dependency is a library/measure, however, it will always take precedence in sorting to ensure all
   //dependencies with links are always shown first
   const sortDependencies = useCallback(() => {
@@ -108,13 +108,22 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
         const displaySecond = secondElement.display?.toUpperCase();
         if (displayFirst && displaySecond) {
           if (
-            firstElement.resource?.includes('Library') ||
-            firstElement.resource?.includes('Measure') ||
-            secondElement.resource?.includes('Library') ||
-            secondElement.resource?.includes('Measure')
+            (firstElement.resource?.includes('Library') || firstElement.resource?.includes('Measure')) &&
+            (secondElement.resource?.includes('Library') || secondElement.resource?.includes('Measure'))
           ) {
+            if (displayFirst < displaySecond) {
+              return -1;
+            }
+            if (displayFirst > displaySecond) {
+              return 1;
+            }
+          }
+          if (firstElement.resource?.includes('Library') || firstElement.resource?.includes('Measure')) {
+            return 1;
+          } else if (secondElement.resource?.includes('Library') || secondElement.resource?.includes('Measure')) {
             return 1;
           }
+
           if (displayFirst < displaySecond) {
             return -1;
           }

--- a/app/src/pages/[resourceType]/[id].tsx
+++ b/app/src/pages/[resourceType]/[id].tsx
@@ -83,6 +83,8 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
       dataRequirements.relatedArtifact.sort((firstElement, secondElement) => {
         const displayFirst = firstElement.display?.toUpperCase();
         const displaySecond = secondElement.display?.toUpperCase();
+        const resourceFirst = firstElement.resource?.toUpperCase();
+        const resourceSecond = secondElement.resource?.toUpperCase();
         if (displayFirst && displaySecond) {
           if (
             (firstElement.resource?.includes('Library') || firstElement.resource?.includes('Measure')) &&
@@ -100,11 +102,18 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
           } else if (secondElement.resource?.includes('Library') || secondElement.resource?.includes('Measure')) {
             return 1;
           }
-
           if (displayFirst < displaySecond) {
             return -1;
           }
           if (displayFirst > displaySecond) {
+            return 1;
+          }
+          //If a related artifact doesn't have a display property it will instead sort by the resource
+        } else if (resourceFirst && resourceSecond) {
+          if (resourceFirst < resourceSecond) {
+            return -1;
+          }
+          if (resourceFirst > resourceSecond) {
             return 1;
           }
         }

--- a/app/src/pages/[resourceType]/[id].tsx
+++ b/app/src/pages/[resourceType]/[id].tsx
@@ -22,6 +22,8 @@ import Dependency from '@/components/DependencyCards';
 export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const resourceType = jsonData.resourceType;
   const [dataReqsView, setDataReqsView] = useState('raw');
+
+  const [activeTab, setActiveTab] = useState<string | null>('json');
   const [height, setWindowHeight] = useState(0);
 
   const decodedCql = useMemo(() => {
@@ -81,6 +83,10 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
     }
   );
 
+  useEffect(() => {
+    setActiveTab('json');
+  }, [jsonData.id]);
+
   const draftMutation = trpc.draft.createDraft.useMutation({
     onSuccess: data => {
       notifications.show({
@@ -133,7 +139,7 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
           </Group>
         </div>
         <Divider my="sm" pb={6} />
-        <Tabs variant="outline" defaultValue="json">
+        <Tabs variant="outline" value={activeTab} onTabChange={setActiveTab}>
           <Tabs.List>
             <Tabs.Tab value="json">JSON</Tabs.Tab>
             {decodedElm != null && <Tabs.Tab value="elm">ELM</Tabs.Tab>}
@@ -217,11 +223,11 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
             <Tabs.Panel value="dependencies">
               <Space h="md" />
               <Text c="dimmed">
-                Number of Dependencies:<b> {dataRequirements?.relatedArtifact.length} </b>
+                Number of Dependencies:<b> {dataRequirements.relatedArtifact.length} </b>
               </Text>
               <Space h="md" />
               <ScrollArea.Autosize mah={height * 0.8} type="hover">
-                {dataRequirements?.relatedArtifact.map((relatedArtifact, index) => (
+                {dataRequirements.relatedArtifact.map((relatedArtifact, index) => (
                   <Dependency key={index} relatedArtifact={relatedArtifact} />
                 ))}
               </ScrollArea.Autosize>

--- a/app/src/pages/[resourceType]/[id].tsx
+++ b/app/src/pages/[resourceType]/[id].tsx
@@ -12,6 +12,7 @@ import { useRouter } from 'next/router';
 import { modifyResourceToDraft } from '@/util/modifyResourceFields';
 import { trpc } from '@/util/trpc';
 import DataReqs from '@/components/DataRequirements';
+import Dependency from '@/components/DependencyCards';
 
 /**
  * Component which displays the JSON/ELM/CQL/narrative/Data Requirements content of an individual resource using
@@ -141,6 +142,7 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
             {dataRequirements?.resourceType === 'Library' && (
               <Tabs.Tab value="data-requirements">Data Requirements</Tabs.Tab>
             )}
+            {dataRequirements?.resourceType === 'Library' && <Tabs.Tab value="dependencies">Dependencies</Tabs.Tab>}
           </Tabs.List>
           <Tabs.Panel value="json" pt="xs">
             <Prism language="json" colorScheme="light">
@@ -209,6 +211,13 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
                     />
                   ))}
               </ScrollArea.Autosize>
+            </Tabs.Panel>
+          )}
+          {dataRequirements?.resourceType === 'Library' && dataRequirements?.relatedArtifact && (
+            <Tabs.Panel value="dependencies">
+              {dataRequirements?.relatedArtifact.map((item: fhir4.RelatedArtifact, index: any) => (
+                <Dependency key={index} value={item} sourceName={jsonData?.id}></Dependency>
+              ))}
             </Tabs.Panel>
           )}
         </Tabs>

--- a/app/src/pages/[resourceType]/[id].tsx
+++ b/app/src/pages/[resourceType]/[id].tsx
@@ -20,7 +20,7 @@ import { FhirArtifact } from '@/util/types/fhir';
 import CQLRegex from '../../util/prismCQL';
 import { Prism as PrismRenderer } from 'prism-react-renderer';
 import parse from 'html-react-parser';
-import { AlertCircle, CircleCheck, AbacusOff } from 'tabler-icons-react';
+import { AlertCircle, CircleCheck } from 'tabler-icons-react';
 import { useRouter } from 'next/router';
 import { modifyResourceToDraft } from '@/util/modifyResourceFields';
 import { trpc } from '@/util/trpc';
@@ -67,34 +67,11 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
     window.addEventListener('resize', handleResize);
   }, []);
 
-  const {
-    data: dataRequirements,
-    refetch,
-    isFetching,
-    isSuccess
-  } = trpc.service.getDataRequirements.useQuery(
+  const { data: dataRequirements, isSuccess } = trpc.service.getDataRequirements.useQuery(
     { resourceType: jsonData.resourceType, id: jsonData.id as string },
     {
-      enabled: false,
-      retry: 0,
-      onSuccess: () => {
-        notifications.show({
-          autoClose: 2000,
-          title: 'Successful Fetch',
-          message: 'Data requirements successfully fetched',
-          color: 'green',
-          icon: <CircleCheck />
-        });
-      },
-      onError: e => {
-        notifications.show({
-          autoClose: 4000,
-          title: 'No Data Requirements Found',
-          message: e.message,
-          color: 'red',
-          icon: <AbacusOff />
-        });
-      }
+      enabled: true,
+      retry: 0
     }
   );
 
@@ -198,21 +175,9 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
             <Text size="xl" color="gray">
               {jsonData.resourceType}/{jsonData.id}
             </Text>
-            <Group>
-              <Button
-                w={240}
-                loading={isFetching}
-                loaderPosition="center"
-                onClick={() => {
-                  refetch();
-                }}
-              >
-                Get Data Requirements
-              </Button>
-              <Button w={240} loading={draftMutation.isLoading} onClick={createDraftOfArtifact}>
-                Create Draft of {jsonData.resourceType}
-              </Button>
-            </Group>
+            <Button w={240} loading={draftMutation.isLoading} onClick={createDraftOfArtifact}>
+              Create Draft of {jsonData.resourceType}
+            </Button>
           </Group>
         </div>
         <Divider my="sm" pb={6} />
@@ -259,6 +224,10 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
               {dataRequirements?.dataRequirement.length > 0 && (
                 <>
                   <Space h="md" />
+                  <Text c="dimmed">
+                    Number of Requirements:<b> {dataRequirements?.dataRequirement.length} </b>
+                  </Text>
+                  <Space h="md" />
                   <Center>
                     <SegmentedControl
                       fullWidth
@@ -270,6 +239,7 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
                       ]}
                     />
                   </Center>
+                  <Space h="md" />
                 </>
               )}
               {dataReqsView === 'raw' && (
@@ -278,11 +248,6 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
                 </Prism>
               )}
               <ScrollArea.Autosize mah={height * 0.8} type="always">
-                <Space h="md" />
-                <Text c="dimmed">
-                  Number of Requirements:<b> {dataRequirements?.dataRequirement.length} </b>
-                </Text>
-                <Space h="md" />
                 {dataReqsView === 'formatted' &&
                   dataRequirements?.dataRequirement.map((data: fhir4.DataRequirement, index) => (
                     <DataReqs

--- a/app/src/pages/[resourceType]/[id].tsx
+++ b/app/src/pages/[resourceType]/[id].tsx
@@ -87,9 +87,7 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
     }
   );
 
-  //Sorts the dependencies of an artifact alphabetically based on display name. If a dependency has a link, however,
-  //it will appear at the top of the list.
-  useEffect(() => {
+  const sortedDependencies =
     dataRequirements?.relatedArtifact?.sort((a, b) => {
       const displayA = a?.display?.toUpperCase();
       const displayB = b?.display?.toUpperCase();
@@ -110,8 +108,7 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
         }
       }
       return 0;
-    });
-  }, [dataRequirements?.relatedArtifact]);
+    }) ?? []; // Defaults to an empty array until we have actual data to sort through
 
   const draftMutation = trpc.draft.createDraft.useMutation({
     onSuccess: data => {
@@ -165,7 +162,7 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
           </Group>
         </div>
         <Divider my="sm" pb={6} />
-        <Tabs variant="outline" value={activeTab} onTabChange={setActiveTab}>
+        <Tabs variant="outline" defaultValue="json" value={activeTab} onTabChange={setActiveTab}>
           <Tabs.List>
             <Tabs.Tab value="json">JSON</Tabs.Tab>
             {decodedElm != null && <Tabs.Tab value="elm">ELM</Tabs.Tab>}
@@ -253,8 +250,8 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
               </Text>
               <Space h="md" />
               <ScrollArea.Autosize mah={height * 0.8} type="hover">
-                {dataRequirements.relatedArtifact.map((relatedArtifact, index) => (
-                  <Dependency key={index} relatedArtifact={relatedArtifact} />
+                {sortedDependencies.map(relatedArtifact => (
+                  <Dependency key={relatedArtifact.resource} relatedArtifact={relatedArtifact} />
                 ))}
               </ScrollArea.Autosize>
               <Space h="md" />

--- a/app/src/pages/[resourceType]/[id].tsx
+++ b/app/src/pages/[resourceType]/[id].tsx
@@ -213,11 +213,19 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
               </ScrollArea.Autosize>
             </Tabs.Panel>
           )}
-          {dataRequirements?.resourceType === 'Library' && dataRequirements?.relatedArtifact && (
+          {dataRequirements?.relatedArtifact && (
             <Tabs.Panel value="dependencies">
-              {dataRequirements?.relatedArtifact.map((item: fhir4.RelatedArtifact, index: any) => (
-                <Dependency key={index} value={item} sourceName={jsonData?.id}></Dependency>
-              ))}
+              <Space h="md" />
+              <Text c="dimmed">
+                Number of Dependencies:<b> {dataRequirements?.relatedArtifact.length} </b>
+              </Text>
+              <Space h="md" />
+              <ScrollArea.Autosize mah={height * 0.8} type="hover">
+                {dataRequirements?.relatedArtifact.map((relatedArtifact, index) => (
+                  <Dependency key={index} relatedArtifact={relatedArtifact} />
+                ))}
+              </ScrollArea.Autosize>
+              <Space h="md" />
             </Tabs.Panel>
           )}
         </Tabs>

--- a/app/src/pages/[resourceType]/[id].tsx
+++ b/app/src/pages/[resourceType]/[id].tsx
@@ -53,6 +53,10 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
     window.addEventListener('resize', handleResize);
   }, []);
 
+  useEffect(() => {
+    setActiveTab('json');
+  }, [jsonData.id]);
+
   const {
     data: dataRequirements,
     refetch,
@@ -83,9 +87,31 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
     }
   );
 
+  //Sorts the dependencies of an artifact alphabetically based on display name. If a dependency has a link, however,
+  //it will appear at the top of the list.
   useEffect(() => {
-    setActiveTab('json');
-  }, [jsonData.id]);
+    dataRequirements?.relatedArtifact?.sort((a, b) => {
+      const displayA = a?.display?.toUpperCase();
+      const displayB = b?.display?.toUpperCase();
+      if (displayA !== undefined && displayB !== undefined) {
+        if (
+          a.resource?.includes('Library') ||
+          a.resource?.includes('Measure') ||
+          b.resource?.includes('Library') ||
+          b.resource?.includes('Measure')
+        ) {
+          return 1;
+        }
+        if (displayA < displayB) {
+          return -1;
+        }
+        if (displayA > displayB) {
+          return 1;
+        }
+      }
+      return 0;
+    });
+  }, [dataRequirements?.relatedArtifact]);
 
   const draftMutation = trpc.draft.createDraft.useMutation({
     onSuccess: data => {


### PR DESCRIPTION
# Summary
The user can now render the dependencies/relatedArtifacts of a resource!

## New behavior
By clicking the "Get Data Requirements" button for a resource, a new `"Dependencies" mantine tab` will pop up. Each of the resource's dependencies and their respective fields  should display in a card component. If the dependency is another library/measure resource then a `SquareArrowRight icon` should appear on the card that, when clicked, links to that resource's own page. 

## Code changes
`app/src/components/DependencyCards.tsx` —> Extracts the different fields and properties of each of the dependencies of a resource and displays them in a card component
` ScrollArea` —> The scrollArea component allows users to scroll through a resource's dependencies and continue to see the top of the page
`Link `--> The user can click the `SquareArrowRight icon` on dependencies to navigate to the resource's own page using the link component.

# Testing guidance
```
 npm run check:all
 npm run start:all
```
Navigate to the repository tab and select a library or measure resource. Then request data requirements for the resource. If the data requirements exist the Dependency tab/panel should appear. The panel should contain card components for each of the resource's dependencies. Every card should display the name and link of the dependency. If the dependency is a Library or Measure resource, the  `SquareArrowRight icon` should appear on the card and should link to the page of the resource when clicked. To make sure the dependencies are being properly displayed, you can navigate to the related Artifacts section in the data requirements tab. Each of the related Artifacts should be displayed accurately. 