### PR TITLE
Add support for directory upload

### DIFF
--- a/service/README.md
+++ b/service/README.md
@@ -59,7 +59,7 @@ npm run db:loadBundle <path to directory>
 ```
 
 ### Bundle Upload Details
-Upon uploading a Measure resource, an [isOwned extension](https://build.fhir.org/ig/HL7/fhir-extensions/StructureDefinition-artifact-isOwned.html) will be added to the measure's `relatedArtifact` array. The isOwned extension references the Measure's main library.
+Upon uploading a Measure resource, the Measure's main library is added to the `relatedArtifact` array with an [isOwned extension](https://build.fhir.org/ig/HL7/fhir-extensions/StructureDefinition-artifact-isOwned.html).
 
 Note that the measure repository service only supports Measure and Library resources. All other resource types will be ignored during bundle upload.
 
@@ -69,7 +69,7 @@ If a resource does not have an id, it will be assigned a unique id during the up
 The server supports transaction bundle uploads via the `:/base_version/` endpoint (ex. `/4_0_1/`).
 
 - The request method must be `POST`.
-- The request body must be a FHIR bundle of type "transaction."
+- The request body must be a FHIR bundle of type `transaction`.
 - The entries SHALL be of resource type "Measure" or "Library." An error will be thrown otherwise.
 
 For ease of use, the `service/directory-upload.sh` script can be used to run the transaction bundle upload on an input directory. Details are as follows:

--- a/service/README.md
+++ b/service/README.md
@@ -52,6 +52,19 @@ To load a measure bundle and related library artifacts, run:
 npm run db:loadBundle <path to measure bundle>
 ```
 
