### PR TITLE
Cache data-requirements

### DIFF
--- a/app/src/pages/authoring/[resourceType]/[id].tsx
+++ b/app/src/pages/authoring/[resourceType]/[id].tsx
@@ -253,11 +253,7 @@ export default function ResourceAuthoringPage() {
               >
                 Update
               </Button>
-              <Button
-                w={120}
-                onClick={() => setIsModalOpen(true)}
-                //TODO/question: disabled={} any disable needed? any necessary fields?
-              >
+              <Button w={120} onClick={() => setIsModalOpen(true)}>
                 Release
               </Button>
             </Group>

--- a/package-lock.json
+++ b/package-lock.json
@@ -12331,7 +12331,7 @@
         "cors": "^2.8.5",
         "dotenv": "^16.0.3",
         "express": "^4.18.2",
-        "fqm-execution": "git+https://git@github.com/projecttacoma/fqm-execution.git#30bc9603da4361e49b48f86d21f33ca6b46339ea",
+        "fqm-execution": "git+https://git@github.com/projecttacoma/fqm-execution",
         "mongodb": "^4.17.0",
         "uuid": "^9.0.0",
         "zod": "^3.20.2"
@@ -18442,7 +18442,7 @@
         "eslint": "^8.28.0",
         "eslint-config-prettier": "^8.5.0",
         "express": "^4.18.2",
-        "fqm-execution": "git+https://git@github.com/projecttacoma/fqm-execution.git#30bc9603da4361e49b48f86d21f33ca6b46339ea",
+        "fqm-execution": "git+https://git@github.com/projecttacoma/fqm-execution",
         "jest": "^29.3.1",
         "mongodb": "^4.17.0",
         "nock": "^13.3.0",

--- a/service/src/db/dbOperations.ts
+++ b/service/src/db/dbOperations.ts
@@ -1,4 +1,4 @@
-import { loggers, FhirResourceType } from '@projecttacoma/node-fhir-server-core';
+import { FhirResourceType, loggers } from '@projecttacoma/node-fhir-server-core';
 import { Filter } from 'mongodb';
 import { Connection } from './Connection';
 
@@ -9,7 +9,7 @@ const logger = loggers.get('default');
  */
 export async function findResourceById<T extends fhir4.FhirResource>(id: string, resourceType: FhirResourceType) {
   const collection = Connection.db.collection(resourceType);
-  return collection.findOne<T>({ id: id }, { projection: { _id: 0 } });
+  return collection.findOne<T>({ id: id, _dataRequirements: { $exists: false } }, { projection: { _id: 0 } });
 }
 
 /**
@@ -20,7 +20,16 @@ export async function findResourcesWithQuery<T extends fhir4.FhirResource>(
   resourceType: FhirResourceType
 ) {
   const collection = Connection.db.collection(resourceType);
-  return collection.find<T>(query, { projection: { _id: 0 } }).toArray();
+  query._dataRequirements = { $exists: false };
+  return collection.find<T>(query, { projection: { _id: 0, _dataRequirements: 0 } }).toArray();
+}
+
+/**
+ * searches the database for the data requirements Library resource of the desired artifact and parameters
+ */
+export async function findDataRequirementsWithQuery<T extends fhir4.Library>(query: Filter<any>) {
+  const collection = Connection.db.collection('Library');
+  return collection.findOne<T>({ _dataRequirements: query }, { projection: { _id: 0, _dataRequirements: 0 } });
 }
 
 /**

--- a/service/src/db/dbOperations.ts
+++ b/service/src/db/dbOperations.ts
@@ -9,7 +9,7 @@ const logger = loggers.get('default');
  */
 export async function findResourceById<T extends fhir4.FhirResource>(id: string, resourceType: FhirResourceType) {
   const collection = Connection.db.collection(resourceType);
-  return collection.findOne<T>({ id: id, _dataRequirements: { $exists: false } }, { projection: { _id: 0 } });
+  return collection.findOne<T>({ id: id }, { projection: { _id: 0, _dataRequirements: 0 } });
 }
 
 /**

--- a/service/src/services/LibraryService.ts
+++ b/service/src/services/LibraryService.ts
@@ -1,12 +1,12 @@
 import { loggers, RequestArgs, RequestCtx } from '@projecttacoma/node-fhir-server-core';
 import {
+  createResource,
   findDataRequirementsWithQuery,
   findResourceById,
   findResourcesWithQuery,
   updateResource
 } from '../db/dbOperations';
 import { LibrarySearchArgs, LibraryDataRequirementsArgs, PackageArgs, parseRequestSchema } from '../requestSchemas';
-import { createResource } from '../db/dbOperations';
 import { Service } from '../types/service';
 import { createLibraryPackageBundle, createSearchsetBundle } from '../util/bundleUtils';
 import { BadRequestError, ResourceNotFoundError } from '../util/errorUtils';
@@ -22,7 +22,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { Calculator } from 'fqm-execution';
 const logger = loggers.get('default');
 import { Filter } from 'mongodb';
-import { FhirResourceWithDR } from '../types/service-types';
+import { FhirLibraryWithDR } from '../types/service-types';
 
 /*
  * Implementation of a service for the `Library` resource
@@ -158,7 +158,7 @@ export class LibraryService implements Service<fhir4.Library> {
     });
 
     dataRequirements.results['id'] = uuidv4();
-    const results = { ...dataRequirements.results } as FhirResourceWithDR;
+    const results = { ...dataRequirements.results } as FhirLibraryWithDR;
 
     // add the data requirements query params to the data requirements Library resource and add to the Library collection
     results['_dataRequirements'] = dataReqsQuery;

--- a/service/src/services/LibraryService.ts
+++ b/service/src/services/LibraryService.ts
@@ -158,9 +158,9 @@ export class LibraryService implements Service<fhir4.Library> {
     });
 
     dataRequirements.results['id'] = uuidv4();
-    const results = { ...dataRequirements.results } as FhirLibraryWithDR;
 
     // add the data requirements query params to the data requirements Library resource and add to the Library collection
+    const results = { ...dataRequirements.results } as FhirLibraryWithDR;
     results['_dataRequirements'] = dataReqsQuery;
     createResource(results, 'Library');
 

--- a/service/src/services/LibraryService.ts
+++ b/service/src/services/LibraryService.ts
@@ -1,5 +1,10 @@
 import { loggers, RequestArgs, RequestCtx } from '@projecttacoma/node-fhir-server-core';
-import { findResourceById, findResourcesWithQuery, updateResource } from '../db/dbOperations';
+import {
+  findDataRequirementsWithQuery,
+  findResourceById,
+  findResourcesWithQuery,
+  updateResource
+} from '../db/dbOperations';
 import { LibrarySearchArgs, LibraryDataRequirementsArgs, PackageArgs, parseRequestSchema } from '../requestSchemas';
 import { createResource } from '../db/dbOperations';
 import { Service } from '../types/service';
@@ -16,6 +21,8 @@ import {
 import { v4 as uuidv4 } from 'uuid';
 import { Calculator } from 'fqm-execution';
 const logger = loggers.get('default');
+import { Filter } from 'mongodb';
+import { FhirResourceWithDR } from '../types/service-types';
 
 /*
  * Implementation of a service for the `Library` resource
@@ -124,15 +131,40 @@ export class LibraryService implements Service<fhir4.Library> {
     const query = extractIdentificationForQuery(args, params);
     const parsedParams = parseRequestSchema({ ...params, ...query }, LibraryDataRequirementsArgs);
 
+    // check to see if data requirements were already calculated for this Library and params
+    const dataReqsQuery: Filter<any> = {};
+    Object.entries(parsedParams).forEach(p => {
+      if (p[0] === 'id') {
+        dataReqsQuery.resourceId = p[1] as string;
+      } else {
+        dataReqsQuery[p[0]] = p[1] as string;
+      }
+    });
+
+    const dataReqs = await findDataRequirementsWithQuery(dataReqsQuery);
+
+    // if data requirements were already calculated for this Library and params, return them
+    if (dataReqs) {
+      logger.info('Successfully retrieved $data-requirements report');
+      return dataReqs;
+    }
+
     logger.info(`${req.method} ${req.path}`);
 
     const { libraryBundle, rootLibRef } = await createLibraryPackageBundle(query, parsedParams);
 
-    const { results } = await Calculator.calculateLibraryDataRequirements(libraryBundle, {
+    const dataRequirements = await Calculator.calculateLibraryDataRequirements(libraryBundle, {
       ...(rootLibRef && { rootLibRef })
     });
 
+    dataRequirements.results['id'] = uuidv4();
+    const results = { ...dataRequirements.results } as FhirResourceWithDR;
+
+    // add the data requirements query params to the data requirements Library resource and add to the Library collection
+    results['_dataRequirements'] = dataReqsQuery;
+    createResource(results, 'Library');
+
     logger.info('Successfully generated $data-requirements report');
-    return results;
+    return dataRequirements.results;
   }
 }

--- a/service/src/services/LibraryService.ts
+++ b/service/src/services/LibraryService.ts
@@ -145,7 +145,7 @@ export class LibraryService implements Service<fhir4.Library> {
 
     // if data requirements were already calculated for this Library and params, return them
     if (dataReqs) {
-      logger.info('Successfully retrieved $data-requirements report');
+      logger.info('Successfully retrieved $data-requirements report from cache.');
       return dataReqs;
     }
 

--- a/service/src/services/MeasureService.ts
+++ b/service/src/services/MeasureService.ts
@@ -162,11 +162,10 @@ export class MeasureService implements Service<fhir4.Measure> {
     });
 
     dataRequirements.results['id'] = uuidv4();
-    const results = { ...dataRequirements.results } as FhirLibraryWithDR;
-
-    results['_dataRequirements'] = dataReqsQuery;
 
     // add the data requirements query params to the data requirements Library resource and add to the Library collection
+    const results = { ...dataRequirements.results } as FhirLibraryWithDR;
+    results['_dataRequirements'] = dataReqsQuery;
     createResource(results, 'Library');
 
     logger.info('Successfully generated $data-requirements report');

--- a/service/src/services/MeasureService.ts
+++ b/service/src/services/MeasureService.ts
@@ -1,5 +1,11 @@
 import { loggers, RequestArgs, RequestCtx } from '@projecttacoma/node-fhir-server-core';
-import { findDataRequirementsWithQuery, findResourceById, findResourcesWithQuery } from '../db/dbOperations';
+import {
+  createResource,
+  findDataRequirementsWithQuery,
+  findResourceById,
+  findResourcesWithQuery,
+  updateResource
+} from '../db/dbOperations';
 import { Service } from '../types/service';
 import { createMeasurePackageBundle, createSearchsetBundle } from '../util/bundleUtils';
 import { BadRequestError, ResourceNotFoundError } from '../util/errorUtils';
@@ -14,7 +20,6 @@ import {
 import { Calculator } from 'fqm-execution';
 import { MeasureSearchArgs, MeasureDataRequirementsArgs, PackageArgs, parseRequestSchema } from '../requestSchemas';
 import { v4 as uuidv4 } from 'uuid';
-import { createResource, updateResource } from '../db/dbOperations';
 import { Filter } from 'mongodb';
 import { FhirLibraryWithDR } from '../types/service-types';
 
@@ -139,7 +144,7 @@ export class MeasureService implements Service<fhir4.Measure> {
 
     // if data requirements were already calculated for this Measure and params, return them
     if (dataReqs) {
-      logger.info('Successfully retrieved $data-requirements report');
+      logger.info('Successfully retrieved $data-requirements report from cache.');
       return dataReqs;
     }
 

--- a/service/src/services/MeasureService.ts
+++ b/service/src/services/MeasureService.ts
@@ -16,7 +16,7 @@ import { MeasureSearchArgs, MeasureDataRequirementsArgs, PackageArgs, parseReque
 import { v4 as uuidv4 } from 'uuid';
 import { createResource, updateResource } from '../db/dbOperations';
 import { Filter } from 'mongodb';
-import { FhirResourceWithDR } from '../types/service-types';
+import { FhirLibraryWithDR } from '../types/service-types';
 
 const logger = loggers.get('default');
 
@@ -157,7 +157,7 @@ export class MeasureService implements Service<fhir4.Measure> {
     });
 
     dataRequirements.results['id'] = uuidv4();
-    const results = { ...dataRequirements.results } as FhirResourceWithDR;
+    const results = { ...dataRequirements.results } as FhirLibraryWithDR;
 
     results['_dataRequirements'] = dataReqsQuery;
 

--- a/service/src/services/MeasureService.ts
+++ b/service/src/services/MeasureService.ts
@@ -1,5 +1,5 @@
 import { loggers, RequestArgs, RequestCtx } from '@projecttacoma/node-fhir-server-core';
-import { findResourceById, findResourcesWithQuery } from '../db/dbOperations';
+import { findDataRequirementsWithQuery, findResourceById, findResourcesWithQuery } from '../db/dbOperations';
 import { Service } from '../types/service';
 import { createMeasurePackageBundle, createSearchsetBundle } from '../util/bundleUtils';
 import { BadRequestError, ResourceNotFoundError } from '../util/errorUtils';
@@ -15,6 +15,8 @@ import { Calculator } from 'fqm-execution';
 import { MeasureSearchArgs, MeasureDataRequirementsArgs, PackageArgs, parseRequestSchema } from '../requestSchemas';
 import { v4 as uuidv4 } from 'uuid';
 import { createResource, updateResource } from '../db/dbOperations';
+import { Filter } from 'mongodb';
+import { FhirResourceWithDR } from '../types/service-types';
 
 const logger = loggers.get('default');
 
@@ -121,8 +123,25 @@ export class MeasureService implements Service<fhir4.Measure> {
     const params = gatherParams(req.query, args.resource);
     validateParamIdSource(req.params.id, params.id);
     const query = extractIdentificationForQuery(args, params);
-
     const parsedParams = parseRequestSchema({ ...params, ...query }, MeasureDataRequirementsArgs);
+
+    // check to see if data requirements were already calculated for this Measure and params
+    const dataReqsQuery: Filter<any> = {};
+    Object.entries(parsedParams).forEach(p => {
+      if (p[0] === 'id') {
+        dataReqsQuery.resourceId = p[1] as string;
+      } else {
+        dataReqsQuery[p[0]] = p[1] as string;
+      }
+    });
+
+    const dataReqs = await findDataRequirementsWithQuery(dataReqsQuery);
+
+    // if data requirements were already calculated for this Measure and params, return them
+    if (dataReqs) {
+      logger.info('Successfully retrieved $data-requirements report');
+      return dataReqs;
+    }
 
     logger.info(`${req.method} ${req.path}`);
 
@@ -132,12 +151,20 @@ export class MeasureService implements Service<fhir4.Measure> {
     // periodStart and periodEnd should be optional. Right now, fqm-execution will default it to 2019.
     // This will be handled in a separate task
     // TODO: Update the fqm-execution dependency and delete this comment block once periodStart/End can safely be excluded
-    const { results } = await Calculator.calculateDataRequirements(measureBundle, {
+    const dataRequirements = await Calculator.calculateDataRequirements(measureBundle, {
       ...(parsedParams.periodStart && { measurementPeriodStart: parsedParams.periodStart }),
       ...(parsedParams.periodEnd && { measurementPeriodEnd: parsedParams.periodEnd })
     });
 
+    dataRequirements.results['id'] = uuidv4();
+    const results = { ...dataRequirements.results } as FhirResourceWithDR;
+
+    results['_dataRequirements'] = dataReqsQuery;
+
+    // add the data requirements query params to the data requirements Library resource and add to the Library collection
+    createResource(results, 'Library');
+
     logger.info('Successfully generated $data-requirements report');
-    return results;
+    return dataRequirements.results;
   }
 }

--- a/service/src/types/service-types.ts
+++ b/service/src/types/service-types.ts
@@ -1,5 +1,5 @@
 import { Filter } from 'mongodb';
 
-export type FhirResourceWithDR = fhir4.Library & {
+export type FhirLibraryWithDR = fhir4.Library & {
   _dataRequirements?: Filter<any>;
 };

--- a/service/src/types/service-types.ts
+++ b/service/src/types/service-types.ts
@@ -1,0 +1,5 @@
+import { Filter } from 'mongodb';
+
+export type FhirResourceWithDR = fhir4.Library & {
+  _dataRequirements?: Filter<any>;
+};

--- a/service/test/services/LibraryService.test.ts
+++ b/service/test/services/LibraryService.test.ts
@@ -463,16 +463,19 @@ describe('LibraryService', () => {
   });
 
   describe('$data-requirements', () => {
-    // spy on calculation function
-    const calc = jest.spyOn(Calculator, 'calculateLibraryDataRequirements').mockResolvedValue({
-      results: {
-        resourceType: 'Library',
-        type: {
-          coding: [{ code: 'module-definition', system: 'http://terminology.hl7.org/CodeSystem/library-type' }]
-        },
-        status: 'draft',
-        dataRequirement: []
-      }
+    let calc: any;
+    beforeEach(() => {
+      // spy on calculation function
+      calc = jest.spyOn(Calculator, 'calculateLibraryDataRequirements').mockResolvedValue({
+        results: {
+          resourceType: 'Library',
+          type: {
+            coding: [{ code: 'module-definition', system: 'http://terminology.hl7.org/CodeSystem/library-type' }]
+          },
+          status: 'draft',
+          dataRequirement: []
+        }
+      });
     });
 
     it('returns 200 and a Library for a simple Library with url, version, dependencies', async () => {

--- a/service/test/services/MeasureService.test.ts
+++ b/service/test/services/MeasureService.test.ts
@@ -447,16 +447,19 @@ describe('MeasureService', () => {
   });
 
   describe('$data-requirements', () => {
-    // spy on calculation function
-    const calc = jest.spyOn(Calculator, 'calculateDataRequirements').mockResolvedValue({
-      results: {
-        resourceType: 'Library',
-        type: {
-          coding: [{ code: 'module-definition', system: 'http://terminology.hl7.org/CodeSystem/library-type' }]
-        },
-        status: 'draft',
-        dataRequirement: []
-      }
+    let calc: any;
+    beforeEach(() => {
+      // spy on calculation function
+      calc = jest.spyOn(Calculator, 'calculateDataRequirements').mockResolvedValue({
+        results: {
+          resourceType: 'Library',
+          type: {
+            coding: [{ code: 'module-definition', system: 'http://terminology.hl7.org/CodeSystem/library-type' }]
+          },
+          status: 'draft',
+          dataRequirement: []
+        }
+      });
     });
 
     it('returns 200 and a Library for a simple measure with dependencies and no period params', async () => {


### PR DESCRIPTION
# Summary
When the `$data-requirements` for a specific artifact and set of parameters are calculated, they are then cached in the mongo database that stores active artifacts so that these Library data requirements resources can be accessed again without having to rerun calculation. 

## New behavior
Before, whenever the user requested the data-requirements for an artifact (either with the `$data-requirements` endpoint or in the UI, the data-requirements calculation was done each time. In order to improve performance in our application, we now cache these Library resources in the Library collection in the published repository service.

## Method:
We talked about different strategies for how to cache data-requirements and where but ultimately settled on the following (for now):
1. When the user navigates to an artifact's page in the UI, `$data-requirements` is called (same behavior as before). 
2. Before, this endpoint would _only_ calculate the data-requirements of a Library or Measure and simply return them. Now, we look in the Library collection to see if the data-requirements of the requested artifact and associated parameters have been calculated before and if so return them. If not, they are calculated and cached in the Library collection and the data-requirements are still returned.
3. We also decided to not calculate data-requirements for an artifact when it is released since the application will route to the released artifacts page which already calls `$data-requirements`.

## Code changes
- `app/src/pages/[resourceType]/[id].tsx` - On the main branch, you will notice some odd behavior in the relatedArtifacts in the Data Requirements tab of an artifact. The previous code was sorting the relatedArtifacts in place. I pulled the sortDependencies out to a function and this gets called on a copy of the relatedArtifacts of data requirements so that the relatedArtifacts are not sorted in place. The sort is only called when the dataRequirements value changes.
- `app/src/pages/authoring/[resourceType]/[id].tsx` - Removed comment
- `package-lock.json` - this changed when I did `npm install --workspace=app --workspace=service`...I think this is okay?
- `dbOperations.ts` - `findResourceById` and `findResourcesWithQuery` make sure to exclude Libraries that have `_dataRequirements` property (they are Library data requirements resources). `findDataRequirementswithQuery` returns the Library data requirements resource that is associated with an artifact and set of query parameters if it exists.
- `LibraryService.ts` / `MeasureService.ts` - `$data-requirements` endpoint now checks mongo collection for cached data requirements and returns it if it exists. If not, it calculates the data-requirements, caches them, and returns them.
- `service/src/types/service-types.ts` - new type for Library data requirements resources to additionally contain an optional `_dataRequirements` property that contains the query associated with the data requirements call.
- `LibraryService.test.ts` / `MeasureService.test.ts` - When `calc` was not reset each time, I was getting a mongo duplicate key error. 

# Testing guidance
- `npm run check:all`
- `npm run start:all` 

Things to look for:
- Functionality for Dependencies tab / search are the same.
- Data requirements is only calculated once for an artifact (you should see a bunch of logs for assembling the data requirements once and then after that only the message that they were successfully retrieved).
- Make sure that the data requirements Library resources are not displayed in any of the Library artifact lists.

One more thing:
- The data requirements output when it is first calculated is slightly different from the data requirements output when it is grabbed from the cache. This is due to `version` being undefined in the output from `fqm-execution`, so when it gets put in mongo it becomes "version"" null. I made that quick code change in mongo and did `npm link` to this repository to confirm that that was the issue and it is. So whenever that is fixed in `fqm-execution`, the outputs will be the same. For now, I am going to make a task to further investigate this in `fqm-execution` and hopefully address it.
