### PR TITLE
Assign ID to resources during bundle upload

### DIFF
--- a/app/src/components/DependencyCards.tsx
+++ b/app/src/components/DependencyCards.tsx
@@ -61,35 +61,38 @@ function Dependencies(props: myComponentProps) {
   }
 
   return (
-    <>
-      <Center>
-        <Paper className={classes.card} shadow="sm" p="md">
-          <Grid align="center">
-            <Grid.Col span={10}>
-              <div>
-                <Text size="lg" fw={700}>
-                  {display}
-                </Text>
-              </div>
-              <div>
-                <Text size="sm" fw={500}>
-                  {resourceLink}
-                </Text>
-              </div>
-            </Grid.Col>
-            {dependencyInfo.type && (
-              <Link href={`/${dependencyInfo.link}`}>
-                <Tooltip label={'Open Dependency Resource'} openDelay={1000}>
-                  <ActionIcon radius="md" size="md" variant="subtle" color="gray">
-                    {<SquareArrowRight size="24" />}
-                  </ActionIcon>
-                </Tooltip>
-              </Link>
-            )}
-          </Grid>
-        </Paper>
-      </Center>
-    </>
+    display &&
+    resourceLink && (
+      <>
+        <Center>
+          <Paper className={classes.card} shadow="sm" p="md">
+            <Grid align="center">
+              <Grid.Col span={10}>
+                <div>
+                  <Text size="lg" fw={700}>
+                    {display}
+                  </Text>
+                </div>
+                <div>
+                  <Text size="sm" fw={500}>
+                    {resourceLink}
+                  </Text>
+                </div>
+              </Grid.Col>
+              {dependencyInfo.type && (
+                <Link href={`/${dependencyInfo.link}`}>
+                  <Tooltip label={'Open Dependency Resource'} openDelay={1000}>
+                    <ActionIcon radius="md" size="md" variant="subtle" color="gray">
+                      {<SquareArrowRight size="24" />}
+                    </ActionIcon>
+                  </Tooltip>
+                </Link>
+              )}
+            </Grid>
+          </Paper>
+        </Center>
+      </>
+    )
   );
 }
 

