### PR TITLE
replica set for docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,28 @@ npm install --workspace=<app-or-service> <package-name>
 
 Copy `app/.env.example` to `app/.env.local` and `service/.env.example` to `service/.env`. Make any changes to point to the measure repository service, Mongo database, and optionally the VSAC API. `0.0.0.0` may be a more appropriate database address than `localhost` for certain environment setups.
 
+### Mongo Replica Set Setup
+
+Use the mongodb configuration file to configure the single node replica set. More information about the configuration file and system location, see the mongodb [configuration file documentation](https://www.mongodb.com/docs/manual/reference/configuration-options/).
+
+1. First shutdown any currently running mongodb standalone instance: `brew services stop mongodb-community`.
+2. Add this replication set configuration to the file:
+```
+replication:
+   replSetName: rs0
+```
+3. Start mongodb again using homebrew: `brew services restart mongodb-community`.
+4. Initialize the replica set using mongosh:
+```bash
+mongosh
+```
+```bash
+rs.initiate()
+```
+5. From here you can continue to use the replica set, and in the future, you can do a normal start of the server using homebrew: `brew services start mongodb-community` (without need to reinitialize the replica set).
+
+Further information on standalong to replica set conversion can be found in the mongodb [replica set conversion documentation](https://www.mongodb.com/docs/manual/tutorial/convert-standalone-to-replica-set/).
+
 ## Usage
 
 Once you have the necessary dependencies installed, you can run the following in the root directory:

--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ Copy `app/.env.example` to `app/.env.local` and `service/.env.example` to `servi
 
 ### Mongo Replica Set Setup
 
-Use the mongodb configuration file to configure the single node replica set. More information about the configuration file and system location, see the mongodb [configuration file documentation](https://www.mongodb.com/docs/manual/reference/configuration-options/).
+Use the mongodb configuration file to configure the single node replica set. For more information about the configuration file and system location, see the mongodb [configuration file documentation](https://www.mongodb.com/docs/manual/reference/configuration-options/).
 
-1. First shutdown any currently running mongodb standalone instance: `brew services stop mongodb-community`.
-2. Add this replication set configuration to the file:
+1. First shutdown any currently running mongodb standalone instances: `brew services stop mongodb-community`.
+2. Add this replication set configuration to the mongo configuration file:
 ```
 replication:
    replSetName: rs0
@@ -54,7 +54,7 @@ rs.initiate()
 ```
 5. From here you can continue to use the replica set, and in the future, you can do a normal start of the server using homebrew: `brew services start mongodb-community` (without need to reinitialize the replica set).
 
-Further information on standalong to replica set conversion can be found in the mongodb [replica set conversion documentation](https://www.mongodb.com/docs/manual/tutorial/convert-standalone-to-replica-set/).
+Further information on standalone to replica set conversion can be found in the mongodb [replica set conversion documentation](https://www.mongodb.com/docs/manual/tutorial/convert-standalone-to-replica-set/).
 
 ## Usage
 

--- a/app/.env.example
+++ b/app/.env.example
@@ -1,3 +1,3 @@
 PUBLIC_MRS_SERVER=http://localhost:3000/4_0_1
 MRS_SERVER=http://localhost:3000/4_0_1
-MONGODB_URI=mongodb://localhost:27017/draft-repository
+MONGODB_URI=mongodb://localhost:27017/draft-repository?replicaSet=rs0

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -6,7 +6,7 @@ services:
       - mongo
     image: tacoma/measure-repository-service
     environment:
-      DATABASE_URL: 'mongodb://mongo:27017/measure-repository'
+      DATABASE_URL: 'mongodb://mongo:27017/measure-repository?replicaSet=rs0'
     ports:
       - "3000:3000"
     stdin_open: true
@@ -22,7 +22,7 @@ services:
       # measure-service container is made public to users with `4_0_1` appended. ex. https://abacus.example.com/mrs/4_0_1
       PUBLIC_MRS_SERVER: http://localhost:3000/4_0_1
       MRS_SERVER: http://measure-service:3000/4_0_1
-      MONGODB_URI: mongodb://mongo:27017/draft-repository
+      MONGODB_URI: mongodb://mongo:27017/draft-repository?replicaSet=rs0
     ports:
       - '3001:3001'
     stdin_open: true
@@ -30,10 +30,24 @@ services:
 
   mongo:
     image: mongo:7.0
+    command: ["--replSet", "rs0", "--bind_ip_all", "--port", "27017"]
     expose:
       - "27017:27017"
+    ports:
+      - 27017:27017
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    healthcheck:
+      test: echo "try { rs.status() } catch (err) { rs.initiate({_id:'rs0',members:[{_id:0,host:'host.docker.internal:27017'}]}) }" | mongosh --port 27017 --quiet
+      interval: 5s
+      timeout: 30s
+      start_period: 0s
+      start_interval: 1s
+      retries: 30
     volumes:
       - mongo_data:/data/db
+      - mongo_config:/data/configdb
 
 volumes:
   mongo_data:
+  mongo_config:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
         - "linux/arm64"
     image: tacoma/measure-repository-service
     environment:
-      DATABASE_URL: 'mongodb://mongo:27017/measure-repository'
+      DATABASE_URL: 'mongodb://mongo:27017/measure-repository?replicaSet=rs0'
     ports:
       - "3000:3000"
     stdin_open: true
@@ -32,7 +32,7 @@ services:
     environment:
       PUBLIC_MRS_SERVER: http://localhost:3000/4_0_1
       MRS_SERVER: http://measure-service:3000/4_0_1
-      MONGODB_URI: mongodb://mongo:27017/draft-repository
+      MONGODB_URI: mongodb://mongo:27017/draft-repository?replicaSet=rs0
     ports:
       - '3001:3001'
     stdin_open: true
@@ -40,13 +40,29 @@ services:
 
   mongo:
     image: mongo:7.0
+    command: ["--replSet", "rs0", "--bind_ip_all", "--port", "27017"]
     expose:
       - "27017:27017"
+    ports:
+      - 27017:27017
     # uncomment the following to have access to the containerized mongo at 27018
     # ports:
     #   - "27018:27017"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    healthcheck:
+      test: echo "try { rs.status() } catch (err) { rs.initiate({_id:'rs0',members:[{_id:0,host:'host.docker.internal:27017'}]}) }" | mongosh --port 27017 --quiet
+      interval: 5s
+      timeout: 30s
+      start_period: 0s
+      start_interval: 1s
+      retries: 30
     volumes:
       - mongo_data:/data/db
+      - mongo_config:/data/configdb
+    stdin_open: true
+    tty: true
 
 volumes:
   mongo_data:
+  mongo_config:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,8 +60,6 @@ services:
     volumes:
       - mongo_data:/data/db
       - mongo_config:/data/configdb
-    stdin_open: true
-    tty: true
 
 volumes:
   mongo_data:

--- a/service/.env.example
+++ b/service/.env.example
@@ -2,5 +2,5 @@
 # Below are the default values
 PORT=3000
 HOST='localhost'
-DATABASE_URL='mongodb://localhost:27017/measure-repository'
+DATABASE_URL='mongodb://localhost:27017/measure-repository?replicaSet=rs0'
 VSAC_API_KEY="<your-api-key>" # Add if you plan on using the `include-terminology` query param


### PR DESCRIPTION
# Summary
Update docker setup to create replica set in containers. Update documentation and environment examples for local mongodb replica set.

## New behavior
Docker starts up using a replica set (and user can do local development with a replica set) allowing the use of certain db features (like transactions).

## Code changes

- README has instructions for local replica set changes.
- Environment variables are updated to reflect replica set connection. 
- docker-compose and the docker-compose example are updated to set up replica set.

# Testing guidance
- Follow the README to set up the local replica set.
- Build and restart the app.
- Verify basic application function by creating draft measures and releasing them.
- Stop your local mongodb and application and run `docker compose up --build` instead
- Verify basic application function by creating draft measures and releasing them.
- Cherry-pick the `batch draft` commit from the `batch-draft` branch (without the later replica set commit)
- Test the batch draft functionality for both local development and using docker: 

1. Temporarily change modifyResourceFields, line 39, to count < 0 for easier testing
2. Rebuild and start the application
3. Reset database and load your favorite measure bundle (I used `directory-upload.sh` to load)
4. Create a draft of the repository measure (should create a draft of the main library and the measure successfully)
5. Delete the draft measure
6. Create a draft of the repository measure again (should fail with a duplicate key error because we reduced the version increments count to 0)
7. There should still just be 1 library and 0 measures in drafts (previously this would have successfully created a new measure and only failed on the library version conflict, but now the creation of a new measure/library parent/child fails together)
