### PR TITLE
Add version to the artifact name/id in the dropdown

### DIFF
--- a/app/src/server/trpc/routers/service.ts
+++ b/app/src/server/trpc/routers/service.ts
@@ -37,7 +37,11 @@ export const serviceRouter = router({
         resArtifacts => resArtifacts.json() as Promise<fhir4.Bundle<FhirArtifact>>
       );
       const artifactList = artifactBundle.entry?.map(entry => ({
-        label: entry.resource?.name || entry.resource?.id || '',
+        label:
+          entry.resource?.name?.concat(`|${entry.resource?.version}`) ||
+          entry.resource?.name ||
+          entry.resource?.id ||
+          '',
         value: entry.resource?.id || `${entry.resource?.resourceType}` || '',
         disabled: !!entry.resource?.extension?.find(
           ext => ext.url === 'http://hl7.org/fhir/StructureDefinition/artifact-isOwned' && ext.valueBoolean === true

--- a/app/src/server/trpc/routers/service.ts
+++ b/app/src/server/trpc/routers/service.ts
@@ -38,9 +38,8 @@ export const serviceRouter = router({
       );
       const artifactList = artifactBundle.entry?.map(entry => ({
         label:
-          entry.resource?.name?.concat(`|${entry.resource?.version}`) ||
-          entry.resource?.name ||
-          entry.resource?.id ||
+          entry.resource?.name?.concat(`|${entry.resource.version}`) ||
+          entry.resource?.id?.concat(`|${entry.resource.version}`) ||
           '',
         value: entry.resource?.id || `${entry.resource?.resourceType}` || '',
         disabled: !!entry.resource?.extension?.find(


### PR DESCRIPTION
# Summary
Adds version to the label of an artifact so it's not just the name or id. This prevents multiple artifacts of the same name but with different versions appearing in the dropdown for drafting measures:

![image](https://github.com/projecttacoma/measure-repository/assets/30158156/57cade3f-d92f-4aa4-9ab9-f41769cb70c0)

## New behavior
None

## Code changes
- `service.ts` - add version to the artifact label

# Testing guidance
- `npm run check:all`
- `npm run start:all`
- Make sure everything looks good!