### PR TITLE
Pull out date change code

### DIFF
--- a/app/src/components/ArtifactComments.tsx
+++ b/app/src/components/ArtifactComments.tsx
@@ -1,7 +1,5 @@
 import { Avatar, createStyles, Group, Paper, rem, Text, TypographyStylesProvider } from '@mantine/core';
 import parse from 'html-react-parser';
-import { useHover } from '@mantine/hooks';
-import { useEffect, useState } from 'react';
 
 const useStyles = createStyles(theme => ({
   card: {
@@ -36,36 +34,6 @@ export interface ArtifactCommentProps {
 
 export default function ArtifactComments({ date, body, author }: ArtifactCommentProps) {
   const { classes } = useStyles();
-  const { hovered, ref } = useHover();
-  const [color, setColor] = useState('grey');
-  const [displayedDate, setDisplayedDate] = useState<string | undefined>(date);
-
-  // This changes the UTC date format into the 'mm/dd/yyyy' format
-  function getDate() {
-    if (date) {
-      const stringDate = new Date(date);
-      return `${stringDate.getMonth() + 1}/${stringDate.getDate()}/${stringDate.getFullYear()}`;
-    }
-  }
-
-  const formattedDate = getDate();
-
-  function changeDate() {
-    if (displayedDate === date) {
-      setDisplayedDate(formattedDate);
-    } else {
-      setDisplayedDate(date);
-    }
-  }
-
-  // Changes the color of the date text depending on if the user is hovering over the text or not
-  useEffect(() => {
-    if (hovered === true) {
-      setColor('blue');
-    } else {
-      setColor('grey');
-    }
-  }, [hovered]);
 
   return (
     <Paper withBorder radius="md" className={classes.card} shadow="md">
@@ -78,11 +46,9 @@ export default function ArtifactComments({ date, body, author }: ArtifactComment
             <Text weight={500} fz="sm">
               {author ? author : 'Guest'}
             </Text>
-            <div ref={ref} style={{ cursor: 'pointer' }}>
-              <Text variant="subtle" fz="xs" onClick={changeDate} opacity={0.8} color={color}>
-                {date ? displayedDate : ''}
-              </Text>
-            </div>
+            <Text variant="subtle" fz="xs" opacity={0.8} color={'grey'}>
+              {date ? date : ''}
+            </Text>
           </div>
         </Group>
         <div style={{ wordBreak: 'break-word' }}>


### PR DESCRIPTION
# Summary
Remove functionality that allows the user to change the date format on review comments.

## New behavior
Review comment date is not clickable and stays in the same format. This feature does not seem to have a lot of utility. Removing it fixes an issue with date displays where a review comment card may show the date of another review comment rather than its own. To reproduce this issue on the main branch:

- Add multiple review comments with dates to a draft artifact, taking note of their correct timestamps
- Add a review comment on the add tab
- Immediately switch over to the view tab
- Some review comments will have incorrect timestamps
- Timestamps are fixed with reload

## Code changes
Remove hover, color change, click response, and date formatter, replaced with simple date display.

# Testing guidance

- 'npm run check:all`
- Run with `npm run start:all`
- Create a draft artifact if necessary
- Select review option for draft artifact
- Try to reproduce issue described above (issue should be fixed, and accurate timestamps should be simply displayed)
