### PR TITLE
Disable child operations

### DIFF
--- a/app/src/pages/[resourceType]/[id].tsx
+++ b/app/src/pages/[resourceType]/[id].tsx
@@ -170,7 +170,17 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
             <Text size="xl" color="gray">
               {jsonData.resourceType}/{jsonData.id}
             </Text>
-            <Button w={240} loading={draftFromArtifactMutation.isLoading} onClick={createDraftOfArtifact}>
+            <Button
+              w={240}
+              loading={draftFromArtifactMutation.isLoading}
+              onClick={createDraftOfArtifact}
+              disabled={
+                !!jsonData.extension?.find(
+                  ext =>
+                    ext.url === 'http://hl7.org/fhir/StructureDefinition/artifact-isOwned' && ext.valueBoolean === true
+                )
+              }
+            >
               Create Draft of {jsonData.resourceType}
             </Button>
           </Group>

--- a/app/src/pages/[resourceType]/[id].tsx
+++ b/app/src/pages/[resourceType]/[id].tsx
@@ -11,7 +11,8 @@ import {
   Stack,
   Tabs,
   Text,
-  TextInput
+  TextInput,
+  Tooltip
 } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
 import React, { useEffect, useMemo, useState } from 'react';
@@ -170,19 +171,26 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
             <Text size="xl" color="gray">
               {jsonData.resourceType}/{jsonData.id}
             </Text>
-            <Button
-              w={240}
-              loading={draftFromArtifactMutation.isLoading}
-              onClick={createDraftOfArtifact}
-              disabled={
-                !!jsonData.extension?.find(
-                  ext =>
-                    ext.url === 'http://hl7.org/fhir/StructureDefinition/artifact-isOwned' && ext.valueBoolean === true
-                )
-              }
-            >
-              Create Draft of {jsonData.resourceType}
-            </Button>
+            {!!jsonData?.extension?.find(
+              ext => ext.url === 'http://hl7.org/fhir/StructureDefinition/artifact-isOwned' && ext.valueBoolean === true
+            ) ? (
+              <Tooltip label="Child artifacts cannot be directly drafted">
+                <span>
+                  <Button w={240} loading={draftFromArtifactMutation.isLoading} disabled={true}>
+                    Create Draft of {jsonData.resourceType}
+                  </Button>
+                </span>
+              </Tooltip>
+            ) : (
+              <Button
+                w={240}
+                loading={draftFromArtifactMutation.isLoading}
+                onClick={createDraftOfArtifact}
+                disabled={false}
+              >
+                Create Draft of {jsonData.resourceType}
+              </Button>
+            )}
           </Group>
         </div>
         <Divider my="sm" pb={6} />

