### PR TITLE
Update landing page with README link and service location

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Measure Repository
 
-A prototype implementation of a [FHIR Measure Repository Service](https://build.fhir.org/ig/HL7/cqf-measures/measure-repository-service.html) and associated frontend application. This repository is a monorepo that consists of: 
+A prototype implementation of a [FHIR Measure Repository Service](http://hl7.org/fhir/us/cqfmeasures/measure-repository-service.html) and associated frontend application. This repository is a monorepo that consists of: 
 - [Measure Repository Service](https://github.com/projecttacoma/measure-repository/blob/main/service/README.md)
-  - Implements portions of the [FHIR Measure Repository Service](https://build.fhir.org/ig/HL7/cqf-measures/measure-repository-service.html) specification
+  - Implements portions of the [FHIR Measure Repository Service](http://hl7.org/fhir/us/cqfmeasures/measure-repository-service.html) specification
   - Acts as a FHIR server and shared source of truth for measures and libraries
 - [Measure Repository App](https://github.com/projecttacoma/measure-repository/blob/main/app/README.md)
   - A prototype [Next.js](https://nextjs.org/) application that demonstrates potential interactions with a FHIR Measure Repository Service

--- a/app/README.md
+++ b/app/README.md
@@ -1,6 +1,6 @@
 # Measure Repository Service App
 
-A frontend application for a prototype implementation of a [FHIR Measure Repository Service](https://build.fhir.org/ig/HL7/cqf-measures/measure-repository-service.html).
+A frontend application for a prototype implementation of a [FHIR Measure Repository Service](http://hl7.org/fhir/us/cqfmeasures/measure-repository-service.html).
 
 - [Installation](#installation)
   - [Prerequisites](#prerequisites)
@@ -69,7 +69,7 @@ The Repository tab displays sets of artifacts from the FHIR Measure Repository S
 ### Viewing
 -	Measure: Resource details show the JSON as well as options to see the Narrative, Data Requirements, and Dependencies, if they exist.          
 -	Library: Resource details show the JSON as well as options to see the ELM, CQL, Narrative, Data Requirements, and Dependencies, if they exist.  
--	Drafting: Both resource views allow the user to create a draft from the artifact. This action copies the existing artifact and any children it owns to the draft Authoring space with a draft status and an incremented version to logically differentiate it from the original artifact. See the [draft operation specification](https://build.fhir.org/ig/HL7/cqf-measures/measure-repository-service.html#draft).
+-	Drafting: Both resource views allow the user to create a draft from the artifact. This action copies the existing artifact and any children it owns to the draft Authoring space with a draft status and an incremented version to logically differentiate it from the original artifact. See the [draft operation specification](http://hl7.org/fhir/us/cqfmeasures/measure-repository-service.html#draft).
 
 ### Reviewing
 Reviewing a resource provides options for viewing existing comments on the resource or adding a new comment. (Note: this is currently partially implemented and requires updates for viewing comments.)
@@ -92,7 +92,7 @@ The left navigation resource type selection displays sets of artifacts that are 
     - title
     - description
     - library (Measure only)
-- Releasing: Both resource types may be released from the editing page. This action publishes the draft artifact and any children it owns to the Repository space, adding them to the FHIR Measure Repository and giving them an active status. The draft artifact(s) will be removed from the Authoring space. See the [release operation specification](https://build.fhir.org/ig/HL7/cqf-measures/measure-repository-service.html#release).
+- Releasing: Both resource types may be released from the editing page. This action publishes the draft artifact and any children it owns to the Repository space, adding them to the FHIR Measure Repository and giving them an active status. The draft artifact(s) will be removed from the Authoring space. See the [release operation specification](http://hl7.org/fhir/us/cqfmeasures/measure-repository-service.html#release).
 
 ### Reviewing
 Reviewing a resource provides options for viewing existing comments on the resource or adding a new comment.

--- a/app/src/components/ReleaseModal.tsx
+++ b/app/src/components/ReleaseModal.tsx
@@ -121,8 +121,7 @@ export default function ReleaseModal({ open = true, onClose, id, resourceType }:
 
   async function confirm() {
     // requirements:
-    // https://build.fhir.org/ig/HL7/cqf-measures/measure-repository-service.html#release
-    // TODO: release recursively all children (ignore for now).
+    // http://hl7.org/fhir/us/cqfmeasures/measure-repository-service.html#release
     if (resource) {
       releaseMutation.mutate({
         resourceType: resourceType,

--- a/app/src/pages/index.tsx
+++ b/app/src/pages/index.tsx
@@ -52,7 +52,7 @@ export default function Home({ capabilityStatement }: InferGetServerSidePropsTyp
     <div>
       <Text>
         This application is an interface for a prototype implementation of a{' '}
-        <Anchor href="https://build.fhir.org/ig/HL7/cqf-measures/measure-repository-service.html">
+        <Anchor href="http://hl7.org/fhir/us/cqfmeasures/measure-repository-service.html">
           FHIR Measure Repository Service
         </Anchor>{' '}
         with Measure and Library authoring capabilities. See the{' '}

--- a/app/src/pages/index.tsx
+++ b/app/src/pages/index.tsx
@@ -55,8 +55,17 @@ export default function Home({ capabilityStatement }: InferGetServerSidePropsTyp
         <Anchor href="https://build.fhir.org/ig/HL7/cqf-measures/measure-repository-service.html">
           FHIR Measure Repository Service
         </Anchor>{' '}
-        with Measure and Library authoring capabilities.
+        with Measure and Library authoring capabilities. See the{' '}
+        <Anchor href="https://github.com/projecttacoma/measure-repository/blob/main/README.md">
+          Measure Repository README
+        </Anchor>{' '}
+        for technical details.
       </Text>
+      <Divider my="sm" variant="dotted" />
+      <Title order={2}>Service Location:</Title>
+      <div style={{ marginTop: '18px', marginBottom: '18px' }}>
+        <Anchor href={`${process.env.NEXT_PUBLIC_MRS_SERVER}`}>{process.env.NEXT_PUBLIC_MRS_SERVER}</Anchor>
+      </div>
       <Divider my="sm" variant="dotted" />
       <Title order={2}>Service Capabilities:</Title>
       <div style={{ marginTop: '18px', marginBottom: '18px' }}>{renderCapabilityTable()}</div>

--- a/app/src/pages/index.tsx
+++ b/app/src/pages/index.tsx
@@ -64,7 +64,9 @@ export default function Home({ capabilityStatement }: InferGetServerSidePropsTyp
       <Divider my="sm" variant="dotted" />
       <Title order={2}>Service Location:</Title>
       <div style={{ marginTop: '18px', marginBottom: '18px' }}>
-        <Anchor href={`${process.env.NEXT_PUBLIC_MRS_SERVER}`}>{process.env.NEXT_PUBLIC_MRS_SERVER}</Anchor>
+        <Anchor
+          href={`${process.env.NEXT_PUBLIC_MRS_SERVER}/metadata`}
+        >{`${process.env.NEXT_PUBLIC_MRS_SERVER}/metadata`}</Anchor>
       </div>
       <Divider my="sm" variant="dotted" />
       <Title order={2}>Service Capabilities:</Title>

--- a/service/README.md
+++ b/service/README.md
@@ -1,6 +1,6 @@
 # Measure Repository Service
 
-A prototype implementation of a [FHIR Measure Repository Service](https://build.fhir.org/ig/HL7/cqf-measures/measure-repository-service.html)
+A prototype implementation of a [FHIR Measure Repository Service](http://hl7.org/fhir/us/cqfmeasures/measure-repository-service.html)
 
 ## Installation
 
@@ -75,7 +75,7 @@ This server currently supports the following CRUD operations:
 
 ### Search
 
-The Measure Repository Service server supports `Library` and `Measure` resource search by the parameters specified in the shareable measure repository section of the [HL7 Measure Repository Docs](https://build.fhir.org/ig/HL7/cqf-measures/measure-repository-service.html#shareable-measure-repository). These parameters are:
+The Measure Repository Service server supports `Library` and `Measure` resource search by the parameters specified in the shareable measure repository section of the [HL7 Measure Repository Docs](http://hl7.org/fhir/us/cqfmeasures/measure-repository-service.html#shareable-measure-repository). These parameters are:
 
 - description
 - identifier
@@ -87,7 +87,7 @@ The Measure Repository Service server supports `Library` and `Measure` resource 
 
 ### Package
 
-The Measure Repository Service server supports the `Library` and `Measure` `$cqfm-package` operation with the `id` and `identifier` parameters and SHALL parameters specified in the shareable measure repository section of the [HL7 Measure Repository Docs](https://build.fhir.org/ig/HL7/cqf-measures/measure-repository-service.html#publishable-measure-repository). Accepted parameters are:
+The Measure Repository Service server supports the `Library` and `Measure` `$cqfm-package` operation with the `id` and `identifier` parameters and SHALL parameters specified in the shareable measure repository section of the [HL7 Measure Repository Docs](http://hl7.org/fhir/us/cqfmeasures/measure-repository-service.html#publishable-measure-repository). Accepted parameters are:
 
 - id
 - url
@@ -98,7 +98,7 @@ See the [`$cqfm-package` OperationDefinition](http://hl7.org/fhir/us/cqfmeasures
 
 ### Data Requirements
 
-The Measure Repository Service server supports the `Measure` and `Library` `$data-requirements` operations with the SHALL parameters specified in the publishable measure repository section of the [HL7 Measure Repository Docs](https://build.fhir.org/ig/HL7/cqf-measures/measure-repository-service.html#publishable-measure-repository). SHALL parameters are:
+The Measure Repository Service server supports the `Measure` and `Library` `$data-requirements` operations with the SHALL parameters specified in the publishable measure repository section of the [HL7 Measure Repository Docs](http://hl7.org/fhir/us/cqfmeasures/measure-repository-service.html#publishable-measure-repository). SHALL parameters are:
 
 - id
 - url

--- a/service/src/requestSchemas.ts
+++ b/service/src/requestSchemas.ts
@@ -21,7 +21,7 @@ const UNSUPPORTED_PACKAGE_ARGS = [
   'terminologyEndpoint'
 ];
 
-// Operation Definition: https://build.fhir.org/ig/HL7/cqf-measures/measure-repository-service.html#requirements
+// Operation Definition: http://hl7.org/fhir/us/cqfmeasures/measure-repository-service.html#requirements
 const UNSUPPORTED_DATA_REQ_ARGS = [
   'expression',
   'include-components',
@@ -30,7 +30,7 @@ const UNSUPPORTED_DATA_REQ_ARGS = [
   'parameters'
 ];
 
-// Operation Definition: https://build.fhir.org/ig/HL7/cqf-measures/measure-repository-service.html#search
+// Operation Definition: http://hl7.org/fhir/us/cqfmeasures/measure-repository-service.html#search
 const UNSUPPORTED_CORE_SEARCH_ARGS = [
   'composed-of',
   'context',

--- a/service/src/requestSchemas.ts
+++ b/service/src/requestSchemas.ts
@@ -175,7 +175,6 @@ export const CoreSearchArgs = z
   .object({
     'composed-of': z.string(),
     context: z.string(),
-    'context-quantity': z.string(),
     'context-type': z.string(),
     'context-type-quantity': z.string(),
     'context-type-value': z.string(),


### PR DESCRIPTION
# Summary
Updates the landing page with a link to the top level README and the location of the service endpoints.

## New behavior
Appropriate links and description on the landing page

## Code changes
Updates to `index.tsx`

# Testing guidance
`npm run check:all`
`npm run start:all`
View landing page at http://localhost:3001/ and check description and links.
