### PR TITLE
Enforce unique combined url and version

### DIFF
--- a/app/src/components/ReleaseModal.tsx
+++ b/app/src/components/ReleaseModal.tsx
@@ -36,7 +36,7 @@ export default function ReleaseModal({ open = true, onClose, id, resourceType }:
         console.error(data.status);
         notifications.show({
           title: `Release Failed!`,
-          message: `Server unable to process request`,
+          message: `Server unable to process request. ${data.error ?? ''}`,
           icon: <AlertCircle />,
           color: 'red'
         });
@@ -70,19 +70,19 @@ export default function ReleaseModal({ open = true, onClose, id, resourceType }:
 
   const releaseMutation = trpc.service.releaseParent.useMutation({
     onSuccess: (data, variables) => {
-      if (!data.location) {
+      if (data.status !== 201) {
+        console.error(data.status);
+        notifications.show({
+          title: `Release Failed!`,
+          message: `Server unable to process request. ${data.error ?? ''}`,
+          icon: <AlertCircle />,
+          color: 'red'
+        });
+      } else if (!data.location) {
         console.error('No resource location for released artifact');
         notifications.show({
           title: `Release Failed!`,
           message: `No resource location exists for draft artifact`,
-          icon: <AlertCircle />,
-          color: 'red'
-        });
-      } else if (data.status !== 201) {
-        console.error(data.status);
-        notifications.show({
-          title: `Release Failed!`,
-          message: `Server unable to process request`,
           icon: <AlertCircle />,
           color: 'red'
         });

--- a/app/src/server/db/mongodb.ts
+++ b/app/src/server/db/mongodb.ts
@@ -6,6 +6,7 @@ if (!process.env.MONGODB_URI) {
 
 const uri = process.env.MONGODB_URI;
 const options = {};
+const COLLECTION_NAMES = ['Measure', 'Library'];
 
 let client;
 let clientPromise: Promise<MongoClient>;
@@ -27,6 +28,11 @@ if (process.env.NODE_ENV === 'development') {
   client = new MongoClient(uri, options);
   clientPromise = client.connect();
 }
+
+COLLECTION_NAMES.map(async cn => {
+  const collection = (await clientPromise).db().collection(cn);
+  collection.createIndex({ url: 1, version: 1 }, { unique: true });
+});
 
 // Export a module-scoped MongoClient promise. By doing this in a
 // separate module, the client can be shared across functions.

--- a/service/scripts/dbSetup.ts
+++ b/service/scripts/dbSetup.ts
@@ -16,7 +16,9 @@ async function createCollections() {
 
   const creations = COLLECTION_NAMES.map(async cn => {
     console.log(`Creating collection ${cn}`);
-    await (await Connection.db.createCollection(cn)).createIndex({ id: 1 }, { unique: true });
+    const collection = await Connection.db.createCollection(cn);
+    await collection.createIndex({ id: 1 }, { unique: true });
+    await collection.createIndex({ url: 1, version: 1 }, { unique: true });
   });
 
   await Promise.all(creations);

--- a/service/src/db/dbOperations.ts
+++ b/service/src/db/dbOperations.ts
@@ -42,7 +42,7 @@ export async function findResourceCountWithQuery(query: Filter<any>, resourceTyp
  */
 export async function findDataRequirementsWithQuery<T extends fhir4.Library>(query: Filter<any>) {
   const collection = Connection.db.collection('Library');
-  return collection.findOne<T>({ _dataRequirements: query }, { projection: { _id: 0, _dataRequirements: 0 } });
+  return collection.findOne<T>({ _dataRequirements: query }, { projection: { _id: 0, _dataRequirements: 0, url: 0 } });
 }
 
 /**

--- a/service/src/services/LibraryService.ts
+++ b/service/src/services/LibraryService.ts
@@ -179,7 +179,7 @@ export class LibraryService implements Service<fhir4.Library> {
     // add the data requirements query params to the data requirements Library resource and add to the Library collection
     const results = { ...dataRequirements.results } as FhirLibraryWithDR;
     results['_dataRequirements'] = dataReqsQuery;
-    results.url = `data-requirements/${dataRequirements.results.id}`;
+    results.url = `Library/${dataRequirements.results.id}`;
     createResource(results, 'Library');
 
     logger.info('Successfully generated $data-requirements report');

--- a/service/src/services/LibraryService.ts
+++ b/service/src/services/LibraryService.ts
@@ -179,6 +179,7 @@ export class LibraryService implements Service<fhir4.Library> {
     // add the data requirements query params to the data requirements Library resource and add to the Library collection
     const results = { ...dataRequirements.results } as FhirLibraryWithDR;
     results['_dataRequirements'] = dataReqsQuery;
+    results.url = `data-requirements/${dataRequirements.results.id}`;
     createResource(results, 'Library');
 
     logger.info('Successfully generated $data-requirements report');

--- a/service/src/services/MeasureService.ts
+++ b/service/src/services/MeasureService.ts
@@ -183,6 +183,7 @@ export class MeasureService implements Service<fhir4.Measure> {
     // add the data requirements query params to the data requirements Library resource and add to the Library collection
     const results = { ...dataRequirements.results } as FhirLibraryWithDR;
     results['_dataRequirements'] = dataReqsQuery;
+    results.url = `data-requirements/${dataRequirements.results.id}`;
     createResource(results, 'Library');
 
     logger.info('Successfully generated $data-requirements report');

--- a/service/src/services/MeasureService.ts
+++ b/service/src/services/MeasureService.ts
@@ -183,7 +183,7 @@ export class MeasureService implements Service<fhir4.Measure> {
     // add the data requirements query params to the data requirements Library resource and add to the Library collection
     const results = { ...dataRequirements.results } as FhirLibraryWithDR;
     results['_dataRequirements'] = dataReqsQuery;
-    results.url = `data-requirements/${dataRequirements.results.id}`;
+    results.url = `Library/${dataRequirements.results.id}`;
     createResource(results, 'Library');
 
     logger.info('Successfully generated $data-requirements report');


### PR DESCRIPTION
# Summary
Enforced unique combination of url and version for both draft artifacts and measure repository artifacts. Updates some error handling to show useful error information to the user.

## New behavior
If a user attempts to create a resource (new or update or through operations or http PUT/POST) that has a combined url/version that conflicts with an existing combined url/version, they will receive an error indicating that the action failed because of a duplicate key (and will show the duplicate keys in question).

## Code changes

dbSetup.ts - creates a unique url/version index for the measure-repository collections
mongodb.ts - creates a unique url/version index for the draft-repository collections
service.ts - passes an error through if a 500 response is received from the server
ReleaseModal.tsx - on release, prioritizes check for error status (non 201) before checking for location and shows error message if any is passed through

# Testing guidance

`npm run check:all`
Recommend dropping/resetting both databases before testing so that indexes are created fresh.

For the following tests, an error with something like "E11000 duplicate key error collection: draft-repository.Measure index: url_1_version_1 dup key: { url: "www.test.com", version: "0.0.1" }" or similar is expected (but with any additional context and the specific keys that are of issue in each case).

- Draft artifacts: Test draft artifact conflicts by creating a new draft measure and giving it a url, such as 'www.test.com'. Create another measure and give it the same url. You should receive an error notification upon hitting the "Update" button.
- Artifact release: Create a draft artifact with the same url as an active artifact. You can do this by releasing an existing active Measure (i.e. load the Colonoscopy Measure, view, and select "Create Draft of Measure"). Manually update the version of the draft artifact to match the active artifact (I used Robo 3T to update this directly in the database). Release the draft measure. You should receive an error notification upon hitting the "Release" button.
- Artifact child release: Similar to the above, but instead, change the version of the draft child library to match the active child library, and return the parent draft measure version to an incremented version that doesn't match the active measure. Release the draft measure. You should receive a success notification for the measure and an error notification for the child library.
- Artifact draft: Use the "Create Draft of Measure" (or Library) button twice in a row on the same artifact. The second time should show an error notification.
- Service interaction: You can also test the server unique keys with direct insomnia POST (or PUT). For example, copy the content (or at least use the same url and version) of an existing active Measure. Put that content in a POST to http://localhost:3000/4_0_1/Measure. The server should return a 500 error with an OperationOutcome indicating the duplicate key.
- Play around with other server interactions or any other user actions that can trigger an artifact key conflict.