--- a/app/src/pages/authoring/[resourceType]/[id].tsx
+++ b/app/src/pages/authoring/[resourceType]/[id].tsx
@@ -253,7 +253,17 @@ export default function ResourceAuthoringPage() {
               >
                 Update
               </Button>
-              <Button w={120} onClick={() => setIsModalOpen(true)}>
+              <Button
+                w={120}
+                onClick={() => setIsModalOpen(true)}
+                disabled={
+                  !!resource?.extension?.find(
+                    ext =>
+                      ext.url === 'http://hl7.org/fhir/StructureDefinition/artifact-isOwned' &&
+                      ext.valueBoolean === true
+                  )
+                }
+              >
                 Release
               </Button>
             </Group>

--- a/app/src/pages/authoring/[resourceType]/[id].tsx
+++ b/app/src/pages/authoring/[resourceType]/[id].tsx
@@ -253,19 +253,22 @@ export default function ResourceAuthoringPage() {
               >
                 Update
               </Button>
-              <Button
-                w={120}
-                onClick={() => setIsModalOpen(true)}
-                disabled={
-                  !!resource?.extension?.find(
-                    ext =>
-                      ext.url === 'http://hl7.org/fhir/StructureDefinition/artifact-isOwned' &&
-                      ext.valueBoolean === true
-                  )
-                }
-              >
-                Release
-              </Button>
+              {!!resource?.extension?.find(
+                ext =>
+                  ext.url === 'http://hl7.org/fhir/StructureDefinition/artifact-isOwned' && ext.valueBoolean === true
+              ) ? (
+                <Tooltip label="Child artifacts cannot be directly released">
+                  <span>
+                    <Button w={120} disabled={true}>
+                      Release
+                    </Button>
+                  </span>
+                </Tooltip>
+              ) : (
+                <Button w={120} onClick={() => setIsModalOpen(true)} disabled={false}>
+                  Release
+                </Button>
+              )}
             </Group>
           </Stack>
         </Grid.Col>

--- a/app/src/pages/authoring/index.tsx
+++ b/app/src/pages/authoring/index.tsx
@@ -169,7 +169,7 @@ export default function AuthoringPage() {
               data={artifacts}
               value={selectedArtifact}
               onChange={setSelectedArtifact}
-              placeholder="Select an independent (non-child) artifact"
+              placeholder={resourceType === 'Library' ? 'Choose an independent (non-child) Library' : ''}
             />
           ) : (
             <Text c="red">An unknown error occurred fetching artifacts</Text>

--- a/app/src/pages/authoring/index.tsx
+++ b/app/src/pages/authoring/index.tsx
@@ -169,6 +169,7 @@ export default function AuthoringPage() {
               data={artifacts}
               value={selectedArtifact}
               onChange={setSelectedArtifact}
+              placeholder="Select an independent (non-child) artifact"
             />
           ) : (
             <Text c="red">An unknown error occurred fetching artifacts</Text>

--- a/app/src/server/trpc/routers/service.ts
+++ b/app/src/server/trpc/routers/service.ts
@@ -38,7 +38,10 @@ export const serviceRouter = router({
       );
       const artifactList = artifactBundle.entry?.map(entry => ({
         label: entry.resource?.name || entry.resource?.id || '',
-        value: entry.resource?.id || `${entry.resource?.resourceType}` || ''
+        value: entry.resource?.id || `${entry.resource?.resourceType}` || '',
+        disabled: !!entry.resource?.extension?.find(
+          ext => ext.url === 'http://hl7.org/fhir/StructureDefinition/artifact-isOwned' && ext.valueBoolean === true
+        )
       }));
 
       return artifactList;

--- a/service/src/util/baseUtils.ts
+++ b/service/src/util/baseUtils.ts
@@ -23,7 +23,7 @@ export function addIsOwnedExtension(entry: DetailedEntry) {
   if (entry.resource?.resourceType && entry.resource?.resourceType === 'Measure' && entry.resource?.library) {
     // get the main Library of the Measure from the library property and the version
     const mainLibrary = entry.resource.library[0];
-    const mainLibraryVersion = entry.resource.version; //TODO: is it okay that this is pulling the measure version rather than the library version, do we assume that these are the same?
+    const mainLibraryVersion = entry.resource.version;
 
     // append the version to the end of the library
     const mainLibraryUrl = mainLibraryVersion ? mainLibrary.concat('|', mainLibraryVersion) : mainLibrary;
@@ -67,6 +67,9 @@ export function addIsOwnedExtension(entry: DetailedEntry) {
   return { modifiedEntry: entry, url: null };
 }
 
+/**
+ * Checks ownedUrls for entry url and adds isOwned extension to the resource if found in ownedUrls
+ */
 export function addLibraryIsOwned(entry: DetailedEntry, ownedUrls: string[]) {
   // add owned to identified resources (currently assumes these will only be Libraries)
   if (entry.resource?.resourceType === 'Library' && entry.resource.url) {
@@ -76,7 +79,7 @@ export function addLibraryIsOwned(entry: DetailedEntry, ownedUrls: string[]) {
     if (ownedUrls.includes(libraryUrl)) {
       entry.resource.extension
         ? entry.resource.extension.push({
-            url: 'http://hl7.org/fhir/StructureDefinition/artifact-isOwned', //TODO: should we use isOwned or make up our own for now?
+            url: 'http://hl7.org/fhir/StructureDefinition/artifact-isOwned',
             valueBoolean: true
           })
         : (entry.resource.extension = [


### PR DESCRIPTION
# Summary
Adds logic for adding the isOwned extension onto a library during upload if that library is a child artifact, and uses the isOwned extension to disable release and drafting operations for the child.

## New behavior

- Child libraries have an isOwned extension.
- Child artifacts may not be drafted or released

## Code changes

- Changes in `[id].tsx` for both the repository and authoring side to disable draft and release respectively
- Changes to `index.tsx` to have a more informative select placeholder and to `service.ts` to populate the select with data that has child artifacts disabled
- 'baseUtils.ts` `addIsOwnedExtension` returns the url for the reference and `addLibraryIsOwned` function creates an isOwned extension on the passed entry resource if its url is in the passed list of ownedUrls
- `BaseService.ts` and `dbSetup.ts` both preprocess the entries being added to the database to find the owned Urls, then adds isOwned extension to child libraries that were found before inserting them into the database

# Testing guidance

`npm run build:all`
`npm run check:all`

Similar to https://github.com/projecttacoma/measure-repository/pull/76, we want to check that the new extension is applied for db:loadBundle, POSTing a transaction bundle, and directory-upload.sh. I used ColorectalCancerScreening -> I mentioned an issue with this in dev hour, but I believe that was an issue actually introduced for some other previous testing and isn't actually in the source measure.
Sample, using ColorectalCancerScreening:
- `npm run db:reset`
- `npm run db:loadBundle ../../ecqm-content-r4-2021/bundles/measure/ColorectalCancerScreeningsFHIR/ColorectalCancerScreeningsFHIR-bundle.json`
- `npm run db:reset`
- POST transaction bundle to http://localhost:3000/4_0_1/
- `npm run db:reset`
- run ./directory-upload.sh script with bundle

We also want to test the disabling in the app itself
Run app, create a draft from the measure (should draft main library) and look for the following disabled: 
- Repository > Library list > main library details > Create Draft of Library disabled
- Authoring > (from scratch box) Library > Select dropdown > main library disabled
- Authoring > (side panel) Library > main library edit > Release disabled
Disabled buttons should have explanatory tooltips, and the disabled select has a more detailed select placeholder text.