### PR TITLE
Update package endpoint to cqfm.package

### DIFF
--- a/service/README.md
+++ b/service/README.md
@@ -87,12 +87,14 @@ The Measure Repository Service server supports `Library` and `Measure` resource 
 
 ### Package
 
-The Measure Repository Service server supports the `Library` and `Measure` `$package` operation with the `id` and `identifier` parameters and SHALL parameters specified in the shareable measure repository section of the [HL7 Measure Repository Docs](https://build.fhir.org/ig/HL7/cqf-measures/measure-repository-service.html#publishable-measure-repository). Accepted parameters are:
+The Measure Repository Service server supports the `Library` and `Measure` `$cqfm-package` operation with the `id` and `identifier` parameters and SHALL parameters specified in the shareable measure repository section of the [HL7 Measure Repository Docs](https://build.fhir.org/ig/HL7/cqf-measures/measure-repository-service.html#publishable-measure-repository). Accepted parameters are:
 
 - id
 - url
 - identifier
 - version
+
+See the [`$cqfm-package` OperationDefinition](http://hl7.org/fhir/us/cqfmeasures/STU4/OperationDefinition-cqfm-package.html) for more information.
 
 ### Data Requirements
 

--- a/service/src/config/capabilityStatementResources.json
+++ b/service/src/config/capabilityStatementResources.json
@@ -140,7 +140,7 @@
               "valueCode": "SHALL"
             }
           ],
-          "name": "package",
+          "name": "cqfm-package",
           "definition": "http://hl7.org/fhir/us/cqfmeasures/OperationDefinition/cqfm-package"
         },
         {

--- a/service/src/config/capabilityStatementResources.json
+++ b/service/src/config/capabilityStatementResources.json
@@ -141,7 +141,7 @@
             }
           ],
           "name": "package",
-          "definition": "http://hl7.org/fhir/us/cqfmeasures/OperationDefinition/Library-package"
+          "definition": "http://hl7.org/fhir/us/cqfmeasures/OperationDefinition/cqfm-package"
         },
         {
           "extension": [
@@ -297,7 +297,7 @@
             }
           ],
           "name": "package",
-          "definition": "http://hl7.org/fhir/us/cqfmeasures/OperationDefinition/Measure-package"
+          "definition": "http://hl7.org/fhir/us/cqfmeasures/OperationDefinition/cqfm-package"
         },
         {
           "extension": [

--- a/service/src/config/capabilityStatementResources.json
+++ b/service/src/config/capabilityStatementResources.json
@@ -296,7 +296,7 @@
               "valueCode": "SHALL"
             }
           ],
