### PR TITLE
Add Artifact comments to a draft resource

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -17,6 +17,7 @@
     "@emotion/server": "^11.10.0",
     "@mantine/core": "^6.0.9",
     "@mantine/dates": "^6.0.9",
+    "@mantine/form": "^6.0.17",
     "@mantine/hooks": "^6.0.9",
     "@mantine/next": "^6.0.9",
     "@mantine/notifications": "^6.0.11",

--- a/app/src/pages/review/[resourceType]/[id].tsx
+++ b/app/src/pages/review/[resourceType]/[id].tsx
@@ -1,29 +1,140 @@
 import { Prism } from '@mantine/prism';
-import { Center, Divider, Grid, Paper, Space, Tabs, Text } from '@mantine/core';
+import {
+  Anchor,
+  Avatar,
+  Box,
+  Button,
+  Center,
+  Checkbox,
+  Divider,
+  Grid,
+  Group,
+  HoverCard,
+  List,
+  Paper,
+  Select,
+  Space,
+  Stack,
+  Tabs,
+  Text,
+  Textarea,
+  TextInput
+} from '@mantine/core';
 import { ArtifactResourceType } from '@/util/types/fhir';
+import { useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/router';
 import { trpc } from '@/util/trpc';
+import { IconStar, IconCalendar, IconInfoHexagonFilled } from '@tabler/icons-react';
+import { AlertCircle, CircleCheck, InfoCircle } from 'tabler-icons-react';
+import { hasLength, isNotEmpty, useForm } from '@mantine/form';
+import { notifications } from '@mantine/notifications';
+
+interface DraftArtifactUpdates {
+  extension?: fhir4.Extension[];
+}
 
 /**
  * Component which renders a page that displays the JSON data of a resource. Also will eventually
  *  provide the user with the ability to make review comments and visualize previous review comments.
  */
 export default function CommentPage() {
+  const ctx = trpc.useContext();
+  const [dateSelected, setDateSelected] = useState(false);
+  const ref = useRef<HTMLInputElement>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
   const router = useRouter();
   const { resourceType: resourceType, id: resourceID, authoring } = router.query;
-  let resource;
+  const { data: resource } = getResource();
 
-  if (authoring === 'true') {
-    resource = trpc.draft.getDraftById.useQuery({
-      id: resourceID as string,
-      resourceType: resourceType as ArtifactResourceType
-    });
-  } else {
-    resource = trpc.service.getArtifactById.useQuery({
-      id: resourceID as string,
-      resourceType: resourceType as ArtifactResourceType
-    });
+  //Validates that all of the necessary form properties were entered by the user
+  const form = useForm({
+    initialValues: {
+      name: '',
+      type: '',
+      comment: ''
+    },
+    validate: {
+      name: hasLength({ min: 2, max: 10 }, 'Name must be 2-10 characters long'),
+      type: isNotEmpty('Select the type of comment'),
+      comment: isNotEmpty('Enter artifact comment')
+    }
+  });
+
+  const resourceUpdate = trpc.draft.updateDraft.useMutation({
+    onSuccess: () => {
+      notifications.show({
+        title: 'Comment Successfully added!',
+        message: `${resourceType} Successful comment`,
+        icon: <CircleCheck />,
+        color: 'green'
+      });
+      ctx.draft.getDraftById.invalidate();
+    },
+    onError: e => {
+      notifications.show({
+        title: 'Update Failed!',
+        message: `Attempt to update ${resourceType} failed with message: ${e.message}`,
+        icon: <AlertCircle />,
+        color: 'red'
+      });
+    }
+  });
+
+  function getResource() {
+    if (authoring === 'true') {
+      //test here
+      return trpc.draft.getDraftById.useQuery({
+        id: resourceID as string,
+        resourceType: resourceType as ArtifactResourceType
+      });
+    } else {
+      return trpc.service.getArtifactById.useQuery({
+        id: resourceID as string,
+        resourceType: resourceType as ArtifactResourceType
+      });
+    }
   }
+
+  function parseUpdate(comment: string, type: string, userName: string, dateSelected: boolean) {
+    const additions: DraftArtifactUpdates = {};
+    const deletions: DraftArtifactUpdates = {};
+    let newExtensionObject: fhir4.Extension[] = [];
+
+    newExtensionObject.push({ url: 'type', valueCode: type });
+    newExtensionObject.push({ url: 'text', valueMarkdown: comment });
+    newExtensionObject.push({ url: 'user', valueString: userName });
+    if (dateSelected === true) {
+      const now = new Date();
+      const isoString = now.toISOString();
+      newExtensionObject.push({ url: 'authoredOn', valueDateTime: isoString });
+    }
+    if (comment.trim() !== '') {
+      if (resource?.extension) {
+        resource.extension.push({
+          extension: newExtensionObject,
+          url: 'http://hl7.org/fhir/us/cqfmeasures/CodeSystem/artifact-comment-type'
+        });
+        additions['extension'] = resource.extension;
+      }
+    }
+    return [additions, deletions];
+  }
+
+  // useEffect to check if the artifact has an extension and adds it if it doesn't
+  useEffect(() => {
+    if (!resource?.extension) {
+      const additions: DraftArtifactUpdates = {};
+      const deletions: DraftArtifactUpdates = {};
+      additions['extension'] = [];
+      resourceUpdate.mutate({
+        resourceType: resourceType as ArtifactResourceType,
+        id: resourceID as string,
+        additions: additions,
+        deletions: deletions
+      });
+    }
+  }, [resource]);
 
   return (
     <div>
@@ -36,28 +147,169 @@ export default function CommentPage() {
       </Center>
       <Divider my="md" mt={14} />
       <Grid>
-        <Grid.Col span={6}>
+        <Grid.Col span={7}>
           <Tabs variant="outline" defaultValue="addComments">
             <Tabs.List>
               <Tabs.Tab value="addComments">Add comment</Tabs.Tab>
-              <Tabs.Tab value="viewComments">View Comments</Tabs.Tab>
+              <Tabs.Tab value="viewComments"> View Comments</Tabs.Tab>
             </Tabs.List>
             <Tabs.Panel value="addComments" pt="xs">
-              Components to add review comment goes here
+              <Paper shadow="sm" p="lg" withBorder radius="xl">
+                <Box
+                  component="form"
+                  maw={1200}
+                  mx="auto"
+                  onSubmit={form.onSubmit(() => {
+                    console.log('random console.log to avoid Eslint error');
+                  })}
+                >
+                  <Group>
+                    <Select
+                      id="commentType"
+                      mt="md"
+                      clearable
+                      radius="lg"
+                      label={
+                        <Group spacing="xs">
+                          Comment Type
+                          <HoverCard width={420} shadow="md" withArrow openDelay={200} closeDelay={200}>
+                            <HoverCard.Target>
+                              <div>
+                                <InfoCircle size="1rem" style={{ opacity: 0.5 }} />
+                              </div>
+                            </HoverCard.Target>
+                            <HoverCard.Dropdown>
+                              <Group>
+                                <Avatar color="blue" radius="xl">
+                                  <IconInfoHexagonFilled size="1.5rem" />
+                                </Avatar>
+                                <Stack spacing={5}>
+                                  <Text size="sm" weight={700} sx={{ lineHeight: 1 }}>
+                                    Mantine
+                                  </Text>
+                                  <Anchor
+                                    target="_blank"
+                                    href="https://build.fhir.org/ig/HL7/cqf-measures/ValueSet-artifact-comment-type.html"
+                                    color="dimmed"
+                                    size="xs"
+                                    sx={{ lineHeight: 1 }}
+                                  >
+                                    Artifact Comment Types
+                                  </Anchor>
+                                </Stack>
+                              </Group>
+                              <Space h="lg" />
+                              <List spacing="sm" size="sm" center>
+                                <List.Item>
+                                  <i>Documentation:</i> The comment is providing additional documentation from an
+                                  authoring perspective
+                                </List.Item>
+                                <List.Item>
+                                  <i>Review:</i> The comment is providing feedback from a reviewer and requires
+                                  resolution
+                                </List.Item>
+                                <List.Item>
+                                  <i>Guidance:</i> The comment is providing usage guidance to an artifact consumer
+                                </List.Item>
+                              </List>
+                            </HoverCard.Dropdown>
+                          </HoverCard>
+                        </Group>
+                      }
+                      icon={<IconStar />}
+                      placeholder="Type"
+                      data={[
+                        { value: 'Documentation', label: 'Documentation' },
+                        { value: 'Guidance', label: 'Guidance' },
+                        { value: 'Review', label: 'Review' }
+                      ]}
+                      {...form.getInputProps('type')}
+                    />
+                  </Group>
+                  <Textarea
+                    radius="lg"
+                    mt="md"
+                    minRows={10}
+                    maxRows={10}
+                    placeholder="Your Artifact comment"
+                    label="Artifact Comment"
+                    description="Add a comment to the resource"
+                    withAsterisk
+                    {...form.getInputProps('comment')}
+                  />
+                  <Space h="md" />
+                  <Group grow>
+                    <TextInput
+                      radius="lg"
+                      label="Endorser Name"
+                      placeholder="Name"
+                      withAsterisk
+                      {...form.getInputProps('name')}
+                    />
+                    <Checkbox
+                      ref={ref}
+                      id="checkbox"
+                      icon={IconCalendar}
+                      color="white"
+                      mt="md"
+                      label="Include Date in Comment"
+                      {...form.getInputProps('date')}
+                      onChange={() => {
+                        setDateSelected(!dateSelected);
+                      }}
+                    />
+                    <Space h="md" />
+                  </Group>
+                  <Space h="md" />
+                  <Group position="right" mt="md">
+                    <Button
+                      loading={isLoading}
+                      type="submit"
+                      onClick={() => {
+                        if (form.isValid()) {
+                          setIsLoading(true);
+                          setTimeout(() => {
+                            setDateSelected(false);
+                            form.reset();
+                            if (ref?.current?.checked) {
+                              ref.current.checked = false;
+                            }
+                            setIsLoading(false);
+                          }, 1000);
+                          const [additions, deletions] = parseUpdate(
+                            form.values.comment,
+                            form.values.type,
+                            form.values.name,
+                            dateSelected
+                          );
+                          resourceUpdate.mutate({
+                            resourceType: resourceType as ArtifactResourceType,
+                            id: resourceID as string,
+                            additions: additions,
+                            deletions: deletions
+                          });
+                        }
+                      }}
+                    >
+                      Submit
+                    </Button>
+                  </Group>
+                </Box>
+              </Paper>
             </Tabs.Panel>
             <Tabs.Panel value="viewComments" pt="xs">
               Components to view comments go here
             </Tabs.Panel>
           </Tabs>
         </Grid.Col>
-        <Grid.Col span={6}>
+        <Grid.Col span={5}>
           <Space />
           <Text c="gray" fz="sm">
             Current JSON Content
           </Text>
           <Paper withBorder>
             <Prism language="json" colorScheme="light" styles={{ scrollArea: { height: 'calc(100vh - 150px)' } }}>
-              {resource.data ? JSON.stringify(resource.data, null, 2) : ''}
+              {resource ? JSON.stringify(resource, null, 2) : ''}
             </Prism>
           </Paper>
         </Grid.Col>

--- a/app/src/pages/review/[resourceType]/[id].tsx
+++ b/app/src/pages/review/[resourceType]/[id].tsx
@@ -100,29 +100,27 @@ export default function CommentPage() {
     const additions: DraftArtifactUpdates = {};
     const deletions: DraftArtifactUpdates = {};
 
-    const newExtensionObject: fhir4.Extension[] = [];
-    newExtensionObject.push({ url: 'type', valueCode: type }, { url: 'text', valueMarkdown: comment });
+    const newExtension: fhir4.Extension[] = [];
+    newExtension.push({ url: 'type', valueCode: type }, { url: 'text', valueMarkdown: comment });
 
     if (userName !== '') {
-      newExtensionObject.push({ url: 'user', valueString: userName });
+      newExtension.push({ url: 'user', valueString: userName });
     }
     if (dateSelected === true) {
       const authoredDate = new Date();
-      newExtensionObject.push({ url: 'authoredOn', valueDateTime: authoredDate.toISOString() });
+      newExtension.push({ url: 'authoredOn', valueDateTime: authoredDate.toISOString() });
     }
 
     if (resource?.extension) {
       resource.extension.push({
-        extension: newExtensionObject,
-        url: 'http://hl7.org/fhir/us/cqfmeasures/CodeSystem/artifact-comment-type'
+        extension: newExtension,
+        url: 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-artifactComment'
       });
       additions['extension'] = resource.extension;
     } else if (resource && !resource.extension) {
-      resource.extension = [];
-      resource.extension.push({
-        extension: newExtensionObject,
-        url: 'http://hl7.org/fhir/us/cqfmeasures/CodeSystem/artifact-comment-type'
-      });
+      resource.extension = [
+        { extension: newExtension, url: 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-artifactComment' }
+      ];
       additions['extension'] = resource.extension;
     }
     return [additions, deletions];
@@ -163,8 +161,10 @@ export default function CommentPage() {
                     clearable
                     radius="lg"
                     label={
-                      <Group spacing="xs">
-                        <Text>Comment Type</Text> <Text color="red">*</Text>
+                      <Group spacing="lg">
+                        <Text>
+                          Comment Type <span style={{ color: 'red' }}>*</span>
+                        </Text>
                         <HoverCard width={420} shadow="md" withArrow openDelay={200} closeDelay={200}>
                           <HoverCard.Target>
                             <div>

--- a/app/src/pages/review/[resourceType]/[id].tsx
+++ b/app/src/pages/review/[resourceType]/[id].tsx
@@ -64,8 +64,6 @@ export default function CommentPage() {
   // Currently we can only update draft artifact resources.
   const resourceUpdate = trpc.draft.updateDraft.useMutation({
     onSuccess: () => {
-      // This if statement prevents the success notifaction from popping up in the unique case
-      // that the draft artifact has just had an extension array added to the JSON.
       notifications.show({
         title: 'Comment Successfully added!',
         message: `Comment Successfully added to ${resourceType}/${resourceID}`,
@@ -109,9 +107,8 @@ export default function CommentPage() {
       newExtensionObject.push({ url: 'user', valueString: userName });
     }
     if (dateSelected === true) {
-      const now = new Date();
-      const isoString = now.toISOString();
-      newExtensionObject.push({ url: 'authoredOn', valueDateTime: isoString });
+      const authoredDate = new Date();
+      newExtensionObject.push({ url: 'authoredOn', valueDateTime: authoredDate.toISOString() });
     }
 
     if (resource?.extension) {
@@ -264,18 +261,20 @@ export default function CommentPage() {
                           }
                           setIsLoading(false);
                         }, 1000);
-                        const [additions, deletions] = parseUpdate(
-                          form.values.comment,
-                          form.values.type,
-                          form.values.name,
-                          dateSelected
-                        );
-                        resourceUpdate.mutate({
-                          resourceType: resourceType as ArtifactResourceType,
-                          id: resourceID as string,
-                          additions: additions,
-                          deletions: deletions
-                        });
+                        if (authoring === 'true') {
+                          const [additions, deletions] = parseUpdate(
+                            form.values.comment,
+                            form.values.type,
+                            form.values.name,
+                            dateSelected
+                          );
+                          resourceUpdate.mutate({
+                            resourceType: resourceType as ArtifactResourceType,
+                            id: resourceID as string,
+                            additions: additions,
+                            deletions: deletions
+                          });
+                        }
                       }
                     }}
                   >

--- a/app/src/pages/review/[resourceType]/[id].tsx
+++ b/app/src/pages/review/[resourceType]/[id].tsx
@@ -21,7 +21,7 @@ import {
   TextInput
 } from '@mantine/core';
 import { ArtifactResourceType } from '@/util/types/fhir';
-import { useEffect, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import { useRouter } from 'next/router';
 import { trpc } from '@/util/trpc';
 import { AlertCircle, CircleCheck, InfoCircle, Star } from 'tabler-icons-react';
@@ -66,14 +66,12 @@ export default function CommentPage() {
     onSuccess: () => {
       //This if statement prevents the success notifaction from popping up in the unique case
       //that the draft artifact has just had an extension array added to the JSON.
-      if (JSON.stringify(resource?.extension) !== undefined) {
-        notifications.show({
-          title: 'Comment Successfully added!',
-          message: `Comment Successfully added to ${resourceType}/${resourceID}`,
-          icon: <CircleCheck />,
-          color: 'green'
-        });
-      }
+      notifications.show({
+        title: 'Comment Successfully added!',
+        message: `Comment Successfully added to ${resourceType}/${resourceID}`,
+        icon: <CircleCheck />,
+        color: 'green'
+      });
       ctx.draft.getDraftById.invalidate();
     },
     onError: e => {
@@ -115,7 +113,15 @@ export default function CommentPage() {
       const isoString = now.toISOString();
       newExtensionObject.push({ url: 'authoredOn', valueDateTime: isoString });
     }
+
     if (resource?.extension) {
+      resource.extension.push({
+        extension: newExtensionObject,
+        url: 'http://hl7.org/fhir/us/cqfmeasures/CodeSystem/artifact-comment-type'
+      });
+      additions['extension'] = resource.extension;
+    } else if (resource && !resource.extension) {
+      resource.extension = [];
       resource.extension.push({
         extension: newExtensionObject,
         url: 'http://hl7.org/fhir/us/cqfmeasures/CodeSystem/artifact-comment-type'
@@ -124,23 +130,6 @@ export default function CommentPage() {
     }
     return [additions, deletions];
   }
-
-  // useEffect to check if the artifact has an extension and adds it if it doesn't
-  /* eslint-disable react-hooks/exhaustive-deps */
-  useEffect(() => {
-    if (!resource?.extension) {
-      const additions: DraftArtifactUpdates = {};
-      const deletions: DraftArtifactUpdates = {};
-      additions['extension'] = [];
-      resourceUpdate.mutate({
-        resourceType: resourceType as ArtifactResourceType,
-        id: resourceID as string,
-        additions: additions,
-        deletions: deletions
-      });
-    }
-  }, [resource]);
-  /* eslint-enable react-hooks/exhaustive-deps */
 
   return (
     <div>

--- a/app/src/pages/review/[resourceType]/[id].tsx
+++ b/app/src/pages/review/[resourceType]/[id].tsx
@@ -46,7 +46,7 @@ export default function CommentPage() {
   const { resourceType: resourceType, id: resourceID, authoring } = router.query;
   const { data: resource } = getResource();
 
-  //Validates that all of the necessary form properties were entered by the user
+  // Validates that all of the necessary form properties were entered by the user
   const form = useForm({
     initialValues: {
       type: '',
@@ -54,18 +54,18 @@ export default function CommentPage() {
       name: '',
       date: ''
     },
-    //An error will be thrown if these fields aren't entered properly
+    // An error will be thrown if these fields aren't entered properly
     validate: {
       type: isNotEmpty('Select the type of comment'),
       comment: isNotEmpty('Enter artifact comment')
     }
   });
 
-  //Currently we can only update draft artifact resources.
+  // Currently we can only update draft artifact resources.
   const resourceUpdate = trpc.draft.updateDraft.useMutation({
     onSuccess: () => {
-      //This if statement prevents the success notifaction from popping up in the unique case
-      //that the draft artifact has just had an extension array added to the JSON.
+      // This if statement prevents the success notifaction from popping up in the unique case
+      // that the draft artifact has just had an extension array added to the JSON.
       notifications.show({
         title: 'Comment Successfully added!',
         message: `Comment Successfully added to ${resourceType}/${resourceID}`,
@@ -153,8 +153,8 @@ export default function CommentPage() {
                 component="form"
                 maw={1200}
                 mx="auto"
-                //This console.log is necessary because the onSubmit function has to use the '() => {}' format
-                //and it will cause an error if it is left empty.
+                // This console.log is necessary because the onSubmit function has to use the '() => {}' format
+                // and it will cause an error if it is left empty.
                 onSubmit={form.onSubmit(values => {
                   console.log(values);
                 })}
@@ -167,7 +167,7 @@ export default function CommentPage() {
                     radius="lg"
                     label={
                       <Group spacing="xs">
-                        Comment Type
+                        <Text>Comment Type</Text> <Text color="red">*</Text>
                         <HoverCard width={420} shadow="md" withArrow openDelay={200} closeDelay={200}>
                           <HoverCard.Target>
                             <div>
@@ -197,14 +197,14 @@ export default function CommentPage() {
                             <Space h="lg" />
                             <List spacing="sm" size="sm" center>
                               <List.Item>
-                                <i>Documentation:</i> The comment is providing additional documentation from an
+                                <i>documentation:</i> The comment is providing additional documentation from an
                                 authoring perspective
                               </List.Item>
                               <List.Item>
-                                <i>Review:</i> The comment is providing feedback from a reviewer and requires resolution
+                                <i>review:</i> The comment is providing feedback from a reviewer and requires resolution
                               </List.Item>
                               <List.Item>
-                                <i>Guidance:</i> The comment is providing usage guidance to an artifact consumer
+                                <i>guidance:</i> The comment is providing usage guidance to an artifact consumer
                               </List.Item>
                             </List>
                           </HoverCard.Dropdown>
@@ -214,9 +214,9 @@ export default function CommentPage() {
                     icon={<Star opacity={0.5} />}
                     placeholder="Type"
                     data={[
-                      { value: 'Documentation', label: 'Documentation' },
-                      { value: 'Guidance', label: 'Guidance' },
-                      { value: 'Review', label: 'Review' }
+                      { value: 'documentation', label: 'documentation' },
+                      { value: 'guidance', label: 'guidance' },
+                      { value: 'review', label: 'review' }
                     ]}
                     {...form.getInputProps('type')}
                   />
@@ -228,7 +228,7 @@ export default function CommentPage() {
                   maxRows={15}
                   placeholder="Your Artifact comment"
                   label="Artifact Comment"
-                  description="Add a comment to the resource"
+                  description="Add a comment to the artifact"
                   withAsterisk
                   {...form.getInputProps('comment')}
                 />

--- a/app/src/pages/review/[resourceType]/[id].tsx
+++ b/app/src/pages/review/[resourceType]/[id].tsx
@@ -24,8 +24,7 @@ import { ArtifactResourceType } from '@/util/types/fhir';
 import { useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/router';
 import { trpc } from '@/util/trpc';
-import { IconStar, IconCalendar, IconInfoHexagonFilled } from '@tabler/icons-react';
-import { AlertCircle, CircleCheck, InfoCircle } from 'tabler-icons-react';
+import { AlertCircle, CircleCheck, InfoCircle, Star } from 'tabler-icons-react';
 import { isNotEmpty, useForm } from '@mantine/form';
 import { notifications } from '@mantine/notifications';
 
@@ -52,7 +51,8 @@ export default function CommentPage() {
     initialValues: {
       type: '',
       comment: '',
-      name: ''
+      name: '',
+      date: ''
     },
     //An error will be thrown if these fields aren't entered properly
     validate: {
@@ -128,9 +128,7 @@ export default function CommentPage() {
   // useEffect to check if the artifact has an extension and adds it if it doesn't
   /* eslint-disable react-hooks/exhaustive-deps */
   useEffect(() => {
-    console.log('in here');
     if (!resource?.extension) {
-      console.log('no extension');
       const additions: DraftArtifactUpdates = {};
       const deletions: DraftArtifactUpdates = {};
       additions['extension'] = [];
@@ -190,7 +188,7 @@ export default function CommentPage() {
                           <HoverCard.Dropdown>
                             <Group>
                               <Avatar color="blue" radius="xl">
-                                <IconInfoHexagonFilled size="1.5rem" />
+                                <InfoCircle size="1.5rem" />
                               </Avatar>
                               <Stack spacing={5}>
                                 <Text size="sm" weight={700} sx={{ lineHeight: 1 }}>
@@ -224,7 +222,7 @@ export default function CommentPage() {
                         </HoverCard>
                       </Group>
                     }
-                    icon={<IconStar />}
+                    icon={<Star opacity={0.5} />}
                     placeholder="Type"
                     data={[
                       { value: 'Documentation', label: 'Documentation' },
@@ -251,7 +249,6 @@ export default function CommentPage() {
                   <Checkbox
                     ref={ref}
                     id="checkbox"
-                    icon={IconCalendar}
                     color="white"
                     mt="md"
                     label="Include Date in Comment"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,9 @@
         "app",
         "service"
       ],
+      "dependencies": {
+        "@mantine/form": "^6.0.17"
+      },
       "devDependencies": {
         "concurrently": "^7.6.0"
       }
@@ -2523,6 +2526,18 @@
         "@mantine/core": "6.0.10",
         "@mantine/hooks": "6.0.10",
         "dayjs": ">=1.0.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@mantine/form": {
+      "version": "6.0.17",
+      "resolved": "https://registry.npmjs.org/@mantine/form/-/form-6.0.17.tgz",
+      "integrity": "sha512-hrWlBukErklaFSvKfz4PCl3Cd7UgHf5Q/FyZPD+WvBDT0zZ5uMjatQpVs/HAfhFOA5O2DFKAcs654mLzmJJ6Wg==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "klona": "^2.0.5"
+      },
+      "peerDependencies": {
         "react": ">=16.8.0"
       }
     },
@@ -8820,6 +8835,14 @@
         "node": ">=6"
       }
     },
+    "node_modules/klona": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.6.tgz",
+      "integrity": "sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA==",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/kuler": {
       "version": "2.0.0",
       "license": "MIT"
@@ -14062,6 +14085,15 @@
         "@mantine/utils": "6.0.10"
       }
     },
+    "@mantine/form": {
+      "version": "6.0.17",
+      "resolved": "https://registry.npmjs.org/@mantine/form/-/form-6.0.17.tgz",
+      "integrity": "sha512-hrWlBukErklaFSvKfz4PCl3Cd7UgHf5Q/FyZPD+WvBDT0zZ5uMjatQpVs/HAfhFOA5O2DFKAcs654mLzmJJ6Wg==",
+      "requires": {
+        "fast-deep-equal": "^3.1.3",
+        "klona": "^2.0.5"
+      }
+    },
     "@mantine/hooks": {
       "version": "6.0.11",
       "resolved": "https://registry.npmjs.org/@mantine/hooks/-/hooks-6.0.11.tgz",
@@ -18148,6 +18180,11 @@
     "kleur": {
       "version": "3.0.3",
       "dev": true
+    },
+    "klona": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.6.tgz",
+      "integrity": "sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA=="
     },
     "kuler": {
       "version": "2.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,6 @@
         "app",
         "service"
       ],
-      "dependencies": {
-        "@mantine/form": "^6.0.17"
-      },
       "devDependencies": {
         "concurrently": "^7.6.0"
       }
@@ -25,6 +22,7 @@
         "@emotion/server": "^11.10.0",
         "@mantine/core": "^6.0.9",
         "@mantine/dates": "^6.0.9",
+        "@mantine/form": "^6.0.17",
         "@mantine/hooks": "^6.0.9",
         "@mantine/next": "^6.0.9",
         "@mantine/notifications": "^6.0.11",
@@ -15188,6 +15186,7 @@
         "@emotion/server": "^11.10.0",
         "@mantine/core": "^6.0.9",
         "@mantine/dates": "^6.0.9",
+        "@mantine/form": "^6.0.17",
         "@mantine/hooks": "^6.0.9",
         "@mantine/next": "^6.0.9",
         "@mantine/notifications": "^6.0.11",

--- a/package.json
+++ b/package.json
@@ -19,8 +19,5 @@
   },
   "devDependencies": {
     "concurrently": "^7.6.0"
-  },
-  "dependencies": {
-    "@mantine/form": "^6.0.17"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,5 +19,8 @@
   },
   "devDependencies": {
     "concurrently": "^7.6.0"
+  },
+  "dependencies": {
+    "@mantine/form": "^6.0.17"
   }
 }


### PR DESCRIPTION
# Summary
This PR allows users to add an artifact comment to a **draft** resource.

## New behavior

On the review page for an artifact, users will be greeted with a `use-form mantine` component in the `add comment` tab panel. Via the form, users can enter the following information: The comment, their name, [the comment type](https://build.fhir.org/ig/HL7/cqf-measures/CodeSystem-artifact-comment-type.html), and whether they would like to include the date or not. The exact current date/time is what will be added to the artifact comment if the user chooses to include the date. Amongst these 4 parameters, only the comment type and the actual comment are needed in order to submit the form. Upon submitting the form, the submit button should show a `loader icon` for 1 millisecond, the form properties should clear themselves, and the new comment should now be loaded in the JSON content. In the JSON itself, the new artifact comment should appear as a `fhir4.Extension array of objects` in another `fhir4.Extension array`. 

When the user enters input into all of the components in the form, the new extension array of objects should look like the following:
![Screenshot 2023-07-24 at 5 27 32 PM](https://github.com/projecttacoma/measure-repository/assets/98363677/aaedf9ab-d893-42d0-8f81-06c3065cec9d)
If the user opted to not include a name then the object with "user" as the url should not appear. If the user doesn't include the date then the object with the url equal to "authoredOn" should not appear.
Users can enter as many comments as they would like and the artifact comments will persist even if the user navigates away from the page. The user will be able to submit these forms in both authoring/repository mode, however the JSON content will only be permanently changed for draft artifacts.

## Code changes
`"@mantine/form"` --> I installed the "@mantine/form" dependency in order to add a form on this page.
`form` --> The form object is composed of all of the mantine components the user must enter input into in order to submit the form. It will double check that the user entered their input in the proper format.
`HoverCard` --> When the user hovers their mouse over the `IconInfoHexagonFilled` icon/ information icon next to the select mantine component, a hover card should pop up explaining the different comment types in more detail.
`updateDraft` --> In order to update a draft resource, I call the trpc procedure updateDraft. This is the reason why only draft resources have their JSON permanently changed.

# Testing guidance
```
Npm run check:all 
Npm run start:all
```
Navigate to the review page for a draft resource artifact. An extension array should already be present in the JSON, although it may have no content entered into it. First fill out the form with all of the information included. Once you click submit, the extension array in the JSON should have a new `fhir4.Extension array of objects` that looks like the above image and a success notification should pop up. Now, try entering as many other comments as you'd like with any combination of input fields. As long as the comment type and comment are filled out, the comment should have no errors when the user clicks submit. Otherwise, the mantine component  that caused the error will highlight red and some text will pop up about what went wrong. Lastly, navigate away from the draft artifact and return to the same review page, all of the comments should still appear in the JSON. 