+To load multiple bundles from a directory, run the same script with the desired directory path:
+
+```
+npm run db:loadBundle <path to directory>
+```
+
+### Bundle Upload Details
+Upon uploading a Measure resource, an [isOwned extension](https://build.fhir.org/ig/HL7/fhir-extensions/StructureDefinition-artifact-isOwned.html) will be added to the measure's `relatedArtifact` array. The isOwned extension references the Measure's main library.
+
+Note that the measure repository service only supports Measure and Library resources. All other resource types will be ignored during bundle upload.
+
+If a resource does not have an id, it will be assigned a unique id during the upload process.
+
 ## Usage
 
 Once MongoDB is running on your machine, run the `npm start` command in this directory to start up the Measure Repository Service server at `localhost:3000`.

--- a/service/README.md
+++ b/service/README.md
@@ -63,7 +63,7 @@ Upon uploading a Measure resource, an [isOwned extension](https://build.fhir.org
 
 Note that the measure repository service only supports Measure and Library resources. All other resource types will be ignored during bundle upload.
 
-If a resource does not have an id, it will be assigned a unique id during the upload process.
+If a resource does not have an id, it will be assigned a unique id during the upload process. If a resource is not in `active` status, it will be coerced to `active`.
 
 ### Transaction Bundle Upload
 The server supports transaction bundle uploads via the `:/base_version/` endpoint (ex. `/4_0_1/`).
@@ -74,6 +74,7 @@ The server supports transaction bundle uploads via the `:/base_version/` endpoin
 
 For ease of use, the `service/directory-upload.sh` script can be used to run the transaction bundle upload on an input directory. Details are as follows:
 
+- The `-h` option can be used to view usage.
 - A server URL must be supplied via the `-s` option.
 - A directory path must be supplied via the `-d` option.
 - The script can support nested directories (one level deep).

--- a/service/README.md
+++ b/service/README.md
@@ -65,6 +65,19 @@ Note that the measure repository service only supports Measure and Library resou
 
 If a resource does not have an id, it will be assigned a unique id during the upload process.
 
+### Transaction Bundle Upload
+The server supports transaction bundle uploads via the `:/base_version/` endpoint (ex. `/4_0_1/`).
+
+- The request method must be `POST`.
+- The request body must be a FHIR bundle of type "transaction."
+- The entries SHALL be of resource type "Measure" or "Library." An error will be thrown otherwise.
+
+For ease of use, the `service/directory-upload.sh` script can be used to run the transaction bundle upload on an input directory. Details are as follows:
+
+- A server URL must be supplied via the `-s` option.
+- A directory path must be supplied via the `-d` option.
+- The script can support nested directories (one level deep).
+
 ## Usage
 
 Once MongoDB is running on your machine, run the `npm start` command in this directory to start up the Measure Repository Service server at `localhost:3000`.

--- a/service/directory-upload.sh
+++ b/service/directory-upload.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+usage="
+usage: $(basename "$0") command [-h] [-s] [-d] arguments...
+Uploads Measure and Library resources to the measure repository service.
+Options:
+    -h
+        Displays help menu.
+    -s [server baseUrl]
+        Specifies the base URL of the FHIR server to access.
+    -d
+        Provides directory path to parse for upload.
+"
+
+while getopts ':h:s:d:' option;
+do
+  case "$option" in
+    h)
+       echo -e "$usage"
+       exit 0
+       ;;
+    s)
+       server=$OPTARG
+       ;;
+    d)
+       directory_path=$OPTARG
+       ;;
+
+   \?) printf "illegal option: -%s\n" "$OPTARG" 1>&2
+       echo "$usage" 1>&2
+       exit 1
+       ;;
+    : )
+      echo "Invalid option: $OPTARG requires an argument" 1>&2
+      ;;
+  esac
+done
+
+if [[ $directory_path == "" ]] ; then
+  echo No directory path provided. Provide directory path via the '-d' flag.
+  exit 1
+fi
+
+if [[ $server == "" ]] ; then
+  echo No server URL provided. Provide server URL via the '-s' flag.
+  exit 1
+fi
+
+echo Using Server URL: $server and directory path: $directory_path
+
+upload_bundle() {
+  echo "Uploading resources for bundle $1"
+    # TODO: update the url or even make that an input...?
+    curl_command="curl -X POST -H 'Content-Type: application/json+fhir' -d @\"$1\" $server"
+    # execute the curl command
+    eval "$curl_command"
+
+    echo "Bundle successfully uploaded."
+    echo ""
+}
+
+# loop over FHIR bundles in specified directory
+for file_path in "$directory_path" ; do
+  if [[ -d $file_path ]] ; then
+    # recurse on directory
+    for f in $(find $file_path -name "*.json") ; do
+      upload_bundle $f
+    done
+
+  elif [[ -f $file_path ]] ; then
+    if [[ ${file_path: -5} == ".json" ]] ; then
+      upload_bundle $file_path
+    fi
+  fi
+done

--- a/service/directory-upload.sh
+++ b/service/directory-upload.sh
@@ -12,7 +12,7 @@ Options:
         Provides directory path to parse for upload.
 "
 
-while getopts ':h:s:d:' option;
+while getopts ':hs:d:' option;
 do
   case "$option" in
     h)

--- a/service/directory-upload.sh
+++ b/service/directory-upload.sh
@@ -8,8 +8,8 @@ Options:
         Displays help menu.
     -s [server baseUrl]
         Specifies the base URL of the FHIR server to access.
-    -d
-        Provides directory path to parse for upload.
+    -d [path]
+        Provides directory or file path to parse for upload.
 "
 
 while getopts ':hs:d:' option;

--- a/service/directory-upload.sh
+++ b/service/directory-upload.sh
@@ -54,7 +54,7 @@ upload_bundle() {
     # execute the curl command
     eval "$curl_command"
 
-    echo "Bundle successfully uploaded."
+    echo "Finished bundle upload."
     echo ""
 }
 

