### PR TITLE
Increment draft version

### DIFF
--- a/app/src/server/trpc/routers/service.ts
+++ b/app/src/server/trpc/routers/service.ts
@@ -82,7 +82,7 @@ export const serviceRouter = router({
       // recursively get any child artifacts from the artifact if they exist
       const children = draftJson.relatedArtifact ? await getChildren(draftJson.relatedArtifact) : [];
 
-      const draftArtifact = modifyResourceToDraft({ ...draftJson });
+      const draftArtifact = await modifyResourceToDraft({ ...draftJson });
 
       // create a draft of the modified parent artifact
       const res = await createDraft(input.resourceType, draftArtifact);
@@ -106,7 +106,7 @@ export const serviceRouter = router({
       const draftRes = artifactBundle.entry?.[0].resource;
 
       // increment the version in the url and update the relatedArtifact.resource to have the new version on the url
-      const draftChildArtifact = modifyResourceToDraft(draftRes as FhirArtifact);
+      const draftChildArtifact = await modifyResourceToDraft(draftRes as FhirArtifact);
 
       // create a draft of the modified child artifact
       const res = await createDraft(input.resourceType, draftChildArtifact);


### PR DESCRIPTION
# Summary
Increment draft version up to 10 times based on any versions that already exist in the draft database.

## New behavior
Creating a draft of a repository artifact multiple times succeeds and increments the version as expected up to a limit.

## Code changes
modifyResourceFields.ts - changes to `modifyResourceToDraft` function to check the draft database for existing versions of the proposed increment and to continue incrementing until an acceptable version is found or the count limit (10) is reached.
service.ts - changes to await the newly async `modifyResourceToDraft` function

Note: I considered doing a different error message if we hit the count limit, but I think the theory that we're working on is that we will never need this many drafts of the same resource at the same time. I think if we think a user will ever realistically hit the count limit, we should up the count limit instead.

# Testing guidance
- `npm run check:all`
- `npm run start:all`
- Load your favorite measure
- Create a draft from the measure or a versioned library
- Do it again (should succeed and increment the version again)
- Do it a bunch of times (see it fail if you do it more than 10 times! wow!)
