### PR TITLE
Child artifact delete

### DIFF
--- a/app/src/components/ResourceInfoCard.tsx
+++ b/app/src/components/ResourceInfoCard.tsx
@@ -90,7 +90,7 @@ export default function ResourceInfoCard({ resourceInfo, authoring }: ResourceIn
         onClose={() => setIsConfirmationModalOpen(false)}
         modalText={`This will delete draft ${resourceInfo.resourceType} "${
           resourceInfo.name ? resourceInfo.name : `${resourceInfo.resourceType}/${resourceInfo.id}`
-        }" permanently.`}
+        }" and any child artifacts permanently.`}
         onConfirm={() => {
           deleteMutation.mutate({
             resourceType: resourceInfo.resourceType,

--- a/app/src/components/ResourceInfoCard.tsx
+++ b/app/src/components/ResourceInfoCard.tsx
@@ -39,24 +39,47 @@ export default function ResourceInfoCard({ resourceInfo, authoring }: ResourceIn
   const ctx = trpc.useContext();
   const [isConfirmationModalOpen, setIsConfirmationModalOpen] = useState(false);
 
-  const deleteMutation = trpc.draft.deleteDraft.useMutation({
-    onSuccess: () => {
-      notifications.show({
-        title: `Draft ${resourceInfo.resourceType} Deleted!`,
-        message: `Draft ${resourceInfo.resourceType}/${resourceInfo.id} successfully deleted`,
-        icon: <CircleCheck />,
-        color: 'green'
+  const successNotification = (resourceType: string, childArtifact: boolean, idOrUrl?: string) => {
+    let message;
+    if (childArtifact) {
+      message = `Draft of child ${resourceType} artifact of url ${idOrUrl} successfully deleted`;
+    } else {
+      message = `Draft of ${resourceType}/${idOrUrl} successfully deleted`;
+    }
+    notifications.show({
+      title: `${resourceType} Deleted!`,
+      message: message,
+      icon: <CircleCheck />,
+      color: 'green'
+    });
+    ctx.draft.getDraftCounts.invalidate();
+  };
+
+  const errorNotification = (resourceType: string, errorMessage: string, childArtifact: boolean, idOrUrl?: string) => {
+    let message;
+    if (childArtifact) {
+      message = `Attempt to delete draft of child ${resourceType} artifact of url ${idOrUrl} failed with message: ${errorMessage}`;
+    } else {
+      message = `Attempt to delete draft of ${resourceType}/${idOrUrl} failed with message: ${errorMessage}`;
+    }
+    notifications.show({
+      title: `${resourceType} Deletion Failed!`,
+      message: message,
+      icon: <AlertCircle />,
+      color: 'red'
+    });
+  };
+
+  const deleteMutation = trpc.draft.deleteParent.useMutation({
+    onSuccess: (data, variables) => {
+      successNotification(variables.resourceType, false, variables.id);
+      data.children.forEach(c => {
+        successNotification(c.resourceType, true, c.url);
       });
-      ctx.draft.getDraftCounts.invalidate();
       ctx.draft.getDrafts.invalidate();
     },
-    onError: e => {
-      notifications.show({
-        title: `Draft ${resourceInfo.resourceType} Deletion Failed!`,
-        message: `Attempt to delete draft of ${resourceInfo.resourceType}/${resourceInfo.id} failed with message: ${e.message}`,
-        icon: <AlertCircle />,
-        color: 'red'
-      });
+    onError: (e, variables) => {
+      errorNotification(variables.resourceType, e.message, false, variables.id);
     }
   });
 
@@ -130,19 +153,28 @@ export default function ResourceInfoCard({ resourceInfo, authoring }: ResourceIn
                 </ActionIcon>
               </Tooltip>
             </Link>
-            {authoring && (
-              <Tooltip label={'Delete Draft Resource'} openDelay={1000}>
-                <ActionIcon
-                  radius="md"
-                  size="md"
-                  variant="subtle"
-                  color="red"
-                  onClick={() => setIsConfirmationModalOpen(true)}
-                >
-                  <Trash size="24" />
-                </ActionIcon>
-              </Tooltip>
-            )}
+            {authoring &&
+              (resourceInfo.isChild ? (
+                <Tooltip label={'Child artifacts cannot be directly deleted'} openDelay={1000}>
+                  <span>
+                    <ActionIcon radius="md" size="md" disabled={true}>
+                      <Trash size="24" />
+                    </ActionIcon>
+                  </span>
+                </Tooltip>
+              ) : (
+                <Tooltip label={'Delete Draft Resource'} openDelay={1000}>
+                  <ActionIcon
+                    radius="md"
+                    size="md"
+                    variant="subtle"
+                    color="red"
+                    onClick={() => setIsConfirmationModalOpen(true)}
+                  >
+                    <Trash size="24" />
+                  </ActionIcon>
+                </Tooltip>
+              ))}
           </Group>
         </Grid>
       </Paper>

--- a/app/src/util/modifyResourceFields.ts
+++ b/app/src/util/modifyResourceFields.ts
@@ -11,6 +11,7 @@ import { getDraftByUrl } from '@/server/db/dbOperations';
 export async function modifyResourceToDraft(artifact: FhirArtifact) {
   artifact.id = uuidv4();
   artifact.status = 'draft';
+  let count = 0;
 
   // initial version coercion and increment
   // we can only increment artifacts whose versions are either semantic, can be coerced
@@ -35,7 +36,6 @@ export async function modifyResourceToDraft(artifact: FhirArtifact) {
     // check for existing draft with proposed version
     let existingDraft = await getDraftByUrl(artifact.url, artifact.version, artifact.resourceType);
     // only increment a limited number of times
-    let count = 0;
     while (existingDraft && count < 10) {
       // increment artifact version
       const incVersion = inc(artifact.version, 'patch');
@@ -56,7 +56,11 @@ export async function modifyResourceToDraft(artifact: FhirArtifact) {
         )
       ) {
         const url = ra.resource.split('|')[0];
-        const version = ra.resource.split('|')[1];
+        let version = ra.resource.split('|')[1];
+        while (count !== 0) {
+          version = incrementArtifactVersion(version);
+          count--;
+        }
         ra.resource = url + '|' + incrementArtifactVersion(version);
       }
     });

--- a/app/src/util/resourceCardUtils.ts
+++ b/app/src/util/resourceCardUtils.ts
@@ -19,7 +19,10 @@ export function extractResourceInfo(resource: FhirArtifact) {
     name: resource.name ?? null,
     url: resource.url ?? null,
     version: resource.version ?? null,
-    status: resource.status ?? null
+    status: resource.status ?? null,
+    isChild: !!resource.extension?.find(
+      ext => ext.url === 'http://hl7.org/fhir/StructureDefinition/artifact-isOwned' && ext.valueBoolean === true
+    )
   };
   return resourceInfo;
 }

--- a/app/src/util/types/fhir.ts
+++ b/app/src/util/types/fhir.ts
@@ -24,4 +24,5 @@ export interface ResourceInfo {
   url: string | null;
   version: string;
   status: string | null;
+  isChild: boolean;
 }


### PR DESCRIPTION
# Summary
This PR continues our work of ensuring that child artifacts in the measure-repository do not have a lifecycle outside of their parent artifact. This PR prevents child artifacts from being deleted from the `draft-repository` and implements recursive deletion of a parent artifact and all of its children in a batch transaction.

## New behavior
- The "delete" button is disabled in the `draft-repository` (authoring side of the app) for artifacts that are child artifacts (meaning they have the `isOwned` extension). 
- Artifact deletion of the `draft-repository` is now batched so that the artifact and any of its child artifacts are also deleted.

## Code changes
- `app/src/components/ResourceInfoCard.tsx` - `deleteParent` trpc procedure is now used instead of `deleteDraft`, delete button is now disabled for child artifacts
- `app/src/server/db/dbOperations.ts` - new `batchDeleteDraft` function to delete a parent artifact and any of its children in a batch transaction. I had to also change how `batchCreateDraft` was written because I would randomly get errors along the lines of "Given transaction number 1 does not match any in-progress transactions" and I saw that a solution was to use `withTransaction` instead.
- `app/src/server/trpc/routers/draft.ts` - new `deleteParent` procedure
- `app/src/util/modifyResourceFields.ts` - fixes a bug I found- basically if a parent artifact was drafted and the version had to be incremented more than once, then we had to make sure the same happened to the version in the reference in relatedArtifacts
- `app/src/util/resourceCardUtils.ts` / `app/src/util/types/fhir.ts` - new `isChild` property to be used in the `ResourceInfoCard.tsx` component to determine whether to disable the delete button or not

# Testing guidance
- `npm run check:all`
- `npm run start:all`
- `cd service`
- `npm run db:reset`
- `npm run db:loadBundle <path-to-bundle>` (use the edited ColorectalCancerScreeningsFHIR bundle I made for #90)
- In the root: `npm run start:all`
- In the app, try various combinations of drafting, releasing, and deleting artifacts and making sure the same happens to their children. Make sure you cannot delete any of the child artifacts from the `draft-repository`. There should hopefully be a clearer lifecycle now of drafting, deleting, and releasing parent artifacts and their children, but try your best to break it.