--- a/service/directory-upload.sh
+++ b/service/directory-upload.sh
@@ -50,8 +50,7 @@ echo Using Server URL: $server and directory path: $directory_path
 
 upload_bundle() {
   echo "Uploading resources for bundle $1"
-    # TODO: update the url or even make that an input...?
-    curl_command="curl -X POST -H 'Content-Type: application/json+fhir' -d @\"$1\" $server"
+    curl_command="curl -X POST -H 'Content-Type: application/json+fhir' -d @\"$1\" $server -o /dev/null"
     # execute the curl command
     eval "$curl_command"
 

--- a/service/scripts/dbSetup.ts
+++ b/service/scripts/dbSetup.ts
@@ -82,8 +82,6 @@ async function uploadBundleResources(filePath: string) {
         // Get the main library from the Measure and add the isOwned extension on that library's
         // entry in the relatedArtifacts of the measure
         if (res?.resource?.resourceType && res?.resource?.resourceType === 'Measure' && res?.resource?.library) {
-
-          // TODO: should we throw an error when the status is not 'active'? or coerce to 'active'?
           // get the main library of the measure from the library property and the version
           const mainLibrary = res.resource.library?.[0];
           const mainLibraryVersion = res.resource.version;
@@ -136,6 +134,12 @@ async function uploadBundleResources(filePath: string) {
           try {
             if (!res.resource.id) {
               res.resource.id = uuidv4();
+            }
+            if (res.resource.status != 'active') {
+              res.resource.status = 'active';
+              console.warn(
+                `Resource ${res?.resource?.resourceType}/${res.resource.id} status has been coerced to 'active'.`
+              );
             }
             const collection = Connection.db.collection<fhir4.FhirResource>(res.resource.resourceType);
             console.log(`Inserting ${res?.resource?.resourceType}/${res.resource.id} into database`);

--- a/service/scripts/dbSetup.ts
+++ b/service/scripts/dbSetup.ts
@@ -82,6 +82,8 @@ async function uploadBundleResources(filePath: string) {
         // Get the main library from the Measure and add the isOwned extension on that library's
         // entry in the relatedArtifacts of the measure
         if (res?.resource?.resourceType && res?.resource?.resourceType === 'Measure' && res?.resource?.library) {
+
+          // TODO: should we throw an error when the status is not 'active'? or coerce to 'active'?
           // get the main library of the measure from the library property and the version
           const mainLibrary = res.resource.library?.[0];
           const mainLibraryVersion = res.resource.version;

--- a/service/scripts/dbSetup.ts
+++ b/service/scripts/dbSetup.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs';
 import * as dotenv from 'dotenv';
 import { MongoError } from 'mongodb';
 import { v4 as uuidv4 } from 'uuid';
+import path from 'path';
 dotenv.config();
 
 const DB_URL = process.env.DATABASE_URL || 'mongodb://localhost:27017/measure-repository';
@@ -33,11 +34,40 @@ async function deleteCollections() {
 }
 
 /*
- * Loads all measure or library resources found in the bundle located at param filePath
+ * Gathers necessary file path(s) for bundle(s) to upload, then uploads all measure and
+ * library resources found in the bundle(s).
  */
-async function loadBundle(filePath: string) {
+async function loadBundle(fileOrDirectoryPath: string) {
   await Connection.connect(DB_URL);
   console.log(`Connected to ${DB_URL}`);
+  const status = fs.statSync(fileOrDirectoryPath);
+  if (status.isDirectory()) {
+    const filePaths: string[] = [];
+    fs.readdirSync(fileOrDirectoryPath, { withFileTypes: true }).forEach(ent => {
+      // if this item is a directory, look for .json files under it
+      if (ent.isDirectory()) {
+        fs.readdirSync(path.join(fileOrDirectoryPath, ent.name), { withFileTypes: true }).forEach(subEnt => {
+          if (!subEnt.isDirectory() && subEnt.name.endsWith('.json')) {
+            filePaths.push(path.join(fileOrDirectoryPath, ent.name, subEnt.name));
+          }
+        });
+      } else if (ent.name.endsWith('.json')) {
+        filePaths.push(path.join(fileOrDirectoryPath, ent.name));
+      }
+    });
+
+    for (const filePath of filePaths) {
+      await uploadBundleResources(filePath);
+    }
+  } else {
+    await uploadBundleResources(fileOrDirectoryPath);
+  }
+}
+
+/*
+ * Loads all measure or library resources found in the bundle located at param filePath
+ */
+async function uploadBundleResources(filePath: string) {
   console.log(`Loading bundle from path ${filePath}`);
 
   const data = fs.readFileSync(filePath, 'utf8');
@@ -129,7 +159,7 @@ async function loadBundle(filePath: string) {
       });
       await Promise.all(uploads);
       console.log(`${resourcesUploaded} resources uploaded.`);
-      console.log(`${notUploaded} non-Measure/non-Library resources skipped.`);
+      console.log(`${notUploaded} non-Measure/non-Library resources skipped.\n`);
     } else {
       console.error('Unable to identify bundle entries.');
     }

--- a/service/src/services/BaseService.ts
+++ b/service/src/services/BaseService.ts
@@ -85,6 +85,7 @@ async function insertBundleResources(entry: DetailedEntry) {
       }
     }
   } else {
+    // TODO: update this to be a warning instead? see if you are allowed to skip resources in txn upload/update status
     throw new BadRequestError(
       entry.resource
         ? `All resource entries must be of either resourceType 'Measure' or 'Library'. Received resourceType ${entry.resource?.resourceType}.`

--- a/service/src/services/BaseService.ts
+++ b/service/src/services/BaseService.ts
@@ -63,6 +63,12 @@ async function uploadResourcesFromBundle(entries: DetailedEntry[]) {
  */
 async function insertBundleResources(entry: DetailedEntry) {
   if (entry.resource?.resourceType === 'Library' || entry.resource?.resourceType === 'Measure') {
+    if (entry.resource.status != 'active') {
+      entry.resource.status = 'active';
+      // TODO: should we update status text with coercion information? -> warning operation outcome?
+      console.warn(`Resource ${entry.resource.resourceType}/${entry.resource.id} status has been coerced to 'active'.`);
+    }
+
     if (entry.isPost) {
       entry.resource.id = uuidv4();
       const { id } = await createResource(entry.resource, entry.resource.resourceType);
@@ -85,7 +91,6 @@ async function insertBundleResources(entry: DetailedEntry) {
       }
     }
   } else {
-    // TODO: update this to be a warning instead? see if you are allowed to skip resources in txn upload/update status
     throw new BadRequestError(
       entry.resource
         ? `All resource entries must be of either resourceType 'Measure' or 'Library'. Received resourceType ${entry.resource?.resourceType}.`

--- a/service/src/services/LibraryService.ts
+++ b/service/src/services/LibraryService.ts
@@ -67,6 +67,10 @@ export class LibraryService implements Service<fhir4.Library> {
     const resource = req.body;
     checkExpectedResourceType(resource.resourceType, 'Library');
     resource['id'] = uuidv4();
+    if (resource.status != 'active') {
+      resource.status = 'active';
+      logger.warn(`Resource ${resource.id} has been coerced to active`);
+    }
     return createResource(resource, 'Library');
   }
 
@@ -84,6 +88,10 @@ export class LibraryService implements Service<fhir4.Library> {
     // Throw error if the id arg in the url does not match the id in the request body
     if (resource.id !== args.id) {
       throw new BadRequestError('Argument id must match request body id for PUT request');
+    }
+    if (resource.status != 'active') {
+      resource.status = 'active';
+      logger.warn(`Resource ${resource.id} has been coerced to active`);
     }
     return updateResource(args.id, resource, 'Library');
   }

--- a/service/src/services/MeasureService.ts
+++ b/service/src/services/MeasureService.ts
@@ -68,6 +68,10 @@ export class MeasureService implements Service<fhir4.Measure> {
     const resource = req.body;
     checkExpectedResourceType(resource.resourceType, 'Measure');
     resource['id'] = uuidv4();
+    if (resource.status != 'active') {
+      resource.status = 'active';
+      logger.warn(`Resource ${resource.id} has been coerced to active`);
+    }
     return createResource(resource, 'Measure');
   }
 
@@ -85,6 +89,10 @@ export class MeasureService implements Service<fhir4.Measure> {
     // Throw error if the id arg in the url does not match the id in the request body
     if (resource.id !== args.id) {
       throw new BadRequestError('Argument id must match request body id for PUT request');
+    }
+    if (resource.status != 'active') {
+      resource.status = 'active';
+      logger.warn(`Resource ${resource.id} has been coerced to active`);
     }
     return updateResource(args.id, resource, 'Measure');
   }

--- a/service/src/util/baseUtils.ts
+++ b/service/src/util/baseUtils.ts
@@ -1,5 +1,6 @@
 import { v4 as uuidv4 } from 'uuid';
 import { loggers } from '@projecttacoma/node-fhir-server-core';
+import { OperationOutcome } from 'fhir/r4';
 
 const logger = loggers.get('default');
 
@@ -10,6 +11,7 @@ export type DetailedEntry = fhir4.BundleEntry & {
   status?: number;
   statusText?: string;
   data?: string;
+  outcome?: OperationOutcome;
 };
 
 /**


### PR DESCRIPTION
# Summary
Adds support for directory bundle upload via both the `db:loadBundle` npm script as well as a new batch script.

## New behavior
The user now has the ability to upload entire directories of bundles to the measure repository rather than needing to run a command on each individual JSON file.

The existing `db:loadBundle` script can be used for directory upload and supports nested directories (one level deep). The script detects whether the input path refers to a file or directory. The new bash script also supports nested directories and applies a transaction bundle upload via a curl command to each of the bundles contained in the directory.

## Code changes
* `service/scripts/dbSetup.ts` - update script to check whether the input path is a directory, and loop over all JSON files accordingly
* `service/directory-upload.sh` - new bash script that takes in a directory path and server url, and applies transaction bundle upload to each JSON bundle in the directory
* `service/README.md` - update documentation on usage of `db:loadBundle` script, details on how the bundles are uploaded (in regard to additions to the data with the isOwned extension, etc.), details on transaction bundle upload

# Testing guidance
`db:loadBundle` testing:
* Reset database, then run script with a file and ensure that functionality remains unchanged
* Reset database, then run script with a directory containing JSON bundles and ensure that the resources in the bundles are successfully uploaded to server
* Reset database, then run script with a directory containing sub-directories of JSON bundles and ensure that the script can traverse the nested directories. For testing, I use `ecqm-content-r4-2021/bundles/measure`

**Open question(s) regarding `db:loadBundle` implementation:**
* Should we throw an error if an artifact is an uploaded artifact is not in “active” status? I have noticed during previous testing with the measure repository that “draft” artifacts may be uploaded to the repository via this script. Would it be preferable to throw a warning about coercing the version to “active,” and then update the status to “active” within this script?

Bash script testing:
* Test the various script options to check that they are supported and function as intended. Try testing invalid options to check that they are properly handled.
* Example command to run script from the terminal: `./directory-upload.sh -s "http://localhost:3000/4_0_1" -d ./ecqm-content-r4-2021/bundles/measure/ColorectalCancerScreeningsFHIR`
* Check that the script can handle nested directories (can similarly use the ecqm-content repository to test this)

**Open question(s) regarding bash script/transaction bundle upload implementation:**
* Currently a 400 error is thrown in `BaseService.ts` if a bundle contains non-Measure/non-Library resources. Should we add documentation requiring that the bundles specified into the bash script only contain Measure and Library resources?
    * Can resources in a transaction bundle be “skipped” during upload? Could we skip non-Measure/non-Library resources, and return a 400 for those entries within the transaction-response bundle? Right now it seems like `BaseService.ts` does not do any error handling in the transaction-response.


Additional testing recommendations:

- Test using the connectathon measures at https://github.com/cqframework/ecqm-content-qicore-2024 i.e. `./directory-upload.sh -s "http://localhost:3000/4_0_1" -d ../../ecqm-content-qicore-2024/bundles/mat/`
- Test the operation outcome warning by posting a bundle that has a draft measure but no valuesets such as CMS130FHIR-v0.1.000-FHIR (colon cancer screening) from qicore-2024. The response should show an entry for the Measure with the warning operation outcome for coercion to active status. 