### PR TITLE
Add UI input for selecting a main logic library while authoring a mea…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Measure Repository
 
-A prototype implementation of a [FHIR Measure Repository Service](https://build.fhir.org/ig/HL7/cqf-measures/measure-repository-service.html) and associated frontend application.
+A prototype implementation of a [FHIR Measure Repository Service](https://build.fhir.org/ig/HL7/cqf-measures/measure-repository.html) and associated frontend application.
 
 ## Installation
 
@@ -24,7 +24,7 @@ If you want to install a dependency in only the `app` or the `service` directory
 npm install --workspace=<app-or-service> <package-name>
 ```
 
-Copy `app/.env.example` to `app/.env.local` and `service/.env.example` to `service/.env`. Make any changes to point to the measure repository service, Mongo database, and optionally the VSAC API.
+Copy `app/.env.example` to `app/.env.local` and `service/.env.example` to `service/.env`. Make any changes to point to the measure repository service, Mongo database, and optionally the VSAC API. `0.0.0.0` may be a more appropriate database address than `localhost` for certain environment setups.
 
 ## Usage
 

--- a/app/src/pages/authoring/[resourceType]/[id].tsx
+++ b/app/src/pages/authoring/[resourceType]/[id].tsx
@@ -1,10 +1,10 @@
 import { trpc } from '@/util/trpc';
-import { Button, Center, Divider, Grid, Paper, Select, Stack, Text } from '@mantine/core';
+import { Button, Center, Divider, Grid, Group, Paper, Select, Stack, Text, Tooltip } from '@mantine/core';
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/router';
 import { Prism } from '@mantine/prism';
 import { notifications } from '@mantine/notifications';
-import { AlertCircle, CircleCheck } from 'tabler-icons-react';
+import { AlertCircle, CircleCheck, InfoCircle } from 'tabler-icons-react';
 import { ArtifactResourceType } from '@/util/types/fhir';
 import ArtifactFieldInput from '@/components/ArtifactFieldInput';
 
@@ -206,7 +206,16 @@ export default function ResourceAuthoringPage() {
             <ArtifactFieldInput label="description" value={description} setField={setDescription} />
             {resourceType === 'Measure' && (
               <Select
-                label="library"
+                label={
+                  <Group spacing="xs">
+                    library
+                    <Tooltip label="Only draft libraries with a valid url may be selected.">
+                      <div>
+                        <InfoCircle size="1rem" style={{ display: 'block', opacity: 0.5 }} />
+                      </div>
+                    </Tooltip>
+                  </Group>
+                }
                 value={library}
                 onChange={setLibrary}
                 placeholder="Select main logic library"

--- a/app/src/pages/authoring/[resourceType]/[id].tsx
+++ b/app/src/pages/authoring/[resourceType]/[id].tsx
@@ -1,5 +1,5 @@
 import { trpc } from '@/util/trpc';
-import { Button, Center, Divider, Grid, Paper, Stack, Text } from '@mantine/core';
+import { Button, Center, Divider, Grid, Paper, Select, Stack, Text } from '@mantine/core';
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/router';
 import { Prism } from '@mantine/prism';
@@ -14,6 +14,7 @@ interface DraftArtifactUpdates {
   name?: string;
   title?: string;
   description?: string;
+  library?: string[] | null;
 }
 
 export default function ResourceAuthoringPage() {
@@ -26,6 +27,7 @@ export default function ResourceAuthoringPage() {
   const [name, setName] = useState('');
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
+  const [library, setLibrary] = useState<string | null>(null);
 
   const ctx = trpc.useContext();
 
@@ -56,6 +58,9 @@ export default function ResourceAuthoringPage() {
           savedIdentifierSystem = resource.identifier[0].system;
         }
       }
+    }
+    if (resource?.resourceType === 'Measure' && library !== resource?.library?.[0]) {
+      return true;
     }
     return (
       url !== (resource?.url ?? '') ||
@@ -98,6 +103,9 @@ export default function ResourceAuthoringPage() {
     if (resource?.description) {
       setDescription(resource.description);
     }
+    if (resource?.resourceType === 'Measure' && resource?.library?.[0]) {
+      setLibrary(resource.library?.[0]);
+    }
   }, [resource]);
 
   const resourceUpdate = trpc.draft.updateDraft.useMutation({
@@ -126,7 +134,8 @@ export default function ResourceAuthoringPage() {
     identifierSystem: string,
     name: string,
     title: string,
-    description: string
+    description: string,
+    library: string | null
   ) {
     const additions: DraftArtifactUpdates = {};
     const deletions: DraftArtifactUpdates = {};
@@ -144,8 +153,35 @@ export default function ResourceAuthoringPage() {
     name.trim() !== '' ? (additions['name'] = name) : (deletions['name'] = '');
     title.trim() !== '' ? (additions['title'] = title) : (deletions['title'] = '');
     description.trim() !== '' ? (additions['description'] = description) : (deletions['description'] = '');
+    library ? (additions['library'] = [library]) : (deletions['library'] = null);
 
     return [additions, deletions];
+  }
+
+  // set up main library options
+  let libOptions: { value: string; label: string; disabled: boolean }[] = []; // default to empty
+  if (resourceType === 'Measure') {
+    const { data: libraries } = trpc.draft.getDrafts.useQuery('Library' as ArtifactResourceType);
+    if (libraries) {
+      libOptions = libraries?.map(l => {
+        if (l.url) {
+          // prioritizes use of url/version
+          const val = `${l.url}${l.version ? `|${l.version}` : ''}`;
+          return { value: val, label: val, disabled: false };
+        } else {
+          // uses id (assumed to exist in this context), but option disabled if no url exists (required for canonical reference)
+          const val = l.id ?? '';
+          return { value: val, label: val, disabled: true };
+        }
+      });
+      // disabled to the bottom, alphabetize by value
+      libOptions.sort((a, b) => {
+        if (a.disabled && !b.disabled) return 1;
+        if (b.disabled && !a.disabled) return -1;
+        if (a.value < b.value) return -1;
+        return 1;
+      });
+    }
   }
 
   return (
@@ -170,6 +206,19 @@ export default function ResourceAuthoringPage() {
             <ArtifactFieldInput label="name" value={name} setField={setName} />
             <ArtifactFieldInput label="title" value={title} setField={setTitle} />
             <ArtifactFieldInput label="description" value={description} setField={setDescription} />
+            {resourceType === 'Measure' && (
+              <Select
+                label="library"
+                value={library}
+                onChange={setLibrary}
+                placeholder="Select main logic library"
+                searchable
+                clearable
+                nothingFound="No libraries available"
+                maxDropdownHeight={280}
+                data={libOptions}
+              />
+            )}
             <Button
               w={120}
               onClick={() => {
@@ -179,7 +228,8 @@ export default function ResourceAuthoringPage() {
                   identifierSystem,
                   name,
                   title,
-                  description
+                  description,
+                  library
                 );
                 resourceUpdate.mutate({
                   resourceType: resourceType as ArtifactResourceType,

--- a/app/src/pages/authoring/[resourceType]/[id].tsx
+++ b/app/src/pages/authoring/[resourceType]/[id].tsx
@@ -59,9 +59,6 @@ export default function ResourceAuthoringPage() {
         }
       }
     }
-    if (resource?.resourceType === 'Measure' && library !== resource?.library?.[0]) {
-      return true;
-    }
     return (
       url !== (resource?.url ?? '') ||
       identifierValue !== savedIdentifierValue ||
@@ -69,7 +66,8 @@ export default function ResourceAuthoringPage() {
       (identifierValue.trim() !== '' && identifierSystem !== savedIdentifierSystem) ||
       name !== (resource?.name ?? '') ||
       title !== (resource?.title ?? '') ||
-      description !== (resource?.description ?? '')
+      description !== (resource?.description ?? '') ||
+      (resource?.resourceType === 'Measure' && (library ? library !== resource?.library?.[0] : resource?.library?.[0]))
     );
   };
 
@@ -104,7 +102,7 @@ export default function ResourceAuthoringPage() {
       setDescription(resource.description);
     }
     if (resource?.resourceType === 'Measure' && resource?.library?.[0]) {
-      setLibrary(resource.library?.[0]);
+      setLibrary(resource.library[0]);
     }
   }, [resource]);
 

--- a/app/src/pages/authoring/[resourceType]/[id].tsx
+++ b/app/src/pages/authoring/[resourceType]/[id].tsx
@@ -67,7 +67,7 @@ export default function ResourceAuthoringPage() {
       name !== (resource?.name ?? '') ||
       title !== (resource?.title ?? '') ||
       description !== (resource?.description ?? '') ||
-      (resource?.resourceType === 'Measure' && (library ? library !== resource?.library?.[0] : resource?.library?.[0]))
+      (resource?.resourceType === 'Measure' && (library ? library !== resource.library?.[0] : resource.library?.[0]))
     );
   };
 
@@ -101,7 +101,7 @@ export default function ResourceAuthoringPage() {
     if (resource?.description) {
       setDescription(resource.description);
     }
-    if (resource?.resourceType === 'Measure' && resource?.library?.[0]) {
+    if (resource?.resourceType === 'Measure' && resource.library?.[0]) {
       setLibrary(resource.library[0]);
     }
   }, [resource]);
@@ -161,7 +161,7 @@ export default function ResourceAuthoringPage() {
   if (resourceType === 'Measure') {
     const { data: libraries } = trpc.draft.getDrafts.useQuery('Library' as ArtifactResourceType);
     if (libraries) {
-      libOptions = libraries?.map(l => {
+      libOptions = libraries.map(l => {
         if (l.url) {
           // prioritizes use of url/version
           const val = `${l.url}${l.version ? `|${l.version}` : ''}`;

--- a/service/README.md
+++ b/service/README.md
@@ -40,10 +40,16 @@ To create these collections:
 npm run db:setup
 ```
 
-to clear the database and regenerate empty FHIR Measure, Library, and MeasureReport collections, run:
+To clear the database and regenerate empty FHIR Measure, Library, and MeasureReport collections, run:
 
 ```
 npm run db:reset
+```
+
+To load a measure bundle and related library artifacts, run:
+
+```
+npm run db:loadBundle <path to measure bundle>
 ```
 
 ## Usage


### PR DESCRIPTION
…sure (and miscellaneous README updates)

# Summary
Adds dropdown in Measure authoring edit screen that allows selection of an authoring draft library as the `.library` main logic library for that measure

## New behavior
Measure authoring screen has library options dropdown, which can be used to update the Measure `.library` field.

## Code changes

- Changes to two `README`s that I noticed might be nice or necessary (mostly came up in reviewing other folks' PRs)
- `[id].tsx` adds a mantine `Select` component and `library` fields so that the Measure object can be mutated with the selected result. The `.library` field is an array of exactly one canonical string based on the library url, and the select default is `null` rather than an empty string, so there are a couple of differences in handling as compared with the other editable fields.

# Testing guidance

- `npm run check:all`
- `npm run start:all`
- Go to http://localhost:3001/
- Navigate to the authoring mode and create a new `Measure` draft resource (or navigate to the Authoring Measures list and choose to edit an existing draft measure)
- Select the `library` dropdown field. Available draft libraries should be shown in alphabetical order by `url` or shown at the end as disabled by `id` if a url is not available (id only libraries are shown so that the user knows they exist, but disabled because a url is required to select it). You can select a library or begin typing to filter the list to a desired library subset.
  - If there are no draft library options, the dropdown should indicate "No libraries available".
<img width="499" alt="Screenshot 2023-07-07 at 2 55 34 PM" src="https://github.com/projecttacoma/measure-repository/assets/2643955/d3369721-1bf0-4b6a-a3c3-d95d25732d6c">

- Select `Submit` once the library is chosen (and any other desired text field updates are made). Submit should update successfully and show the corresponding library array in the json on the right.
<img width="446" alt="Screenshot 2023-07-07 at 2 58 25 PM" src="https://github.com/projecttacoma/measure-repository/assets/2643955/cb25aa0d-58c6-4617-8ccf-df29b654a7ad">

- Try different combinations of selecting a library, selecting no library, changing other fields, etc.
- Draft Library editing should remain unaltered and continue to function
