### PR TITLE
Batch release

### DIFF
--- a/app/src/components/ReleaseModal.tsx
+++ b/app/src/components/ReleaseModal.tsx
@@ -30,47 +30,9 @@ export default function ReleaseModal({ open = true, onClose, id, resourceType }:
     }
   });
 
-  const releaseChildMutation = trpc.service.releaseChild.useMutation({
-    onSuccess: (data, variables) => {
-      if (data.status !== 201) {
-        console.error(data.status);
-        notifications.show({
-          title: `Release Failed!`,
-          message: `Server unable to process request. ${data.error ?? ''}`,
-          icon: <AlertCircle />,
-          color: 'red'
-        });
-      } else {
-        notifications.show({
-          title: `Draft ${variables.resourceType} released!`,
-          message: `Child draft ${variables.resourceType}/${data.id} successfully released to the Publishable Measure Repository!`,
-          icon: <CircleCheck />,
-          color: 'green'
-        });
-        ctx.draft.getDraftCounts.invalidate();
-        ctx.draft.getDrafts.invalidate();
-
-        // delete draft child artifact from the draft database now that it has been released
-        deleteMutation.mutate({
-          resourceType: variables.resourceType,
-          id: data.id
-        });
-      }
-    },
-    onError: (e, variables) => {
-      console.error(e);
-      notifications.show({
-        title: `Release Failed!`,
-        message: `Attempt to release child ${variables.resourceType} with url ${variables.url} failed with message: ${e.message}`,
-        icon: <AlertCircle />,
-        color: 'red'
-      });
-    }
-  });
-
   const releaseMutation = trpc.service.releaseParent.useMutation({
-    onSuccess: (data, variables) => {
-      if (data.status !== 201) {
+    onSuccess: data => {
+      if (data.status !== 200) {
         console.error(data.status);
         notifications.show({
           title: `Release Failed!`,
@@ -87,31 +49,22 @@ export default function ReleaseModal({ open = true, onClose, id, resourceType }:
           color: 'red'
         });
       } else {
-        notifications.show({
-          title: `Draft ${variables.resourceType} released!`,
-          message: `Draft ${variables.resourceType}/${variables.id} successfully released to the Publishable Measure Repository!`,
-          icon: <CircleCheck />,
-          color: 'green'
+        data.deletable?.forEach(d => {
+          notifications.show({
+            title: `Draft ${d.resourceType} released!`,
+            message: `Draft ${d.resourceType}/${d.id} successfully released to the Publishable Measure Repository!`,
+            icon: <CircleCheck />,
+            color: 'green'
+          });
         });
         ctx.draft.getDraftCounts.invalidate();
         ctx.draft.getDrafts.invalidate();
         router.push(data.location);
 
-        // delete draft artifact from the draft database now that it has been released
-        deleteMutation.mutate({
-          resourceType: resourceType,
-          id: id
-        });
-
-        // go through all of the recursively found child artifacts and release them
-        // child artifacts only get released if the release of the parent was successful
-        // the success of the parent does not rely on the success of its child artifacts
-        // nor do the child artifacts rely on each other
-        data.children.forEach(childArtifact => {
-          releaseChildMutation.mutate({
-            resourceType: childArtifact.resourceType,
-            url: childArtifact.url,
-            version: childArtifact.version
+        data.deletable?.forEach(d => {
+          deleteMutation.mutate({
+            resourceType: d.resourceType,
+            id: d.id
           });
         });
       }

--- a/app/src/components/ReleaseModal.tsx
+++ b/app/src/components/ReleaseModal.tsx
@@ -33,7 +33,7 @@ export default function ReleaseModal({ open = true, onClose, id, resourceType }:
   const releaseMutation = trpc.service.releaseParent.useMutation({
     onSuccess: data => {
       if (data.status !== 200) {
-        console.error(data.status);
+        console.error(data.status || data.error);
         notifications.show({
           title: `Release Failed!`,
           message: `Server unable to process request. ${data.error ?? ''}`,

--- a/app/src/server/trpc/routers/service.ts
+++ b/app/src/server/trpc/routers/service.ts
@@ -156,7 +156,8 @@ export const serviceRouter = router({
         resourceType: 'Measure' | 'Library';
         id: string;
       }[] = [{ resourceType: input.resourceType, id: input.id }]; //start with parent and add children to be deleted upon success
-      const childEntries = children.map(async c => {
+
+      for (const c of children) {
         // get the draft child artifact by its URL and version
         const childDraftRes = await getDraftByUrl(c.url, c.version, c.resourceType);
 
@@ -167,22 +168,23 @@ export const serviceRouter = router({
           childDraftRes.date = DateTime.now().toISO() || '';
           toDelete.push({ resourceType: c.resourceType, id: childDraftRes.id });
         } else {
-          throw new Error(
-            `No child draft artifact found for resourceType ${c.resourceType}, version ${c.version}, and URL ${c.url}`
-          );
+          return {
+            location: null,
+            deletable: null,
+            status: null,
+            error: `No child draft artifact found for resourceType ${c.resourceType}, version ${c.version}, and URL ${c.url}`
+          };
         }
-        return {
+        txnBundle.entry?.push({
           resource: childDraftRes,
           request: {
             method: 'POST',
             url: `${childDraftRes.resourceType}/${childDraftRes.id}`
           }
-        } as BundleEntry<FhirResource>;
-      });
+        } as BundleEntry<FhirResource>);
+      }
 
-      txnBundle.entry?.push(...(await Promise.all(childEntries)));
-
-      // release the parent draft artifact to the measure repository through a PUT operation to the server by id
+      // release the parent and children draft artifacts to the measure repository through a transaction bundle POST
       const res = await fetch(`${process.env.MRS_SERVER}`, {
         method: 'POST',
         headers: {

--- a/app/src/server/trpc/routers/service.ts
+++ b/app/src/server/trpc/routers/service.ts
@@ -6,7 +6,7 @@ import { z } from 'zod';
 import { TRPCError } from '@trpc/server';
 import { DateTime } from 'luxon';
 import { getChildren } from '@/util/serviceUtils';
-import { OperationOutcome } from 'fhir/r4';
+import { Bundle, BundleEntry, FhirResource, OperationOutcome } from 'fhir/r4';
 
 /**
  * Endpoints dealing with outgoing calls to the central measure repository service
@@ -119,7 +119,7 @@ export const serviceRouter = router({
       };
     }),
 
-  // new release procedures (separate release of parent and release of child)
+  // new release procedures (batched release of parent and child using transaction bundle)
   releaseParent: publicProcedure
     .input(z.object({ resourceType: z.enum(['Measure', 'Library']), id: z.string(), version: z.string() }))
     .mutation(async ({ input }) => {
@@ -131,64 +131,82 @@ export const serviceRouter = router({
         draftRes.version = input.version;
         draftRes.status = 'active';
         draftRes.date = DateTime.now().toISO() || '';
+      } else {
+        throw new Error(`No draft artifact found for resourceType ${input.resourceType}, id ${input.id}`);
       }
 
+      // construct transaction bundle
+      const txnBundle: Bundle = {
+        resourceType: 'Bundle',
+        type: 'transaction',
+        entry: [
+          {
+            resource: draftRes as FhirResource,
+            request: {
+              method: 'POST',
+              url: `${draftRes?.resourceType}/${draftRes?.id}`
+            }
+          }
+        ]
+      };
+
+      // recursively get any child artifacts from the artifact if they exist
+      const children = draftRes?.relatedArtifact ? await getChildren(draftRes.relatedArtifact) : [];
+      const toDelete: {
+        resourceType: 'Measure' | 'Library';
+        id: string;
+      }[] = [{ resourceType: input.resourceType, id: input.id }]; //start with parent and add children to be deleted upon success
+      const childEntries = children.map(async c => {
+        // get the draft child artifact by its URL and version
+        const childDraftRes = await getDraftByUrl(c.url, c.version, c.resourceType);
+
+        // if a draft artifact of that resource type, url, and version exists, then modify its content to be an active artifact
+        if (childDraftRes) {
+          childDraftRes.version = c.version;
+          childDraftRes.status = 'active';
+          childDraftRes.date = DateTime.now().toISO() || '';
+          toDelete.push({ resourceType: c.resourceType, id: childDraftRes.id });
+        } else {
+          throw new Error(
+            `No child draft artifact found for resourceType ${c.resourceType}, version ${c.version}, and URL ${c.url}`
+          );
+        }
+        return {
+          resource: childDraftRes,
+          request: {
+            method: 'POST',
+            url: `${childDraftRes.resourceType}/${childDraftRes.id}`
+          }
+        } as BundleEntry<FhirResource>;
+      });
+
+      txnBundle.entry?.push(...(await Promise.all(childEntries)));
+
       // release the parent draft artifact to the measure repository through a PUT operation to the server by id
-      const res = await fetch(`${process.env.MRS_SERVER}/${input.resourceType}/${draftRes?.id}`, {
-        method: 'PUT',
+      const res = await fetch(`${process.env.MRS_SERVER}`, {
+        method: 'POST',
         headers: {
           'Content-Type': 'application/json+fhir'
         },
-        body: JSON.stringify(draftRes)
+        body: JSON.stringify(txnBundle)
       });
 
       if (res.status === 500) {
         // If error, return error text
         const outcome: OperationOutcome = await res.json();
-        return { location: null, status: res.status, children: null, error: outcome.issue[0].details?.text };
+        return { location: null, deletable: null, status: res.status, error: outcome.issue[0].details?.text };
       }
 
-      let location = res.headers.get('Location');
+      const resBundle: Bundle = await res.json();
+
+      if (!resBundle.entry || resBundle.entry.length === 0) {
+        throw new Error(`No transaction responses found for releasing ${input.resourceType}, id ${input.id}`);
+      }
+      let location = resBundle.entry[0].response?.location; //response same order as request
       if (location?.substring(0, 5) === '4_0_1') {
         location = location?.substring(5); // remove 4_0_1 (version)
       }
 
-      // recursively get any child artifacts from the artifact if they exist
-      const children = draftRes?.relatedArtifact ? await getChildren(draftRes.relatedArtifact) : [];
-
-      return { location: location, status: res.status, children: children, error: null };
-    }),
-
-  releaseChild: publicProcedure
-    .input(z.object({ resourceType: z.enum(['Measure', 'Library']), url: z.string(), version: z.string() }))
-    .mutation(async ({ input }) => {
-      // get the draft child artifact by its URL and version
-      const draftRes = await getDraftByUrl(input.url, input.version, input.resourceType);
-
-      // if a draft artifact of that resource type, url, and version exists, then modify its content to be an active artifact
-      if (draftRes) {
-        draftRes.version = input.version;
-        draftRes.status = 'active';
-        draftRes.date = DateTime.now().toISO() || '';
-      } else {
-        throw new Error('No draft artifact found for this resourceType, version, and URL');
-      }
-
-      // release the child draft artifact to the measure repository through a PUT operation to the server by id
-      const res = await fetch(`${process.env.MRS_SERVER}/${input.resourceType}/${draftRes.id}`, {
-        method: 'PUT',
-        headers: {
-          'Content-Type': 'application/json+fhir'
-        },
-        body: JSON.stringify(draftRes)
-      });
-
-      if (res.status === 500) {
-        // If error, return error text
-        const outcome: OperationOutcome = await res.json();
-        return { id: draftRes.id, status: res.status, error: outcome.issue[0].details?.text };
-      }
-
-      return { id: draftRes.id, status: res.status, error: null };
+      return { location: location, deletable: toDelete, status: res.status, error: null };
     })
 });


### PR DESCRIPTION
# Summary
Child resources are batched with their parent for release.

## New behavior
The front end acts the same with some minor tweaks to notifications. Under the hood, the parent and child artifacts are released using a transaction bundle in order to ensure they are batched.

## Code changes

- ReleaseModal - releaseChild mutation is removed, transaction bundles response expected to be a 200, a notification is shown and a resource deleted for every released resource in the `deletable` list
- service.ts - construct a transaction bundle, and create a toDelete structure with the parent data, then iterate through the children to add to the transaction bundle entries and the toDelete structure. Send transaction bundle and use response to send new location and deletable resource information to the ReleaseModal

# Testing guidance

- `npm run check:all`
- in /service `npm run db:reset`
- in /service `npm run db:loadBundle {your favorite bundle here}` (I used ColorectalCancerScreenings)
- `npm run start:all`
- use the measure to create a draft (should also draft main library)
- release the draft measure (should also release the draft library, delete both, and redirect to the new released measure)
