### PR TITLE
Added _summary search param for artifact count optimization

### DIFF
--- a/app/src/server/trpc/routers/service.ts
+++ b/app/src/server/trpc/routers/service.ts
@@ -17,8 +17,8 @@ export const serviceRouter = router({
 
   getArtifactCounts: publicProcedure.query(async () => {
     const [measureBundle, libraryBundle] = await Promise.all([
-      fetch(`${process.env.NEXT_PUBLIC_MRS_SERVER}/Measure?_summary=count`),
-      fetch(`${process.env.NEXT_PUBLIC_MRS_SERVER}/Library?_summary=count`)
+      fetch(`${process.env.MRS_SERVER}/Measure?_summary=count`),
+      fetch(`${process.env.MRS_SERVER}/Library?_summary=count`)
     ]).then(([resMeasure, resLibrary]) =>
       Promise.all([resMeasure.json() as Promise<fhir4.Bundle>, resLibrary.json() as Promise<fhir4.Bundle>])
     );

--- a/app/src/server/trpc/routers/service.ts
+++ b/app/src/server/trpc/routers/service.ts
@@ -17,8 +17,8 @@ export const serviceRouter = router({
 
   getArtifactCounts: publicProcedure.query(async () => {
     const [measureBundle, libraryBundle] = await Promise.all([
-      fetch(`${process.env.MRS_SERVER}/Measure`),
-      fetch(`${process.env.MRS_SERVER}/Library`)
+      fetch(`${process.env.NEXT_PUBLIC_MRS_SERVER}/Measure?_summary=count`),
+      fetch(`${process.env.NEXT_PUBLIC_MRS_SERVER}/Library?_summary=count`)
     ]).then(([resMeasure, resLibrary]) =>
       Promise.all([resMeasure.json() as Promise<fhir4.Bundle>, resLibrary.json() as Promise<fhir4.Bundle>])
     );

--- a/service/README.md
+++ b/service/README.md
@@ -59,6 +59,7 @@ npm run db:loadBundle <path to directory>
 ```
 
 ### Bundle Upload Details
+
 Upon uploading a Measure resource, the Measure's main library is added to the `relatedArtifact` array with an [isOwned extension](https://build.fhir.org/ig/HL7/fhir-extensions/StructureDefinition-artifact-isOwned.html).
 
 Note that the measure repository service only supports Measure and Library resources. All other resource types will be ignored during bundle upload.
@@ -66,6 +67,7 @@ Note that the measure repository service only supports Measure and Library resou
 If a resource does not have an id, it will be assigned a unique id during the upload process. If a resource is not in `active` status, it will be coerced to `active`.
 
 ### Transaction Bundle Upload
+
 The server supports transaction bundle uploads via the `:/base_version/` endpoint (ex. `/4_0_1/`).
 
 - The request method must be `POST`.
@@ -111,6 +113,10 @@ The Measure Repository Service server supports `Library` and `Measure` resource 
 - title
 - url
 - version (can appear only in combination with a url search)
+
+The Measure Repository Service server also supports the `_summary` search parameter specified in the [HL7 FHIR Search Docs](https://www.hl7.org/fhir/search.html#_summary). The server currently supports the following `_summary` parameter values:
+
+- count
 
 ### Package
 

--- a/service/src/db/dbOperations.ts
+++ b/service/src/db/dbOperations.ts
@@ -21,7 +21,20 @@ export async function findResourcesWithQuery<T extends fhir4.FhirResource>(
 ) {
   const collection = Connection.db.collection(resourceType);
   query._dataRequirements = { $exists: false };
+  query._summary = { $exists: false };
   return collection.find<T>(query, { projection: { _id: 0, _dataRequirements: 0 } }).toArray();
+}
+
+/**
+ *
+ * searches the database for all resources of the given type that match the given query
+ * but only returns the number of matches
+ */
+export async function findResourceCountWithQuery(query: Filter<any>, resourceType: FhirResourceType) {
+  const collection = Connection.db.collection(resourceType);
+  query._dataRequirements = { $exists: false };
+  query._summary = { $exists: false };
+  return collection.countDocuments(query);
 }
 
 /**

--- a/service/src/requestSchemas.ts
+++ b/service/src/requestSchemas.ts
@@ -194,7 +194,9 @@ export const CoreSearchArgs = z
     title: z.string(),
     topic: z.string(),
     url: z.string().url(),
-    version: z.string()
+    version: z.string(),
+    // adding _summary for count (https://www.hl7.org/fhir/search.html#_summary)
+    _summary: z.string()
   })
   .partial()
   .strict();

--- a/service/src/requestSchemas.ts
+++ b/service/src/requestSchemas.ts
@@ -196,7 +196,7 @@ export const CoreSearchArgs = z
     url: z.string().url(),
     version: z.string(),
     // adding _summary for count (https://www.hl7.org/fhir/search.html#_summary)
-    _summary: z.string()
+    _summary: z.literal('count')
   })
   .partial()
   .strict();

--- a/service/src/util/bundleUtils.ts
+++ b/service/src/util/bundleUtils.ts
@@ -27,6 +27,20 @@ export function createSearchsetBundle<T extends fhir4.FhirResource>(entries: T[]
 }
 
 /**
+ *
+ * Takes in a number of FHIR resources and creates a FHIR searchset Bundle without entries
+ */
+export function createSummarySearchsetBundle<T extends fhir4.FhirResource>(count: number): fhir4.Bundle<T> {
+  return {
+    resourceType: 'Bundle',
+    meta: { lastUpdated: new Date().toISOString() },
+    id: v4(),
+    type: 'searchset',
+    total: count
+  };
+}
+
+/**
  * Takes in a mongo query, finds a Measure based on the query and all dependent
  * Library resources and bundles them together with the Measure in a collection bundle
  */


### PR DESCRIPTION
# Summary
This PR adds the `_summary` search parameter (specified in the HL7 FHIR docs [here](https://www.hl7.org/fhir/search.html#_summary)) to the Library and Measure search capabilities. Adding this allows our `getArtifactCounts` trpc procedure on the frontend to get the number of artifacts without sending a request that gets all of the artifacts.

## New behavior
Before, it took awhile for the frontend application to load the number of Measure and Library artifacts. This was due to how our `getArtifactCounts` trpc procedure was written- a GET request was sent to get all of the Measures and Libraries and then `.total` on the searchset bundle was returned. Now, `getArtifactCounts` sends requests to `/Measure?_summary=count` and `/Library?_summary=count` so that searchsets excluding all of the entries are returned. 

## Code changes
- `app/src/server/trpc/routers/service.ts` - changed the request to include the `_summary=count` parameter 
- `service/README.md` - added to the list of supported search params
- `service/src/db/dbOperations.ts` - added function `findResourceCountWithQuery` to get the number of documents (artifacts) a query returns
- `service/src/requestSchemas.ts` - added `_summary` as a CoreSearchArg
- `LibraryService.ts`/`MeasureService.ts` - added to `search` to return a summary searchset bundle if the `_summary=count` parameter is included in the query
- `service/src/util/bundleUtils.ts` - added `createSummarySearchsetBundle` function to create a searchset bundle with a specified count and without the `entry` array

# Testing guidance
- Upload a bunch of measure bundles (`npm run db:loadBundle <path to ecqm-content-qicore-2024/bundles/measure>` as an example in the `service` directory)
- Spin up server and frontend in the root directory: `npm run start:all`
- Navigate to the app in the browser. See how long it takes for the Measure and Library counts in the side panel to load, hopefully it is noticeably faster than the main branch.

- `npm run check:all` in root directory 

- Test out the `_summary` search parameter in Insomnia (or some other API client). Make sure that `_summary=count` works properly for both Measures and Libraries. Also check that parameter being used with other search parameters supported by the server.

# Questions
1. `_summary` is not listed in the [Measure Repository Service Docs](http://hl7.org/fhir/us/cqfmeasures/measure-repository-service.html#search) as a parameter. Is it okay that I do this then? I wasn't sure what an alternative solution would be for this issue since this seemed more correct than creating my own endpoint.
