### PR TITLE
Fix recursion

### DIFF
--- a/app/src/components/ReleaseModal.tsx
+++ b/app/src/components/ReleaseModal.tsx
@@ -33,7 +33,7 @@ export default function ReleaseModal({ open = true, onClose, id, resourceType }:
   const releaseMutation = trpc.service.releaseParent.useMutation({
     onSuccess: data => {
       if (data.status !== 200) {
-        console.error(data.status || data.error);
+        console.error(data.status);
         notifications.show({
           title: `Release Failed!`,
           message: `Server unable to process request. ${data.error ?? ''}`,

--- a/app/src/components/ReleaseModal.tsx
+++ b/app/src/components/ReleaseModal.tsx
@@ -33,7 +33,7 @@ export default function ReleaseModal({ open = true, onClose, id, resourceType }:
   const releaseMutation = trpc.service.releaseParent.useMutation({
     onSuccess: data => {
       if (data.status !== 200) {
-        console.error(data.status);
+        console.error(data.status || data.error);
         notifications.show({
           title: `Release Failed!`,
           message: `Server unable to process request. ${data.error ?? ''}`,

--- a/app/src/server/trpc/routers/service.ts
+++ b/app/src/server/trpc/routers/service.ts
@@ -143,7 +143,6 @@ export const serviceRouter = router({
         id: string;
       }[] = [{ resourceType: input.resourceType, id: input.id }]; //start with parent and add children to be deleted upon success
       const childEntries = children.map(async c => {
-        console.log('hi', c);
         // get the draft child artifact by its URL and version
         const childDraftRes = await getDraftByUrl(c.url, c.version, c.resourceType);
 

--- a/app/src/server/trpc/routers/service.ts
+++ b/app/src/server/trpc/routers/service.ts
@@ -5,7 +5,7 @@ import { FhirArtifact } from '@/util/types/fhir';
 import { z } from 'zod';
 import { TRPCError } from '@trpc/server';
 import { DateTime } from 'luxon';
-import { getChildren } from '@/util/serviceUtils';
+import { getChildren, getDraftChildren } from '@/util/serviceUtils';
 import { Bundle, BundleEntry, FhirResource, OperationOutcome } from 'fhir/r4';
 
 /**
@@ -137,12 +137,13 @@ export const serviceRouter = router({
       };
 
       // recursively get any child artifacts from the artifact if they exist
-      const children = draftRes?.relatedArtifact ? await getChildren(draftRes.relatedArtifact) : [];
+      const children = draftRes?.relatedArtifact ? await getDraftChildren(draftRes.relatedArtifact) : [];
       const toDelete: {
         resourceType: 'Measure' | 'Library';
         id: string;
       }[] = [{ resourceType: input.resourceType, id: input.id }]; //start with parent and add children to be deleted upon success
       const childEntries = children.map(async c => {
+        console.log('hi', c);
         // get the draft child artifact by its URL and version
         const childDraftRes = await getDraftByUrl(c.url, c.version, c.resourceType);
 

--- a/app/src/server/trpc/routers/service.ts
+++ b/app/src/server/trpc/routers/service.ts
@@ -142,6 +142,7 @@ export const serviceRouter = router({
         resourceType: 'Measure' | 'Library';
         id: string;
       }[] = [{ resourceType: input.resourceType, id: input.id }]; //start with parent and add children to be deleted upon success
+
       for (const c of children) {
         // get the draft child artifact by its URL and version
         const childDraftRes = await getDraftByUrl(c.url, c.version, c.resourceType);

--- a/app/src/util/modifyResourceFields.ts
+++ b/app/src/util/modifyResourceFields.ts
@@ -56,7 +56,8 @@ export async function modifyResourceToDraft(artifact: FhirArtifact) {
         )
       ) {
         const url = ra.resource.split('|')[0];
-        ra.resource = url + '|' + artifact.version;
+        const version = ra.resource.split('|')[1];
+        ra.resource = url + '|' + incrementArtifactVersion(version);
       }
     });
   }

--- a/app/src/util/serviceUtils.ts
+++ b/app/src/util/serviceUtils.ts
@@ -76,15 +76,11 @@ export async function getDraftChildren(relatedArtifacts: fhir4.RelatedArtifact[]
 
       const [url, version] = ra.resource.split('|');
 
-      console.log('hellloooo', version);
-
       // add child artifact info to the array of child artifact info
       children.push({ resourceType, url, version });
 
       // search for the related artifact in the draft repository
       const childArtifact = await getDraftByUrl(url, version, resourceType);
-
-      console.log('CHILD', childArtifact?.relatedArtifact);
 
       // if the related artifact exists in the draft repository, then we
       // want to recursively look for its child artifacts as well

--- a/service/scripts/dbSetup.ts
+++ b/service/scripts/dbSetup.ts
@@ -93,7 +93,11 @@ async function uploadBundleResources(filePath: string) {
         if (ent.resource?.resourceType === 'Measure' || ent.resource?.resourceType === 'Library') {
           ent.resource.relatedArtifact?.forEach(ra => {
             if (ra.type === 'composed-of') {
-              if (ra.extension?.some(e => e.url === 'http://hl7.org/fhir/StructureDefinition/artifact-isOwned')) {
+              if (
+                ra.extension?.some(
+                  e => e.url === 'http://hl7.org/fhir/StructureDefinition/artifact-isOwned' && e.valueBoolean === true
+                )
+              ) {
                 if (ra.resource) {
                   ownedUrls.push(ra.resource);
                 }

--- a/service/scripts/dbSetup.ts
+++ b/service/scripts/dbSetup.ts
@@ -89,6 +89,18 @@ async function uploadBundleResources(filePath: string) {
         // that library's entry in the relatedArtifacts of the measure
         const { modifiedEntry, url } = addIsOwnedExtension(ent);
         if (url) ownedUrls.push(url);
+        // check if there are other isOwned urls but already in the relatedArtifacts
+        if (ent.resource?.resourceType === 'Measure' || ent.resource?.resourceType === 'Library') {
+          ent.resource.relatedArtifact?.forEach(ra => {
+            if (ra.type === 'composed-of') {
+              if (ra.extension?.some(e => e.url === 'http://hl7.org/fhir/StructureDefinition/artifact-isOwned')) {
+                if (ra.resource) {
+                  ownedUrls.push(ra.resource);
+                }
+              }
+            }
+          });
+        }
         return modifiedEntry;
       });
       const uploads = modifiedEntries.map(async entry => {


### PR DESCRIPTION
# Summary
We recently noticed an error that we made in our release logic- `getChildren` pulls child artifacts from the measure repository service; however, for the "release" functionality of the app, we should be pulling the children from the draft repository instead.

## New behavior
New function called `getDraftChildren` in `serviceUtils.ts` gets child artifacts from the draft repository when release is being called on an artifact.

## Code changes
- `app/src/util/serviceUtils.ts` - adds `getDraftChildren` function.
- `app/src/util/modifyResourceFields.ts` - `modifyResourceToDraft` function properly increments the version on the relatedArtifact url rather than assigning it to the parent artifact's version.
- `app/src/server/trpc/routers/service.ts` - `releaseParent` trpc procedure now properly calls `getDraftChildren` to get the child artifacts from the draft repository for release rather than from the measure repository.
- `service/scripts/dbSetup/ts` - make sure all child artifacts urls are added to ownedUrls so that child artifacts can be properly labeled as isOwned

# Testing guidance
- `npm run check:all`
- For testing an extra layer of recursion for child artifacts, I took the `ColorectalCancerScreeningsFHIR.json` measure bundle from ecqm-content-r4-2021 repo and edited it so that the main Library has a `composed-of` relatedArtifact that points to the `AdvancedIllnessandFrailtyExclusionECQMFHIR4` Library (that way we have a child artifact library that has a child artifact). Either ask me for the edited bundle for testing or do this yourself. 
- When you go to draft the ColorectalCancerScreenings Measure, it should create a draft of that measure as well as a draft of its main Library AND that AdvancedIllnessandFrailtyExclusion... Library. 
- Also make sure that both the main Library and the other child artifact Library have the draft and release options disabled.
- You should then be able to release that measure and the associated child artifacts should be released as well.
- Test all other functionality including batch release functionality etc. to make sure that nothing breaks.