-          "name": "package",
+          "name": "cqfm-package",
           "definition": "http://hl7.org/fhir/us/cqfmeasures/OperationDefinition/cqfm-package"
         },
         {

--- a/service/src/config/serverConfig.ts
+++ b/service/src/config/serverConfig.ts
@@ -39,25 +39,25 @@ export const serverConfig: ServerConfig = {
       versions: [constants.VERSIONS['4_0_1']],
       operation: [
         {
-          name: 'package',
+          name: 'cqfm.package',
           route: '/$cqfm.package',
           method: 'GET',
           reference: 'http://hl7.org/fhir/us/cqfmeasures/OperationDefinition/cqfm-package'
         },
         {
-          name: 'package',
+          name: 'cqfm.package',
           route: '/$cqfm.package',
           method: 'POST',
           reference: 'http://hl7.org/fhir/us/cqfmeasures/OperationDefinition/cqfm-package'
         },
         {
-          name: 'package',
+          name: 'cqfm.package',
           route: '/:id/$cqfm.package',
           method: 'GET',
           reference: 'http://hl7.org/fhir/us/cqfmeasures/OperationDefinition/cqfm-package'
         },
         {
-          name: 'package',
+          name: 'cqfm.package',
           route: '/:id/$cqfm.package',
           method: 'POST',
           reference: 'http://hl7.org/fhir/us/cqfmeasures/OperationDefinition/cqfm-package'
@@ -93,25 +93,25 @@ export const serverConfig: ServerConfig = {
       versions: [constants.VERSIONS['4_0_1']],
       operation: [
         {
-          name: 'package',
+          name: 'cqfm.package',
           route: '/$cqfm.package',
           method: 'GET',
           reference: 'http://hl7.org/fhir/us/cqfmeasures/OperationDefinition/cqfm-package'
         },
         {
-          name: 'package',
+          name: 'cqfm.package',
           route: '/$cqfm.package',
           method: 'POST',
           reference: 'http://hl7.org/fhir/us/cqfmeasures/OperationDefinition/cqfm-package'
         },
         {
-          name: 'package',
+          name: 'cqfm.package',
           route: '/:id/$cqfm.package',
           method: 'GET',
           reference: 'http://hl7.org/fhir/us/cqfmeasures/OperationDefinition/cqfm-package'
         },
         {
-          name: 'package',
+          name: 'cqfm.package',
           route: '/:id/$cqfm.package',
           method: 'POST',
           reference: 'http://hl7.org/fhir/us/cqfmeasures/OperationDefinition/cqfm-package'

--- a/service/src/config/serverConfig.ts
+++ b/service/src/config/serverConfig.ts
@@ -39,25 +39,25 @@ export const serverConfig: ServerConfig = {
       versions: [constants.VERSIONS['4_0_1']],
       operation: [
         {
-          name: 'cqfm.package',
+          name: 'package',
           route: '/$cqfm.package',
           method: 'GET',
           reference: 'http://hl7.org/fhir/us/cqfmeasures/OperationDefinition/cqfm-package'
         },
         {
-          name: 'cqfm.package',
+          name: 'package',
           route: '/$cqfm.package',
           method: 'POST',
           reference: 'http://hl7.org/fhir/us/cqfmeasures/OperationDefinition/cqfm-package'
         },
         {
-          name: 'cqfm.package',
+          name: 'package',
           route: '/:id/$cqfm.package',
           method: 'GET',
           reference: 'http://hl7.org/fhir/us/cqfmeasures/OperationDefinition/cqfm-package'
         },
         {
-          name: 'cqfm.package',
+          name: 'package',
           route: '/:id/$cqfm.package',
           method: 'POST',
           reference: 'http://hl7.org/fhir/us/cqfmeasures/OperationDefinition/cqfm-package'
@@ -93,25 +93,25 @@ export const serverConfig: ServerConfig = {
       versions: [constants.VERSIONS['4_0_1']],
       operation: [
         {
-          name: 'cqfm.package',
+          name: 'package',
           route: '/$cqfm.package',
           method: 'GET',
           reference: 'http://hl7.org/fhir/us/cqfmeasures/OperationDefinition/cqfm-package'
         },
         {
-          name: 'cqfm.package',
+          name: 'package',
           route: '/$cqfm.package',
           method: 'POST',
           reference: 'http://hl7.org/fhir/us/cqfmeasures/OperationDefinition/cqfm-package'
         },
         {
-          name: 'cqfm.package',
+          name: 'package',
           route: '/:id/$cqfm.package',
           method: 'GET',
           reference: 'http://hl7.org/fhir/us/cqfmeasures/OperationDefinition/cqfm-package'
         },
         {
-          name: 'cqfm.package',
+          name: 'package',
           route: '/:id/$cqfm.package',
           method: 'POST',
           reference: 'http://hl7.org/fhir/us/cqfmeasures/OperationDefinition/cqfm-package'

--- a/service/src/config/serverConfig.ts
+++ b/service/src/config/serverConfig.ts
@@ -40,27 +40,27 @@ export const serverConfig: ServerConfig = {
       operation: [
         {
           name: 'package',
-          route: '/$package',
+          route: '/$cqfm.package',
           method: 'GET',
-          reference: 'http://hl7.org/fhir/us/cqfmeasures/OperationDefinition/Measure-package'
+          reference: 'http://hl7.org/fhir/us/cqfmeasures/OperationDefinition/cqfm-package'
         },
         {
           name: 'package',
-          route: '/$package',
+          route: '/$cqfm.package',
           method: 'POST',
-          reference: 'http://hl7.org/fhir/us/cqfmeasures/OperationDefinition/Measure-package'
+          reference: 'http://hl7.org/fhir/us/cqfmeasures/OperationDefinition/cqfm-package'
         },
         {
           name: 'package',
-          route: '/:id/$package',
+          route: '/:id/$cqfm.package',
           method: 'GET',
-          reference: 'http://hl7.org/fhir/us/cqfmeasures/OperationDefinition/Measure-package'
+          reference: 'http://hl7.org/fhir/us/cqfmeasures/OperationDefinition/cqfm-package'
         },
         {
           name: 'package',
-          route: '/:id/$package',
+          route: '/:id/$cqfm.package',
           method: 'POST',
-          reference: 'http://hl7.org/fhir/us/cqfmeasures/OperationDefinition/Measure-package'
+          reference: 'http://hl7.org/fhir/us/cqfmeasures/OperationDefinition/cqfm-package'
         },
         {
           name: 'dataRequirements',
@@ -94,27 +94,27 @@ export const serverConfig: ServerConfig = {
       operation: [
         {
           name: 'package',
-          route: '/$package',
+          route: '/$cqfm.package',
           method: 'GET',
-          reference: 'http://hl7.org/fhir/us/cqfmeasures/OperationDefinition/Library-package'
+          reference: 'http://hl7.org/fhir/us/cqfmeasures/OperationDefinition/cqfm-package'
         },
         {
           name: 'package',
-          route: '/$package',
+          route: '/$cqfm.package',
           method: 'POST',
-          reference: 'http://hl7.org/fhir/us/cqfmeasures/OperationDefinition/Library-package'
+          reference: 'http://hl7.org/fhir/us/cqfmeasures/OperationDefinition/cqfm-package'
         },
         {
           name: 'package',
-          route: '/:id/$package',
+          route: '/:id/$cqfm.package',
           method: 'GET',
-          reference: 'http://hl7.org/fhir/us/cqfmeasures/OperationDefinition/Library-package'
+          reference: 'http://hl7.org/fhir/us/cqfmeasures/OperationDefinition/cqfm-package'
         },
         {
           name: 'package',
-          route: '/:id/$package',
+          route: '/:id/$cqfm.package',
           method: 'POST',
-          reference: 'http://hl7.org/fhir/us/cqfmeasures/OperationDefinition/Library-package'
+          reference: 'http://hl7.org/fhir/us/cqfmeasures/OperationDefinition/cqfm-package'
         },
         {
           name: 'dataRequirements',

--- a/service/src/requestSchemas.ts
+++ b/service/src/requestSchemas.ts
@@ -121,6 +121,9 @@ export const IdentifyingParameters = z
   .partial();
 
 export const PackageArgs = IdentifyingParameters.extend({
+  // TODO: The canonical version parameters are generalizations of the system version parameters.
+  // Check that the canonical version params are preferred and that the system version params
+  // are no longer supported by the measure repository service
   canonicalVersion: z.string(),
   capability: z.string(),
   contentEndpoint: z.string(),

--- a/service/src/requestSchemas.ts
+++ b/service/src/requestSchemas.ts
@@ -9,8 +9,8 @@ const UNSUPPORTED_PACKAGE_ARGS = [
   'canonicalVersion',
   'capability',
   'checkCanonicalVersion',
-  // TODO: check whether it's supposed to be content or contact
-  'contactEndpoint',
+  // TODO: Both 'contentEndpoint' and 'contactEndpoint' are listed throughout the documentation.
+  // Default to 'contentEndpoint' for now since it is defined in the OperationDefinition.
   'contentEndpoint',
   'count',
   'forceCanonicalVersion',
@@ -121,18 +121,20 @@ export const IdentifyingParameters = z
   .partial();
 
 export const PackageArgs = IdentifyingParameters.extend({
-  // TODO: add the other, now supported params here?
+  canonicalVersion: z.string(),
   capability: z.string(),
-  // TODO: do more thorough check to see if the version params still exist
-  'check-system-version': z.string(),
+  contentEndpoint: z.string(),
+  checkCanonicalVersion: z.string(),
   count: stringToNumber,
-  'force-system-version': z.string(),
-  'include-components': stringToBool,
-  'include-dependencies': stringToBool,
-  // TODO: check whether this is still defined... we have support for it
+  forceCanonicalVersion: z.string(),
+  include: z.string(),
+  // The 'include-terminology' parameter is not defined in the OperationDefinition but we support it
+  // TODO: check if the 'include' param should encompass the 'include-terminology' functionality
   'include-terminology': stringToBool,
   manifest: z.string(),
   offset: stringToNumber,
+  packageOnly: stringToBool,
+  terminologyEndpoint: z.string(),
   'system-version': z.string()
 })
   .partial()

--- a/service/src/requestSchemas.ts
+++ b/service/src/requestSchemas.ts
@@ -4,17 +4,21 @@ import { BadRequestError, NotImplementedError } from './util/errorUtils';
 
 const DATE_REGEX = /([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)(-(0[1-9]|1[0-2])(-(0[1-9]|[1-2][0-9]|3[0-1]))?)/;
 
-// Operation Definition: https://build.fhir.org/ig/HL7/cqf-measures/measure-repository-service.html#package
+// Operation Definition: http://hl7.org/fhir/us/cqfmeasures/STU4/OperationDefinition-cqfm-package.html
 const UNSUPPORTED_PACKAGE_ARGS = [
+  'canonicalVersion',
   'capability',
-  'check-system-version',
+  'checkCanonicalVersion',
+  // TODO: check whether it's supposed to be content or contact
+  'contactEndpoint',
+  'contentEndpoint',
   'count',
-  'force-system-version',
-  'include-components',
-  'include-dependencies',
+  'forceCanonicalVersion',
+  'include',
   'manifest',
   'offset',
-  'system-version'
+  'packageOnly',
+  'terminologyEndpoint'
 ];
 
 // Operation Definition: https://build.fhir.org/ig/HL7/cqf-measures/measure-repository-service.html#requirements
@@ -117,12 +121,15 @@ export const IdentifyingParameters = z
   .partial();
 
 export const PackageArgs = IdentifyingParameters.extend({
+  // TODO: add the other, now supported params here?
   capability: z.string(),
+  // TODO: do more thorough check to see if the version params still exist
   'check-system-version': z.string(),
   count: stringToNumber,
   'force-system-version': z.string(),
   'include-components': stringToBool,
   'include-dependencies': stringToBool,
+  // TODO: check whether this is still defined... we have support for it
   'include-terminology': stringToBool,
   manifest: z.string(),
   offset: stringToNumber,

--- a/service/src/services/LibraryService.ts
+++ b/service/src/services/LibraryService.ts
@@ -90,7 +90,7 @@ export class LibraryService implements Service<fhir4.Library> {
 
   /**
    * result of sending a POST or GET request to:
-   * {BASE_URL}/4_0_1/Library/$package or {BASE_URL}/4_0_1/Library/:id/$package
+   * {BASE_URL}/4_0_1/Library/$cqfm.package or {BASE_URL}/4_0_1/Library/:id/$cqfm.package
    * creates a bundle of the library (specified by parameters) and all dependent libraries
    * requires parameters id, url, and/or identifier, but also supports version as supplemental (optional)
    */

--- a/service/src/services/MeasureService.ts
+++ b/service/src/services/MeasureService.ts
@@ -91,7 +91,7 @@ export class MeasureService implements Service<fhir4.Measure> {
 
   /**
    * result of sending a POST or GET request to:
-   * {BASE_URL}/4_0_1/Measure/$package or {BASE_URL}/4_0_1/Measure/:id/$package
+   * {BASE_URL}/4_0_1/Measure/$cqfm.package or {BASE_URL}/4_0_1/Measure/:id/$cqfm.package
    * creates a bundle of the measure (specified by parameters) and all dependent libraries
    * requires parameters id and/or url and/or identifier, but also supports version as supplemental (optional)
    */

--- a/service/src/util/bundleUtils.ts
+++ b/service/src/util/bundleUtils.ts
@@ -47,7 +47,7 @@ export async function createMeasurePackageBundle(
     throw new BadRequestError(
       `Multiple resources found in collection: Measure, with ${Object.keys(query)
         .map(key => `${key}: ${query[key]}`)
-        .join(' and ')}. /Measure/$package operation must specify a single Measure`
+        .join(' and ')}. /Measure/$cqfm.package operation must specify a single Measure`
     );
   }
 
@@ -95,7 +95,7 @@ export async function createLibraryPackageBundle(
     throw new BadRequestError(
       `Multiple resources found in collection: Library, with ${Object.keys(query)
         .map(key => `${key}: ${query[key]}`)
-        .join(' and ')}. /Library/$package operation must specify a single Library`
+        .join(' and ')}. /Library/$cqfm.package operation must specify a single Library`
     );
   }
   const libraryForPackaging = library[0];
@@ -114,7 +114,7 @@ export async function createLibraryPackageBundle(
 }
 
 /**
- * Takes in the main library from either Measure/$package or Library/$package
+ * Takes in the main library from either Measure/$cqfm.package or Library/$cqfm.package
  * and returns a bundle of all the dependent libraries
  */
 export async function createDepLibraryBundle(

--- a/service/src/util/inputUtils.ts
+++ b/service/src/util/inputUtils.ts
@@ -11,7 +11,7 @@ export function gatherParams(query: RequestQuery, parameters?: fhir4.Parameters)
   if (parameters?.parameter) {
     parameters.parameter.reduce((params, bodyParam) => {
       if (!bodyParam.resource) {
-        // Currently value types needed by $package (add others as needed)
+        // Currently value types needed by $cqfm.package (add others as needed)
         params[bodyParam.name as string] =
           bodyParam.valueUrl ||
           bodyParam.valueString ||

--- a/service/test/services/LibraryService.test.ts
+++ b/service/test/services/LibraryService.test.ts
@@ -240,10 +240,10 @@ describe('LibraryService', () => {
     });
   });
 
-  describe('$package', () => {
+  describe('$cqfm.package', () => {
     it('returns a Bundle including the Library when the Library has no dependencies and id passed through args', async () => {
       await supertest(server.app)
-        .get('/4_0_1/Library/testLibraryWithNoDeps/$package')
+        .get('/4_0_1/Library/testLibraryWithNoDeps/$cqfm.package')
         .expect(200)
         .then(response => {
           expect(response.body.resourceType).toEqual('Bundle');
@@ -254,7 +254,7 @@ describe('LibraryService', () => {
 
     it('returns a Bundle including the Library when the Library has no dependencies and id passed through body', async () => {
       await supertest(server.app)
-        .post('/4_0_1/Library/$package')
+        .post('/4_0_1/Library/$cqfm.package')
         .send({ resourceType: 'Parameters', parameter: [{ name: 'id', valueString: 'testLibraryWithNoDeps' }] })
         .set('content-type', 'application/fhir+json')
         .expect(200)
@@ -267,7 +267,7 @@ describe('LibraryService', () => {
 
     it('returns a Bundle including the Library and its dependent libraries when the Library has dependencies and id passed through args', async () => {
       await supertest(server.app)
-        .get('/4_0_1/Library/testLibraryWithDeps/$package')
+        .get('/4_0_1/Library/testLibraryWithDeps/$cqfm.package')
         .expect(200)
         .expect(200)
         .then(response => {
@@ -285,7 +285,7 @@ describe('LibraryService', () => {
 
     it('returns a Bundle including the Library and its dependent libraries when the Library has dependencies and id passed through body', async () => {
       await supertest(server.app)
-        .post('/4_0_1/Library/$package')
+        .post('/4_0_1/Library/$cqfm.package')
         .send({ resourceType: 'Parameters', parameter: [{ name: 'id', valueString: 'testLibraryWithDeps' }] })
         .set('content-type', 'application/fhir+json')
         .expect(200)
@@ -304,7 +304,7 @@ describe('LibraryService', () => {
 
     it('returns a Bundle including just the Library when the Library has no dependencies and identifier with just idenifier.value passed through body', async () => {
       await supertest(server.app)
-        .post('/4_0_1/Library/$package')
+        .post('/4_0_1/Library/$cqfm.package')
         .send({
           resourceType: 'Parameters',
           parameter: [{ name: 'identifier', valueString: 'libraryWithIdentifierValue' }]
@@ -320,7 +320,7 @@ describe('LibraryService', () => {
 
     it('returns a Bundle including just the Library when the Library has no dependencies and identifier with just identifier.system passed through body', async () => {
       await supertest(server.app)
-        .post('/4_0_1/Library/$package')
+        .post('/4_0_1/Library/$cqfm.package')
         .send({
           resourceType: 'Parameters',
           parameter: [{ name: 'identifier', valueString: 'http://example.com/libraryWithIdentifierSystem|' }]
@@ -336,7 +336,7 @@ describe('LibraryService', () => {
 
     it('returns a Bundle including just the Library when the Library has no dependencies and identifier with both identifier.system and identifier.value passed through body', async () => {
       await supertest(server.app)
-        .post('/4_0_1/Library/$package')
+        .post('/4_0_1/Library/$cqfm.package')
         .send({
           resourceType: 'Parameters',
           parameter: [
@@ -359,7 +359,7 @@ describe('LibraryService', () => {
 
     it('throws a 400 error when only an identifier system is included in the body but there are two libraries with that identifier.system', async () => {
       await supertest(server.app)
-        .post('/4_0_1/Library/$package')
+        .post('/4_0_1/Library/$cqfm.package')
         .send({
           resourceType: 'Parameters',
           parameter: [
@@ -374,14 +374,14 @@ describe('LibraryService', () => {
         .then(response => {
           expect(response.body.issue[0].code).toEqual('invalid');
           expect(response.body.issue[0].details.text).toEqual(
-            'Multiple resources found in collection: Library, with identifier: http://example.com/libraryWithSameSystem|. /Library/$package operation must specify a single Library'
+            'Multiple resources found in collection: Library, with identifier: http://example.com/libraryWithSameSystem|. /Library/$cqfm.package operation must specify a single Library'
           );
         });
     });
 
     it('throws a 400 error when no url or id included in request', async () => {
       await supertest(server.app)
-        .post('/4_0_1/Library/$package')
+        .post('/4_0_1/Library/$cqfm.package')
         .send({ resourceType: 'Parameters', parameter: [] })
         .set('content-type', 'application/fhir+json')
         .expect(400)
@@ -395,7 +395,7 @@ describe('LibraryService', () => {
 
     it('throws a 400 error when an id is included in both the path and a FHIR parameter', async () => {
       await supertest(server.app)
-        .post('/4_0_1/Library/testLibraryWithDeps/$package')
+        .post('/4_0_1/Library/testLibraryWithDeps/$cqfm.package')
         .send({ resourceType: 'Parameters', parameter: [{ name: 'id', valueString: 'testLibraryWithDeps' }] })
         .set('content-type', 'application/fhir+json')
         .expect(400)
@@ -409,7 +409,7 @@ describe('LibraryService', () => {
 
     it('throws a 400 error when an id is included in both the path and a query parameter', async () => {
       await supertest(server.app)
-        .get('/4_0_1/Library/testLibraryWithDeps/$package')
+        .get('/4_0_1/Library/testLibraryWithDeps/$cqfm.package')
         .query({ id: 'testLibraryWithDeps' })
         .set('content-type', 'application/fhir+json')
         .expect(400)
@@ -423,7 +423,7 @@ describe('LibraryService', () => {
 
     it('throws a 404 error when both the library id and url are specified but one of them is invalid', async () => {
       await supertest(server.app)
-        .post('/4_0_1/Library/$package')
+        .post('/4_0_1/Library/$cqfm.package')
         .send({
           resourceType: 'Parameters',
           parameter: [
@@ -443,7 +443,7 @@ describe('LibraryService', () => {
 
     it('throws a 404 error when no library matching id and url can be found', async () => {
       await supertest(server.app)
-        .post('/4_0_1/Library/$package')
+        .post('/4_0_1/Library/$cqfm.package')
         .send({
           resourceType: 'Parameters',
           parameter: [

--- a/service/test/services/MeasureService.test.ts
+++ b/service/test/services/MeasureService.test.ts
@@ -229,10 +229,10 @@ describe('MeasureService', () => {
     });
   });
 
-  describe('$package', () => {
+  describe('$cqfm.package', () => {
     it('returns a Bundle including the root lib and Measure when root lib has no dependencies and id passed through args', async () => {
       await supertest(server.app)
-        .get('/4_0_1/Measure/testWithRootLib/$package')
+        .get('/4_0_1/Measure/testWithRootLib/$cqfm.package')
         .expect(200)
         .then(response => {
           expect(response.body.resourceType).toEqual('Bundle');
@@ -245,7 +245,7 @@ describe('MeasureService', () => {
 
     it('returns a Bundle including the root lib and Measure when root lib has no dependencies and id passed through body', async () => {
       await supertest(server.app)
-        .post('/4_0_1/Measure/$package')
+        .post('/4_0_1/Measure/$cqfm.package')
         .send({ resourceType: 'Parameters', parameter: [{ name: 'id', valueUrl: 'testWithRootLib' }] })
         .set('content-type', 'application/fhir+json')
         .expect(200)
@@ -260,7 +260,7 @@ describe('MeasureService', () => {
 
     it('returns a Bundle including the root lib, Measure and dependent libraries when root lib has dependencies and id passed through args', async () => {
       await supertest(server.app)
-        .get('/4_0_1/Measure/testWithRootLibAndDeps/$package')
+        .get('/4_0_1/Measure/testWithRootLibAndDeps/$cqfm.package')
         .expect(200)
         .then(response => {
           expect(response.body.resourceType).toEqual('Bundle');
@@ -277,7 +277,7 @@ describe('MeasureService', () => {
 
     it('returns a Bundle including the root lib, Measure, and dependent libraries when root lib has dependencies and id passed through body', async () => {
       await supertest(server.app)
-        .post('/4_0_1/Measure/$package')
+        .post('/4_0_1/Measure/$cqfm.package')
         .send({ resourceType: 'Parameters', parameter: [{ name: 'id', valueString: 'testWithRootLibAndDeps' }] })
         .set('content-type', 'application/fhir+json')
         .expect(200)
@@ -296,7 +296,7 @@ describe('MeasureService', () => {
 
     it('returns a Bundle including the root lib and Measure when root lib has no dependencies and identifier with just identifier.value passed through body', async () => {
       await supertest(server.app)
-        .post('/4_0_1/Measure/$package')
+        .post('/4_0_1/Measure/$cqfm.package')
         .send({
           resourceType: 'Parameters',
           parameter: [{ name: 'identifier', valueString: 'measureWithIdentifierValueRootLib' }]
@@ -317,7 +317,7 @@ describe('MeasureService', () => {
 
     it('returns a Bundle including the root lib and Measure when root lib has no dependencies and identifier with just identifier.system passed through body', async () => {
       await supertest(server.app)
-        .post('/4_0_1/Measure/$package')
+        .post('/4_0_1/Measure/$cqfm.package')
         .send({
           resourceType: 'Parameters',
           parameter: [{ name: 'identifier', valueString: 'http://example.com/measureWithIdentifierSystemRootLib|' }]
@@ -338,7 +338,7 @@ describe('MeasureService', () => {
 
     it('returns a Bundle including the root lib and Measure when root lib has no dependencies and identifier with both identifier.system and identifier.value passed through body', async () => {
       await supertest(server.app)
-        .post('/4_0_1/Measure/$package')
+        .post('/4_0_1/Measure/$cqfm.package')
         .send({
           resourceType: 'Parameters',
           parameter: [
@@ -365,7 +365,7 @@ describe('MeasureService', () => {
 
     it('throws a 404 error when both the Measure id and url are specified but one of them is invalid', async () => {
       await supertest(server.app)
-        .post('/4_0_1/Measure/$package')
+        .post('/4_0_1/Measure/$cqfm.package')
         .send({
           resourceType: 'Parameters',
           parameter: [
@@ -385,7 +385,7 @@ describe('MeasureService', () => {
 
     it('throws a 400 error when no url or id included in request', async () => {
       await supertest(server.app)
-        .post('/4_0_1/Measure/$package')
+        .post('/4_0_1/Measure/$cqfm.package')
         .send({ resourceType: 'Parameters', parameter: [] })
         .set('content-type', 'application/fhir+json')
         .expect(400)
@@ -399,7 +399,7 @@ describe('MeasureService', () => {
 
     it('throws a 400 error when an id is included in both the path and a FHIR parameter', async () => {
       await supertest(server.app)
-        .post('/4_0_1/Measure/testWithRootLib/$package')
+        .post('/4_0_1/Measure/testWithRootLib/$cqfm.package')
         .send({ resourceType: 'Parameters', parameter: [{ name: 'id', valueString: 'testWithRootLib' }] })
         .set('content-type', 'application/fhir+json')
         .expect(400)
@@ -413,7 +413,7 @@ describe('MeasureService', () => {
 
     it('throws a 400 error when an id is included in both the path and a query parameter', async () => {
       await supertest(server.app)
-        .get('/4_0_1/Measure/testWithRootLib/$package')
+        .get('/4_0_1/Measure/testWithRootLib/$cqfm.package')
         .query({ id: 'testWithRootLib' })
         .set('content-type', 'application/fhir+json')
         .expect(400)
@@ -427,7 +427,7 @@ describe('MeasureService', () => {
 
     it('throws a 404 error when no measure matching id and url can be found', async () => {
       await supertest(server.app)
-        .post('/4_0_1/Measure/$package')
+        .post('/4_0_1/Measure/$cqfm.package')
         .send({
           resourceType: 'Parameters',
           parameter: [


### PR DESCRIPTION
# Summary
The [published version of the measure repository service](http://hl7.org/fhir/us/cqfmeasures/OperationDefinition/cqfm-package) now specifies `$cqfm.package` as the endpoint for the package operation. This PR changes instances of `$package` with `$cqfm.package`.

## New behavior
No new features. Changes the package endpoint from `$package` to `$cqfm.package`. Also updates our schema instances, which impacts which parameters throw errors when caught being used without support from the server.

## Code changes
* README updates
* `capabilityStatementResources.json` - update OperationDefinition link for the package operation
* `serverConfig.ts` - update operation endpoint and reference
* `requestSchemas.ts` - Made updates to unsupported package args and general package args schema based on changes to the spec.
* Updates to `LibraryService` and `MeasureService` tests (update the mock requests)
* Other miscellaneous changes to update documentation related to the change in endpoint

# Testing guidance
* Run unit tests for the measure repository service and ensure that they all pass
* Run various`$cqfm.package` requests - The Insomnia imports from previous pull requests can be used as a starting point for making these requests (the only change that needs to be made within these imports is the change from `$package` to `$cqfm.package`). All successful requests should return `200` status and a FHIR Bundle.
    * Example endpoints include `[base]/Library/$cqfm.package`, `[base]/Library/[id]/$cqfm.package`, etc.
    * Test both POST and GET requests
* Check that the request schema parameters align with the parameters listed in the measure repository service definition. There are a few inconsistencies between the [CQFM Package OperationDefinition](http://hl7.org/fhir/us/cqfmeasures/STU4/OperationDefinition-cqfm-package.html), the [CQFM Package section](http://hl7.org/fhir/us/cqfmeasures/measure-repository-service.html#package) of the measure repository page, and the [Publishable Measure Repository Section](http://hl7.org/fhir/us/cqfmeasures/measure-repository-service.html#libraries-1). Check that the TODO comments align with the inconsistencies that need to be addressed.

Insomnia tests are included below (endpoint will need to be changed to `$cqfm.package`):
[Library-$package-testing.json](https://github.com/projecttacoma/measure-repository/files/13270438/Library-.package-testing.json)
[Measure-$package-testing.json](https://github.com/projecttacoma/measure-repository/files/13270441/Measure-.package-testing.json)

