### PR TITLE
Add _elements search param

### DIFF
--- a/app/src/pages/[resourceType].tsx
+++ b/app/src/pages/[resourceType].tsx
@@ -52,8 +52,8 @@ export const getServerSideProps: GetServerSideProps<{
   // Cast to ArtifactResourceType since we know the server should only support resourceType that matches
   const checkedResourceType = resourceType as ArtifactResourceType;
 
-  // Fetch resource data
-  const res = await fetch(`${process.env.MRS_SERVER}/${checkedResourceType}`);
+  // Fetch resource data with the _elements parameter so we only get the elements that we need
+  const res = await fetch(`${process.env.MRS_SERVER}/${checkedResourceType}?_elements=id,identifier,name,url,version`);
   const bundle = (await res.json()) as fhir4.Bundle<FhirArtifact>;
   if (!bundle.entry) {
     // Measure Repository should not provide a bundle without an entry

--- a/app/src/server/trpc/routers/service.ts
+++ b/app/src/server/trpc/routers/service.ts
@@ -33,9 +33,9 @@ export const serviceRouter = router({
   getArtifactsByType: publicProcedure
     .input(z.object({ resourceType: z.enum(['Measure', 'Library']) }))
     .query(async ({ input }) => {
-      const artifactBundle = await fetch(`${process.env.MRS_SERVER}/${input.resourceType}`).then(
-        resArtifacts => resArtifacts.json() as Promise<fhir4.Bundle<FhirArtifact>>
-      );
+      const artifactBundle = await fetch(
+        `${process.env.MRS_SERVER}/${input.resourceType}?_elements=id,name,extension`
+      ).then(resArtifacts => resArtifacts.json() as Promise<fhir4.Bundle<FhirArtifact>>);
       const artifactList = artifactBundle.entry?.map(entry => ({
         label:
           entry.resource?.name?.concat(`|${entry.resource.version}`) ||

--- a/app/src/server/trpc/routers/service.ts
+++ b/app/src/server/trpc/routers/service.ts
@@ -34,7 +34,7 @@ export const serviceRouter = router({
     .input(z.object({ resourceType: z.enum(['Measure', 'Library']) }))
     .query(async ({ input }) => {
       const artifactBundle = await fetch(
-        `${process.env.MRS_SERVER}/${input.resourceType}?_elements=id,name,extension`
+        `${process.env.MRS_SERVER}/${input.resourceType}?_elements=id,name,extension,version`
       ).then(resArtifacts => resArtifacts.json() as Promise<fhir4.Bundle<FhirArtifact>>);
       const artifactList = artifactBundle.entry?.map(entry => ({
         label:

--- a/service/README.md
+++ b/service/README.md
@@ -114,9 +114,13 @@ The Measure Repository Service server supports `Library` and `Measure` resource 
 - url
 - version (can appear only in combination with a url search)
 
-The Measure Repository Service server also supports the `_summary` search parameter specified in the [HL7 FHIR Search Docs](https://www.hl7.org/fhir/search.html#_summary). The server currently supports the following `_summary` parameter values:
+The Measure Repository Service server also supports the `_summary` and `_elements` search parameters.
+
+The `_summary` parameter is specified in the [HL7 FHIR Search Docs](https://www.hl7.org/fhir/search.html#_summary). The server currently supports the following `_summary` parameter values:
 
 - count
+
+The `_elements` parameter is specified in the [HL7 FHIR Search Docs](https://www.hl7.org/fhir/search.html#_elements) and supports a comma-separated list of base element names.
 
 ### Package
 

--- a/service/src/db/dbOperations.ts
+++ b/service/src/db/dbOperations.ts
@@ -35,7 +35,11 @@ export async function findResourceElementsWithQuery<T extends fhir4.FhirResource
   resourceType: FhirResourceType
 ) {
   const collection = Connection.db.collection(resourceType);
-  const projection: any = { status: 1, resourceType: 1, type: 1 };
+
+  // if the resourceType is Library, then we want to include type in the projection
+  const projection: any =
+    resourceType === 'Library' ? { status: 1, resourceType: 1, type: 1 } : { status: 1, resourceType: 1 };
+
   (query._elements as string[]).forEach(elem => {
     projection[elem] = 1;
   });

--- a/service/src/db/dbOperations.ts
+++ b/service/src/db/dbOperations.ts
@@ -22,7 +22,28 @@ export async function findResourcesWithQuery<T extends fhir4.FhirResource>(
   const collection = Connection.db.collection(resourceType);
   query._dataRequirements = { $exists: false };
   query._summary = { $exists: false };
+  query._elements = { $exists: false };
   return collection.find<T>(query, { projection: { _id: 0, _dataRequirements: 0 } }).toArray();
+}
+
+/**
+ * searches the database and returns an array of all resources of the given type that match the given query
+ * but the resources only include the elements specified by the _elements parameter
+ */
+export async function findResourceElementsWithQuery<T extends fhir4.FhirResource>(
+  query: Filter<any>,
+  resourceType: FhirResourceType
+) {
+  const collection = Connection.db.collection(resourceType);
+  const projection: any = { status: 1, resourceType: 1, type: 1 };
+  (query._elements as string[]).forEach(elem => {
+    projection[elem] = 1;
+  });
+  projection['_id'] = 0;
+  query._dataRequirements = { $exists: false };
+  query._summary = { $exists: false };
+  query._elements = { $exists: false };
+  return collection.find<T>(query, { projection: projection }).toArray();
 }
 
 /**
@@ -34,6 +55,7 @@ export async function findResourceCountWithQuery(query: Filter<any>, resourceTyp
   const collection = Connection.db.collection(resourceType);
   query._dataRequirements = { $exists: false };
   query._summary = { $exists: false };
+  query._elements = { $exists: false };
   return collection.countDocuments(query);
 }
 

--- a/service/src/requestSchemas.ts
+++ b/service/src/requestSchemas.ts
@@ -196,7 +196,9 @@ export const CoreSearchArgs = z
     url: z.string().url(),
     version: z.string(),
     // adding _summary for count (https://www.hl7.org/fhir/search.html#_summary)
-    _summary: z.literal('count')
+    _summary: z.literal('count'),
+    // adding _elements for a comma separated string (https://www.hl7.org/fhir/search.html#_elements)
+    _elements: z.string()
   })
   .partial()
   .strict();

--- a/service/src/services/LibraryService.ts
+++ b/service/src/services/LibraryService.ts
@@ -4,6 +4,7 @@ import {
   findDataRequirementsWithQuery,
   findResourceById,
   findResourceCountWithQuery,
+  findResourceElementsWithQuery,
   findResourcesWithQuery,
   updateResource
 } from '../db/dbOperations';
@@ -46,6 +47,13 @@ export class LibraryService implements Service<fhir4.Library> {
     if (parsedQuery._summary && parsedQuery._summary === 'count') {
       const count = await findResourceCountWithQuery(mongoQuery, 'Library');
       return createSummarySearchsetBundle<fhir4.Library>(count);
+    }
+    // if the _elements parameter with a comma-separated string is included
+    // then return a searchset bundle that includes only those elements
+    // on those resource entries
+    else if (parsedQuery._elements) {
+      const entries = await findResourceElementsWithQuery<fhir4.Library>(mongoQuery, 'Library');
+      return createSearchsetBundle(entries);
     } else {
       const entries = await findResourcesWithQuery<fhir4.Library>(mongoQuery, 'Library');
       return createSearchsetBundle(entries);

--- a/service/src/services/LibraryService.ts
+++ b/service/src/services/LibraryService.ts
@@ -53,6 +53,20 @@ export class LibraryService implements Service<fhir4.Library> {
     // on those resource entries
     else if (parsedQuery._elements) {
       const entries = await findResourceElementsWithQuery<fhir4.Library>(mongoQuery, 'Library');
+      // add the SUBSETTED tag to the resources returned by the _elements parameter
+      entries.map(e => {
+        if (e.meta) {
+          if (e.meta.tag) {
+            e.meta.tag.push({ code: 'SUBSETTED', system: 'http://terminology.hl7.org/CodeSystem/v3-ObservationValue' });
+          } else {
+            e.meta.tag = [{ code: 'SUBSETTED', system: 'http://terminology.hl7.org/CodeSystem/v3-ObservationValue' }];
+          }
+        } else {
+          e.meta = {
+            tag: [{ code: 'SUBSETTED', system: 'http://terminology.hl7.org/CodeSystem/v3-ObservationValue' }]
+          };
+        }
+      });
       return createSearchsetBundle(entries);
     } else {
       const entries = await findResourcesWithQuery<fhir4.Library>(mongoQuery, 'Library');

--- a/service/src/services/MeasureService.ts
+++ b/service/src/services/MeasureService.ts
@@ -4,6 +4,7 @@ import {
   findDataRequirementsWithQuery,
   findResourceById,
   findResourceCountWithQuery,
+  findResourceElementsWithQuery,
   findResourcesWithQuery,
   updateResource
 } from '../db/dbOperations';
@@ -47,6 +48,13 @@ export class MeasureService implements Service<fhir4.Measure> {
     if (parsedQuery._summary && parsedQuery._summary === 'count') {
       const count = await findResourceCountWithQuery(mongoQuery, 'Measure');
       return createSummarySearchsetBundle<fhir4.Measure>(count);
+    }
+    // if the _elements parameter with a comma-separated string is included
+    // then return a searchset bundle that includes only those elements
+    // on those resource entries
+    else if (parsedQuery._elements) {
+      const entries = await findResourceElementsWithQuery<fhir4.Measure>(mongoQuery, 'Measure');
+      return createSearchsetBundle(entries);
     } else {
       const entries = await findResourcesWithQuery<fhir4.Measure>(mongoQuery, 'Measure');
       return createSearchsetBundle(entries);

--- a/service/src/services/MeasureService.ts
+++ b/service/src/services/MeasureService.ts
@@ -54,6 +54,20 @@ export class MeasureService implements Service<fhir4.Measure> {
     // on those resource entries
     else if (parsedQuery._elements) {
       const entries = await findResourceElementsWithQuery<fhir4.Measure>(mongoQuery, 'Measure');
+      // add the SUBSETTED tag to the resources returned by the _elements parameter
+      entries.map(e => {
+        if (e.meta) {
+          if (e.meta.tag) {
+            e.meta.tag.push({ code: 'SUBSETTED', system: 'http://terminology.hl7.org/CodeSystem/v3-ObservationValue' });
+          } else {
+            e.meta.tag = [{ code: 'SUBSETTED', system: 'http://terminology.hl7.org/CodeSystem/v3-ObservationValue' }];
+          }
+        } else {
+          e.meta = {
+            tag: [{ code: 'SUBSETTED', system: 'http://terminology.hl7.org/CodeSystem/v3-ObservationValue' }]
+          };
+        }
+      });
       return createSearchsetBundle(entries);
     } else {
       const entries = await findResourcesWithQuery<fhir4.Measure>(mongoQuery, 'Measure');

--- a/service/src/util/queryUtils.ts
+++ b/service/src/util/queryUtils.ts
@@ -31,6 +31,9 @@ export function getMongoQueryFromRequest(query: RequestQuery): Filter<any> {
         mf['identifier.system'] = splitIden[0];
         mf['identifier.value'] = splitIden[1];
       }
+    } else if (key === '_elements') {
+      const elements = query[key] as string;
+      mf[key] = elements.split(',');
     } else {
       // Otherwise no parsing necessary
       mf[key] = query[key];

--- a/service/test/services/LibraryService.test.ts
+++ b/service/test/services/LibraryService.test.ts
@@ -18,7 +18,15 @@ const LIBRARY_WITH_URL_ONLY_ID: fhir4.Library = {
   resourceType: 'Library',
   type: { coding: [{ code: 'logic-library' }] },
   id: 'testWithUrl',
-  status: 'active'
+  status: 'active',
+  meta: {
+    tag: [
+      {
+        code: 'SUBSETTED',
+        system: 'http://terminology.hl7.org/CodeSystem/v3-ObservationValue'
+      }
+    ]
+  }
 };
 
 const LIBRARY_WITH_IDENTIFIER_VALUE: fhir4.Library = {

--- a/service/test/services/LibraryService.test.ts
+++ b/service/test/services/LibraryService.test.ts
@@ -14,6 +14,13 @@ const LIBRARY_WITH_URL: fhir4.Library = {
   url: 'http://example.com'
 };
 
+const LIBRARY_WITH_URL_ONLY_ID: fhir4.Library = {
+  resourceType: 'Library',
+  type: { coding: [{ code: 'logic-library' }] },
+  id: 'testWithUrl',
+  status: 'active'
+};
+
 const LIBRARY_WITH_IDENTIFIER_VALUE: fhir4.Library = {
   resourceType: 'Library',
   type: { coding: [{ code: 'logic-library' }] },
@@ -162,6 +169,51 @@ describe('LibraryService', () => {
               })
             ])
           );
+        });
+    });
+
+    it('returns 200 and correct searchset bundle with only id element when query matches single resource', async () => {
+      await supertest(server.app)
+        .get('/4_0_1/Library')
+        .query({ _elements: 'id', status: 'active', url: 'http://example.com' })
+        .set('Accept', 'application/json+fhir')
+        .expect(200)
+        .then(response => {
+          expect(response.body.resourceType).toEqual('Bundle');
+          expect(response.body.total).toEqual(1);
+          expect(response.body.entry[0].resource).toEqual(LIBRARY_WITH_URL_ONLY_ID);
+        });
+    });
+
+    it('returns 200 and correct searchset bundle with only id element when query matches multiple resources', async () => {
+      await supertest(server.app)
+        .get('/4_0_1/Library')
+        .query({ _elements: 'id', status: 'active' })
+        .set('Accept', 'application/json+fhir')
+        .expect(200)
+        .then(response => {
+          expect(response.body.resourceType).toEqual('Bundle');
+          expect(response.body.total).toEqual(7);
+          expect(response.body.entry).toEqual(
+            expect.arrayContaining([
+              expect.objectContaining<fhir4.BundleEntry>({
+                resource: LIBRARY_WITH_URL_ONLY_ID
+              })
+            ])
+          );
+        });
+    });
+
+    it('returns 200 and correct searchset bundle that does not have entries only the count when the _summary=count parameter is provided', async () => {
+      await supertest(server.app)
+        .get('/4_0_1/Library')
+        .query({ _summary: 'count' })
+        .set('Accept', 'application/json+fhir')
+        .expect(200)
+        .then(response => {
+          expect(response.body.resourceType).toEqual('Bundle');
+          expect(response.body.total).toEqual(9);
+          expect(response.body.entry).toBeUndefined;
         });
     });
 

--- a/service/test/services/MeasureService.test.ts
+++ b/service/test/services/MeasureService.test.ts
@@ -19,7 +19,15 @@ const MEASURE_WITH_URL: fhir4.Measure = {
 const MEASURE_WITH_URL_ONLY_ID: fhir4.Measure = {
   resourceType: 'Measure',
   id: 'testWithUrl',
-  status: 'active'
+  status: 'active',
+  meta: {
+    tag: [
+      {
+        code: 'SUBSETTED',
+        system: 'http://terminology.hl7.org/CodeSystem/v3-ObservationValue'
+      }
+    ]
+  }
 };
 
 const MEASURE_WITH_IDENTIFIER_VALUE_ROOT_LIB: fhir4.Measure = {

--- a/service/test/services/MeasureService.test.ts
+++ b/service/test/services/MeasureService.test.ts
@@ -16,6 +16,12 @@ const MEASURE_WITH_URL: fhir4.Measure = {
   version: 'searchable'
 };
 
+const MEASURE_WITH_URL_ONLY_ID: fhir4.Measure = {
+  resourceType: 'Measure',
+  id: 'testWithUrl',
+  status: 'active'
+};
+
 const MEASURE_WITH_IDENTIFIER_VALUE_ROOT_LIB: fhir4.Measure = {
   resourceType: 'Measure',
   identifier: [{ value: 'measureWithIdentifierValueRootLib' }],
@@ -154,6 +160,51 @@ describe('MeasureService', () => {
               })
             ])
           );
+        });
+    });
+
+    it('returns 200 and correct searchset bundle with only id element when query matches single resource', async () => {
+      await supertest(server.app)
+        .get('/4_0_1/Measure')
+        .query({ _elements: 'id', status: 'active', url: 'http://example.com' })
+        .set('Accept', 'application/json+fhir')
+        .expect(200)
+        .then(response => {
+          expect(response.body.resourceType).toEqual('Bundle');
+          expect(response.body.total).toEqual(1);
+          expect(response.body.entry[0].resource).toEqual(MEASURE_WITH_URL_ONLY_ID);
+        });
+    });
+
+    it('returns 200 and correct searchset bundle with only id element when query matches multiple resources', async () => {
+      await supertest(server.app)
+        .get('/4_0_1/Measure')
+        .query({ _elements: 'id', status: 'active' })
+        .set('Accept', 'application/json+fhir')
+        .expect(200)
+        .then(response => {
+          expect(response.body.resourceType).toEqual('Bundle');
+          expect(response.body.total).toEqual(7);
+          expect(response.body.entry).toEqual(
+            expect.arrayContaining([
+              expect.objectContaining<fhir4.BundleEntry>({
+                resource: MEASURE_WITH_URL_ONLY_ID
+              })
+            ])
+          );
+        });
+    });
+
+    it('returns 200 and correct searchset bundle that does not have entries only the count when the _summary=count parameter is provided', async () => {
+      await supertest(server.app)
+        .get('/4_0_1/Measure')
+        .query({ _summary: 'count' })
+        .set('Accept', 'application/json+fhir')
+        .expect(200)
+        .then(response => {
+          expect(response.body.resourceType).toEqual('Bundle');
+          expect(response.body.total).toEqual(7);
+          expect(response.body.entry).toBeUndefined;
         });
     });
 


### PR DESCRIPTION
# Summary
This PR implements the `_elements` search parameter (https://www.hl7.org/fhir/search.html#_elements) in Measure and Library search in order to speed up rendering of the list of artifacts in the frontend.

## New behavior
When navigating to the Measure and Library tabs in the measure repository service app, it no longer takes time for it to load because it is now only fetching the necessary information we need from the server rather than the entirety of all of the artifacts.

## Code changes
- `app/src/pages/[resourceType].tsx` - add `_elements` parameter with the elements that we want in order to speed up this fetch
- `app/src/server/trpc/routers/service.ts` - add `_elements` parameter with the elements that we want in order to speed up this fetch
- `service/src/db/dbOperations.ts` - adds a function for getting resources from the database with a query AND `_elements` parameter
- `service/src/requestSchemas.ts` - add `_elements` to the zod schema
- `service/src/services/LibraryService.ts`/`service/src/services/MeasureService.ts`- add new parameter to search implementation
- `service/src/util/queryUtils.ts` - add comma-separated list parsing for `_elements` parameter
- `LibraryService.test.ts`/`MeasureService.test.ts` - add unit tests for `_elements` and `_summary` parameters

# Testing guidance
- `npm run check:all`
- `npm run start:all`
- Make sure you have enough artifacts in the database to see a difference in the speed in the frontend application (`./directory-upload.sh`) 
- Click on the Measure/Library tabs and see how quickly they load! Wow!
- Not sure if this is totally necessary since the `_elements` parameter is technically not valid in a measure repository service at this point in time (like `_summary`), but attached is a collection of Insomnia requests that can be used to test the `_elements` parameter in combination with different queries and the `_summary` parameter.

## Open Questions
- When deciding between using the [`_elements` parameter](https://www.hl7.org/fhir/search.html#_elements) and the [`_summary=true` parameter](https://www.hl7.org/fhir/search.html#_summary), I was not sure how to determine what elements on a Measure or Library were summary=true (in the `_summary` description: "This subset SHOULD consist solely of all supported elements that are marked as "summary" in the base definition of the resource(s)") without either creating a manual list or parsing the StructureDefinition. I figured this was unnecessary and implementing the `_elements` parameter made more sense for this particular use case (we know what elements we want). Does this make sense? Or should `_summary=true` make more sense?

[ElementParamTesting.json](https://github.com/projecttacoma/measure-repository/files/14214850/ElementParamTesting.json)