--- a/app/src/components/DependencyCards.tsx
+++ b/app/src/components/DependencyCards.tsx
@@ -50,7 +50,7 @@ function Dependencies(props: myComponentProps) {
   //Canonicals for FHIR resources should be formatted in such a way that this code will work
   //to get the proper url that routes the user to the new page.
   // However, they can technically be anything and so we should potentially add
-  //some logic that handles viewing resource details using the canoncical URL of the resource as
+  //some logic that handles viewing resource details using the canonical URL of the resource as
   //the identifying information
   if (resourceLink?.includes('Library')) {
     const resourceArr: string[] = resourceLink.substring(resourceLink.indexOf('Library')).split('|');

--- a/app/src/components/DependencyCards.tsx
+++ b/app/src/components/DependencyCards.tsx
@@ -42,7 +42,7 @@ const useStyles = createStyles(theme => ({
 function Dependencies(props: myComponentProps) {
   const { classes } = useStyles();
   const display = props.relatedArtifact.display;
-  const resourceLink = props.relatedArtifact.resource;
+  const resourceLink = props.relatedArtifact.resource || props.relatedArtifact.url;
 
   let dependencyInfo: DependencyInformation = {};
 
@@ -60,7 +60,7 @@ function Dependencies(props: myComponentProps) {
     dependencyInfo = { type: 'Measure', link: resourceArr[0] };
   }
 
-  return display && resourceLink ? (
+  return resourceLink ? (
     <>
       <Center>
         <Paper className={classes.card} shadow="sm" p="md">
@@ -77,6 +77,7 @@ function Dependencies(props: myComponentProps) {
                 </Text>
               </div>
             </Grid.Col>
+            {/* TODO: we want to have the link refer to <resourceType>/<id>, so we need a way to find the id of the resource, and make that the link if it exists */}
             {dependencyInfo.type && (
               <Link href={`/${dependencyInfo.link}`}>
                 <Tooltip label={'Open Dependency Resource'} openDelay={1000}>

--- a/app/src/components/DependencyCards.tsx
+++ b/app/src/components/DependencyCards.tsx
@@ -60,40 +60,37 @@ function Dependencies(props: myComponentProps) {
     dependencyInfo = { type: 'Measure', link: resourceArr[0] };
   }
 
-  return (
-    display &&
-    resourceLink && (
-      <>
-        <Center>
-          <Paper className={classes.card} shadow="sm" p="md">
-            <Grid align="center">
-              <Grid.Col span={10}>
-                <div>
-                  <Text size="lg" fw={700}>
-                    {display}
-                  </Text>
-                </div>
-                <div>
-                  <Text size="sm" fw={500}>
-                    {resourceLink}
-                  </Text>
-                </div>
-              </Grid.Col>
-              {dependencyInfo.type && (
-                <Link href={`/${dependencyInfo.link}`}>
-                  <Tooltip label={'Open Dependency Resource'} openDelay={1000}>
-                    <ActionIcon radius="md" size="md" variant="subtle" color="gray">
-                      {<SquareArrowRight size="24" />}
-                    </ActionIcon>
-                  </Tooltip>
-                </Link>
-              )}
-            </Grid>
-          </Paper>
-        </Center>
-      </>
-    )
-  );
+  return display && resourceLink ? (
+    <>
+      <Center>
+        <Paper className={classes.card} shadow="sm" p="md">
+          <Grid align="center">
+            <Grid.Col span={10}>
+              <div>
+                <Text size="lg" fw={700}>
+                  {display}
+                </Text>
+              </div>
+              <div>
+                <Text size="sm" fw={500}>
+                  {resourceLink}
+                </Text>
+              </div>
+            </Grid.Col>
+            {dependencyInfo.type && (
+              <Link href={`/${dependencyInfo.link}`}>
+                <Tooltip label={'Open Dependency Resource'} openDelay={1000}>
+                  <ActionIcon radius="md" size="md" variant="subtle" color="gray">
+                    {<SquareArrowRight size="24" />}
+                  </ActionIcon>
+                </Tooltip>
+              </Link>
+            )}
+          </Grid>
+        </Paper>
+      </Center>
+    </>
+  ) : null;
 }
 
 export default Dependencies;

--- a/app/src/pages/[resourceType]/[id].tsx
+++ b/app/src/pages/[resourceType]/[id].tsx
@@ -25,7 +25,7 @@ import { useRouter } from 'next/router';
 import { modifyResourceToDraft } from '@/util/modifyResourceFields';
 import { trpc } from '@/util/trpc';
 import DataReqs from '@/components/DataRequirements';
-import Dependency from '@/components/DependencyCards';
+import Dependencies from '@/components/DependencyCards';
 
 /**
  * Component which displays the JSON/ELM/CQL/narrative/Data Requirements content of an individual resource using
@@ -239,7 +239,7 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
               <Space h="md" />
               <ScrollArea.Autosize mah={height * 0.8} type="hover">
                 {sortedDependencies.map(relatedArtifact => (
-                  <Dependency key={relatedArtifact.resource} relatedArtifact={relatedArtifact} />
+                  <Dependencies key={relatedArtifact.resource} relatedArtifact={relatedArtifact} />
                 ))}
               </ScrollArea.Autosize>
               <Space h="md" />

--- a/app/src/pages/[resourceType]/[id].tsx
+++ b/app/src/pages/[resourceType]/[id].tsx
@@ -80,7 +80,7 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
 
   useEffect(() => {
     if (dataRequirements?.relatedArtifact) {
-      setSortedDependencies(sortDependencies(dataRequirements.relatedArtifact.filter(r => r.resource)));
+      setSortedDependencies(sortDependencies(dataRequirements.relatedArtifact));
     }
   }, [dataRequirements]);
 

--- a/app/src/pages/[resourceType]/[id].tsx
+++ b/app/src/pages/[resourceType]/[id].tsx
@@ -80,7 +80,7 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
 
   useEffect(() => {
     if (dataRequirements?.relatedArtifact) {
-      setSortedDependencies(sortDependencies(dataRequirements.relatedArtifact));
+      setSortedDependencies(sortDependencies(dataRequirements.relatedArtifact.filter(r => r.resource)));
     }
   }, [dataRequirements]);
 

--- a/service/scripts/dbSetup.ts
+++ b/service/scripts/dbSetup.ts
@@ -2,6 +2,7 @@ import { Connection } from '../src/db/Connection';
 import * as fs from 'fs';
 import * as dotenv from 'dotenv';
 import { MongoError } from 'mongodb';
+import { v4 as uuidv4 } from 'uuid';
 dotenv.config();
 
 const DB_URL = process.env.DATABASE_URL || 'mongodb://localhost:27017/measure-repository';
@@ -54,6 +55,9 @@ async function loadBundle(filePath: string) {
           (res?.resource?.resourceType === 'Library' || res?.resource?.resourceType === 'Measure')
         ) {
           try {
+            if (!res.resource.id) {
+              res.resource.id = uuidv4();
+            }
             const collection = Connection.db.collection<fhir4.FhirResource>(res.resource.resourceType);
             console.log(`Inserting ${res?.resource?.resourceType}/${res.resource.id} into database`);
             await collection.insertOne(res.resource);


### PR DESCRIPTION
# Summary
Adds an `id` to resources uploaded to the measure repository service via the `db:loadBundle` script. Adds handling for dependency card rendering.

## New behavior
The `db:loadBundle` script does not check for the presence of an id on the uploaded artifacts, and so artifacts can be uploaded to the server that do not have an `id`. This causes apps that consume the measure repository endpoints (i.e. `[id]/$package` in `fqm-testify`) to throw errors.

The script now adds a new `uuid` to a resource if an `id` is not pre-defined on the resource prior to upload.

Additionally, filters out related artifacts without the `.resource` field. This will filter out resources that use `.url` instead.

## Code changes
* App/src/pages/[resourceType]/[id].tsx —> adds related artifact filtering
* Service/scripts/dbSetup.ts —> adds uuid to uploaded resources

# Testing guidance
- Test on the main branch with a bundle that contains a resource that does not have a defined `id`. Example commands: `npm run db:reset` —> `npm run db:loadBundle <bundle path>` and check the output for

```bash
Inserting Measure/undefined into database
```

Or 

```bash
Inserting Library/undefined into database
```

- Test on this branch with a bundle that contains a resource that does not have a defined `id`. Check that all artifacts uploaded contain an id.
- Once uploaded, try to search by id for the resource, package by id, etc. to ensure that the endpoints dependent on id function as expected for the resource.
- Test that there are no blank dependency cards rendered. On the main branch, the related artifacts without `.resource` still get rendered as blank cards. Check that this is not the case on this branch and that they get filtered out