### PR TITLE
batch draft

### DIFF
--- a/app/src/pages/[resourceType]/[id].tsx
+++ b/app/src/pages/[resourceType]/[id].tsx
@@ -115,30 +115,13 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
     });
   };
 
-  const draftChildMutation = trpc.service.draftChild.useMutation({
-    onSuccess: (_, variables) => {
-      successNotification(variables.resourceType, true, variables.url);
-    },
-    onError: (e, variables) => {
-      errorNotification(variables.resourceType, e.message, true, variables.url);
-    }
-  });
-
   const draftFromArtifactMutation = trpc.service.draftParent.useMutation({
     onSuccess: (data, variables) => {
       successNotification(variables.resourceType, false, variables.id);
-      router.push(`/authoring/${resourceType}/${data.draftId}`);
-
-      // child artifacts only get drafted if the draft of the parent was successful
-      // the success of the parent does not rely on the success of its child artifacts
-      // nor do the child artifacts rely on each other
-      data.children.forEach(childArtifact => {
-        draftChildMutation.mutate({
-          resourceType: childArtifact.resourceType,
-          url: childArtifact.url,
-          version: childArtifact.version
-        });
+      data.children.forEach(c => {
+        successNotification(c.resourceType, true, c.url);
       });
+      router.push(`/authoring/${resourceType}/${data.draftId}`);
     },
     onError: (e, variables) => {
       errorNotification(variables.resourceType, e.message, false, variables.id);

--- a/app/src/pages/authoring/index.tsx
+++ b/app/src/pages/authoring/index.tsx
@@ -95,29 +95,12 @@ export default function AuthoringPage() {
     }
   });
 
-  const draftChildMutation = trpc.service.draftChild.useMutation({
-    onSuccess: (_, variables) => {
-      successNotification(variables.resourceType, true, true, variables.url);
-    },
-    onError: (e, variables) => {
-      errorNotification(variables.resourceType, e.message, true, true, variables.url);
-    }
-  });
-
   const draftFromArtifactMutation = trpc.service.draftParent.useMutation({
     onSuccess: (data, variables) => {
       successNotification(variables.resourceType, true, false, variables.id);
       router.push(`authoring/${resourceType}/${data.draftId}`);
-
-      // child artifacts only get drafted if the draft of the parent was successful
-      // the success of the parent does not rely on the success of its child artifacts
-      // nor do the child artifacts rely on each other
-      data.children.forEach(childArtifact => {
-        draftChildMutation.mutate({
-          resourceType: childArtifact.resourceType,
-          url: childArtifact.url,
-          version: childArtifact.version
-        });
+      data.children.forEach(c => {
+        successNotification(c.resourceType, true, true, c.url);
       });
     },
     onError: (e, variables) => {

--- a/app/src/pages/authoring/index.tsx
+++ b/app/src/pages/authoring/index.tsx
@@ -98,10 +98,10 @@ export default function AuthoringPage() {
   const draftFromArtifactMutation = trpc.service.draftParent.useMutation({
     onSuccess: (data, variables) => {
       successNotification(variables.resourceType, true, false, variables.id);
-      router.push(`authoring/${resourceType}/${data.draftId}`);
       data.children.forEach(c => {
         successNotification(c.resourceType, true, true, c.url);
       });
+      router.push(`authoring/${resourceType}/${data.draftId}`);
     },
     onError: (e, variables) => {
       errorNotification(variables.resourceType, e.message, true, false, variables.id);

--- a/app/src/server/db/dbOperations.ts
+++ b/app/src/server/db/dbOperations.ts
@@ -42,6 +42,32 @@ export async function createDraft(resourceType: ArtifactResourceType, draft: any
 }
 
 /**
+ * Creates several new draft resources in a batch
+ */
+export async function batchCreateDraft(drafts: FhirArtifact[]) {
+  let error = null;
+  const client = await clientPromise;
+  const session = client.startSession();
+  try {
+    session.startTransaction();
+    const inserts = drafts.map(draft => {
+      const collection = client.db().collection(draft.resourceType);
+      return collection.insertOne(draft as any, { session });
+    });
+    await Promise.all(inserts);
+    await session.commitTransaction();
+    console.log('Batch drafts transaction committed.');
+  } catch (err) {
+    console.error('Batch drafts transaction failed:' + err);
+    await session.abortTransaction();
+    error = err;
+  } finally {
+    await session.endSession();
+  }
+  if (error) throw error;
+}
+
+/**
  * Updates the resource of the given type with the given id
  */
 export async function updateDraft(resourceType: ArtifactResourceType, id: string, additions: any, deletions: any) {

--- a/app/src/server/db/dbOperations.ts
+++ b/app/src/server/db/dbOperations.ts
@@ -58,7 +58,7 @@ export async function batchCreateDraft(drafts: FhirArtifact[]) {
     await session.commitTransaction();
     console.log('Batch drafts transaction committed.');
   } catch (err) {
-    console.error('Batch drafts transaction failed:' + err);
+    console.error('Batch drafts transaction failed: ' + err);
     await session.abortTransaction();
     error = err;
   } finally {

--- a/app/src/server/trpc/routers/service.ts
+++ b/app/src/server/trpc/routers/service.ts
@@ -99,7 +99,7 @@ export const serviceRouter = router({
       const parentArtifact = await modifyResourceToDraft({ ...draftJson });
       const draftArtifacts = [parentArtifact].concat(await Promise.all(childDrafts));
 
-      // create a draft of the modified parent artifact
+      // create a draft of the modified parent artifact and any children
       await batchCreateDraft(draftArtifacts);
 
       return { draftId: parentArtifact.id, children: children };


### PR DESCRIPTION
# Summary
Parent and child artifacts are batched for the draft action.

Note: the mongod transaction functionality requires us to be running mongod using replica sets rather than as standalone. Trying to run on a standalone configuration will cause: `MongoError: Transaction numbers are only allowed on a replica set member or mongos`
For this PR, make sure you've followed directions added from the previous replica set PR so that your local configuration is using replica sets.

## New behavior
Parent and child artifacts are drafted in batch, so that if one fails, the other fails as well. This is implemented as a database transaction.

## Code changes

- dbOperations adds `batchCreateDraft` which uses a transaction to do multiple inserts
- service.ts removes the `draftChild` procedure and bundles parent and child together for insertion with `batchCreateDraft`
- index.tsx and [id].tsx both leverage the updated `draftParent` procedure and show success notifications for the child artifacts as part of the parent mutation

# Testing guidance

Before testing:

- `npm run check:all`
- Temporarily change `modifyResourceFields`, line 39, to count < 0 for easier testing
- `npm run start:all`
- `npm run db:reset`
- Load your favorite measure bundle

Testing:

- Create a draft of the repository measure (should create a draft of the main library and the measure successfully)
- Delete the draft measure
- Create a draft of the repository measure again (should fail with a duplicate key error because we reduced the version increments count to 0)
- There should still just be 1 library and 0 measures in drafts (previously this would have successfully created a new measure and only failed on the library version conflict, but now the creation of a new measure/library parent/child fails together)