### PR TITLE
Add isOwned extension functionality to txn bundle upload

### DIFF
--- a/service/src/services/BaseService.ts
+++ b/service/src/services/BaseService.ts
@@ -4,7 +4,7 @@ import { checkContentTypeHeader } from '../util/inputUtils';
 import { v4 as uuidv4 } from 'uuid';
 import { createResource, updateResource } from '../db/dbOperations';
 import path from 'path';
-import { DetailedEntry, replaceReferences } from '../util/baseUtils';
+import { DetailedEntry, addIsOwnedExtension, replaceReferences } from '../util/baseUtils';
 
 const logger = loggers.get('default');
 
@@ -49,7 +49,9 @@ async function uploadResourcesFromBundle(entries: DetailedEntry[]) {
           `Expected requests of type PUT or POST, received ${method} for ${entry.resource?.resourceType}/${entry.resource?.id}`
         );
       } else {
-        return insertBundleResources(entry);
+        // if the entry is a Measure, check to see if the isOwned extension needs to be added
+        const modifiedEntry = addIsOwnedExtension(entry);
+        return insertBundleResources(modifiedEntry);
       }
     } else {
       throw new BadRequestError('Each entry must contain request details that provide the HTTP details of the action.');

--- a/service/src/util/baseUtils.ts
+++ b/service/src/util/baseUtils.ts
@@ -1,10 +1,10 @@
 import { v4 as uuidv4 } from 'uuid';
 import { loggers } from '@projecttacoma/node-fhir-server-core';
-import { OperationOutcome } from 'fhir/r4';
+import { FhirResource, OperationOutcome } from 'fhir/r4';
 
 const logger = loggers.get('default');
 
-export type DetailedEntry = fhir4.BundleEntry & {
+export type DetailedEntry = fhir4.BundleEntry<FhirResource> & {
   isPost: boolean;
   oldId?: string;
   newId: string;
@@ -13,6 +13,56 @@ export type DetailedEntry = fhir4.BundleEntry & {
   data?: string;
   outcome?: OperationOutcome;
 };
+
+/**
+ * Add isOwned extension to the main Library reference on a Measure's relatedArtifacts
+ */
+export function addIsOwnedExtension(entry: DetailedEntry) {
+  if (entry.resource?.resourceType && entry.resource?.resourceType === 'Measure' && entry.resource?.library) {
+    // get the main Library of the Measure from the library property and the version
+    const mainLibrary = entry.resource.library[0];
+    const mainLibraryVersion = entry.resource.version;
+
+    // append the version to the end of the library
+    const mainLibraryUrl = mainLibraryVersion ? mainLibrary.concat('|', mainLibraryVersion) : mainLibrary;
+
+    // check if relatedArtifacts property exists on the measure, add it if it doesn't
+    if (entry.resource.relatedArtifact === undefined) {
+      entry.resource.relatedArtifact = [];
+    }
+
+    // check if the main library already exists in the relatedArtifacts
+    const mainLibraryRA = entry.resource.relatedArtifact.find(
+      ra => (ra.url === mainLibraryUrl || ra.resource === mainLibraryUrl) && ra.type === 'composed-of'
+    );
+
+    if (mainLibraryRA) {
+      // check if the main library's extension array exists and create it if it doesn't
+      if (mainLibraryRA.extension) {
+        // if it does exist, check that the isOwned extension is not already on it, add it if not
+        if (
+          mainLibraryRA.extension.find(e => e.url === 'http://hl7.org/fhir/StructureDefinition/artifact-isOwned') ===
+          undefined
+        )
+          mainLibraryRA.extension.push({
+            url: 'http://hl7.org/fhir/StructureDefinition/artifact-isOwned',
+            valueBoolean: true
+          });
+      } else {
+        mainLibraryRA.extension = [
+          { url: 'http://hl7.org/fhir/StructureDefinition/artifact-isOwned', valueBoolean: true }
+        ];
+      }
+    } else {
+      entry.resource.relatedArtifact.push({
+        type: 'composed-of',
+        resource: mainLibraryUrl,
+        extension: [{ url: 'http://hl7.org/fhir/StructureDefinition/artifact-isOwned', valueBoolean: true }]
+      });
+    }
+  }
+  return entry;
+}
 
 /**
  * For entries in a transaction bundle whose IDs will be auto-generated, replace all instances of an existing reference

--- a/service/src/util/baseUtils.ts
+++ b/service/src/util/baseUtils.ts
@@ -15,7 +15,7 @@ export type DetailedEntry = fhir4.BundleEntry<FhirResource> & {
 };
 
 /**
- * Add isOwned extension to the main Library reference on a Measure's relatedArtifacts
+ * Checks entry for Measure type with library and adds isOwned extension to the main Library reference on a Measure's relatedArtifacts
  */
 export function addIsOwnedExtension(entry: DetailedEntry) {
   if (entry.resource?.resourceType && entry.resource?.resourceType === 'Measure' && entry.resource?.library) {


### PR DESCRIPTION
# Summary
Previously, we had only implemented the `isOwned` child artifact functionality when bundles were uploaded using the `dbSetup.ts` script (`npm run db:loadBundle`). Now that we have the `./directory-upload.sh` script, want want to make sure that the `isOwned` extension gets added when transaction bundles are uploaded.

## New behavior
The same thing that is done for adding the `isOwned` extension on the `relatedArtifacts` of Measures is now done for transaction bundle uploads as well as the `dbSetup.ts` script.

Note: there is more code that we can probably consolidate/make more reusable but I tried to keep it to the scope of the `isOwned` extension so that we can have this functionality for the Connectathon.

## Code changes
- `dbSetup.ts` - pulled out `isOwned` extension code and replaced it with a function call (`addIsOwnedExtension`)
- `BaseService.ts` - added `isOwned` functionality to the transaction bundle upload through a call to `addIsOwnedExtension`
- `baseUtils.ts` - added `isOwned` extension code to reusable function `addIsOwnedExtension`

# Testing guidance
- `npm run check:all`
- Make sure child artifacts functionality works in the following scenarios (see #69 PR for child artifact testing guidance):
- Uploading a measure bundle through the `dbSetup.ts` script (`npm run db:loadBundle`)
- Uploading a directory of measure bundles (uses transaction bundle upload) through `./directory-upload.sh` script
- Send a `POST` request to the server where the body contains a transaction bundle
