### PR TITLE
Add comment about changing hoster.docker.internal for linux systems

### DIFF
--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: "3"
 
 services:
   measure-service:
@@ -6,7 +6,7 @@ services:
       - mongo
     image: tacoma/measure-repository-service
     environment:
-      DATABASE_URL: 'mongodb://mongo:27017/measure-repository?replicaSet=rs0'
+      DATABASE_URL: "mongodb://mongo:27017/measure-repository?replicaSet=rs0"
     ports:
       - "3000:3000"
     stdin_open: true
@@ -24,7 +24,7 @@ services:
       MRS_SERVER: http://measure-service:3000/4_0_1
       MONGODB_URI: mongodb://mongo:27017/draft-repository?replicaSet=rs0
     ports:
-      - '3001:3001'
+      - "3001:3001"
     stdin_open: true
     tty: true
 
@@ -38,6 +38,7 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
     healthcheck:
+      # for linux systems, replace host.docker.internal with mongo
       test: echo "try { rs.status() } catch (err) { rs.initiate({_id:'rs0',members:[{_id:0,host:'host.docker.internal:27017'}]}) }" | mongosh --port 27017 --quiet
       interval: 5s
       timeout: 30s


### PR DESCRIPTION
# Summary
This PR adds a comment to the `docker-compose.example.yml` file to reflect the change that we had to make in the `docker-compose.yml` in abacus-dev in order to get replicaSet functionality to work on a linux platform.

## New behavior
- n/a

## Code changes
- `docker-compose.example.yml` - adds comment, looks like prettier was applied too

# Testing guidance
- Make sure abacus-dev.mitre.org/mrs works as intended 
- Make sure this setup makes sense for now. Note that Lauren made a backlog task for looking into this further after our discussion.