### PR TITLE
Publishable write

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "service"
       ],
       "devDependencies": {
+        "@types/lodash": "^4.17.4",
         "concurrently": "^7.6.0"
       }
     },
@@ -4126,6 +4127,12 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+      "dev": true
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.4.tgz",
+      "integrity": "sha512-wYCP26ZLxaT3R39kiN2+HcJ4kTd3U1waI/cY7ivWYqFP6pW3ZNpvi6Wd6PHZx7T/t8z0vlkXMg3QYLa7DZ/IJQ==",
       "dev": true
     },
     "node_modules/@types/luxon": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test:service": "npm run test --workspace=service"
   },
   "devDependencies": {
+    "@types/lodash": "^4.17.4",
     "concurrently": "^7.6.0"
   }
 }

--- a/service/.env.example
+++ b/service/.env.example
@@ -4,3 +4,4 @@ PORT=3000
 HOST='localhost'
 DATABASE_URL='mongodb://localhost:27017/measure-repository?replicaSet=rs0'
 VSAC_API_KEY="<your-api-key>" # Add if you plan on using the `include-terminology` query param
+AUTHORING=true # Make false if this is running as a publishable repository instead

--- a/service/.env.test
+++ b/service/.env.test
@@ -1,1 +1,2 @@
 VSAC_API_KEY="example-api-key"
+AUTHORING=true

--- a/service/README.md
+++ b/service/README.md
@@ -99,8 +99,28 @@ This server currently supports the following CRUD operations:
 
 - Read by ID with `GET` to endpoint: `4_0_1/<resourceType>/<resourceId>`
 - Create resource (Library or Measure) with `POST` to endpoint: `4_0_1/<resourceType>`
+  - Publishable:
+    - Supports the [CRMI Publishable Artifact Repository](https://hl7.org/fhir/uv/crmi/1.0.0-snapshot/artifact-repository-service.html#publishable-artifact-repository) minimum write capability _publish_
+    - Artifact must be in active status and conform to appropriate shareable and publishable profiles
+  - Authoring (In Progress):
+    - Supports the [CRMI Authoring Artifact Repository](https://hl7.org/fhir/uv/crmi/1.0.0-snapshot/artifact-repository-service.html#authoring-artifact-repository) additional authoring capability _submit_
+    - Artifact must be in draft status
+
 - Update resource (Library or Measure) with `PUT` to endpoint: `4_0_1/<resourceType>/<resourceId>`
-  _More functionality coming soon!_
+  - Publishable:
+    - Supports the [CRMI Publishable Artifact Repository](https://hl7.org/fhir/uv/crmi/1.0.0-snapshot/artifact-repository-service.html#publishable-artifact-repository) minimum write capability _retire_
+    - Artifact must be in active status and may only change the status to retired and update the date (and other metadata appropriate to indicate retired status)
+  - Authoring (In Progress):
+    - Supports the [CRMI Authoring Artifact Repository](https://hl7.org/fhir/uv/crmi/1.0.0-snapshot/artifact-repository-service.html#authoring-artifact-repository) additional authoring capability _revise_
+    - Artifact must be in (and remain in) draft status
+
+- Delete resource (Library or Measure) with `DELETE` to endpoint: `4_0_1/<resourceType>/<resourceId>`
+  - Publishable:
+    - Supports the [CRMI Publishable Artifact Repository](https://hl7.org/fhir/uv/crmi/1.0.0-snapshot/artifact-repository-service.html#publishable-artifact-repository) minimum write capability _archive_
+    - Artifact must be in retired status
+  - Authoring (In Progress):
+    - Supports the [CRMI Authoring Artifact Repository](https://hl7.org/fhir/uv/crmi/1.0.0-snapshot/artifact-repository-service.html#authoring-artifact-repository) additional authoring capability _withdraw_
+    - Artifact must be in draft status
 
 ### Search
 

--- a/service/package.json
+++ b/service/package.json
@@ -13,6 +13,7 @@
     "db:reset": "ts-node ./scripts/dbSetup.ts reset",
     "db:setup": "ts-node ./scripts/dbSetup.ts create",
     "db:loadBundle": "ts-node ./scripts/dbSetup.ts loadBundle",
+    "db:postBundle": "ts-node ./scripts/dbSetup.ts postBundle",
     "lint": "eslint \"./src/**/*.{js,ts}\"",
     "lint:fix": "eslint \"./src/**/*.{js,ts}\" --fix",
     "prettier": "prettier --check \"./src/**/*.{js,ts}\"",

--- a/service/scripts/dbSetup.ts
+++ b/service/scripts/dbSetup.ts
@@ -4,7 +4,7 @@ import * as dotenv from 'dotenv';
 import { MongoError } from 'mongodb';
 import { v4 as uuidv4 } from 'uuid';
 import path from 'path';
-import { DetailedEntry, addIsOwnedExtension, addLibraryIsOwned } from '../src/util/baseUtils';
+import { addIsOwnedExtension, addLibraryIsOwned } from '../src/util/baseUtils';
 dotenv.config();
 
 const DB_URL = process.env.DATABASE_URL || 'mongodb://localhost:27017/measure-repository';
@@ -39,10 +39,9 @@ async function deleteCollections() {
 /*
  * Gathers necessary file path(s) for bundle(s) to upload, then uploads all measure and
  * library resources found in the bundle(s).
+ *
  */
-async function loadBundle(fileOrDirectoryPath: string) {
-  await Connection.connect(DB_URL);
-  console.log(`Connected to ${DB_URL}`);
+async function loadBundle(fileOrDirectoryPath: string, connectionURL?: string) {
   const status = fs.statSync(fileOrDirectoryPath);
   if (status.isDirectory()) {
     const filePaths: string[] = [];
@@ -60,10 +59,61 @@ async function loadBundle(fileOrDirectoryPath: string) {
     });
 
     for (const filePath of filePaths) {
-      await uploadBundleResources(filePath);
+      await (connectionURL ? postBundleResources(filePath, connectionURL) : uploadBundleResources(filePath));
     }
   } else {
-    await uploadBundleResources(fileOrDirectoryPath);
+    await (connectionURL
+      ? postBundleResources(fileOrDirectoryPath, connectionURL)
+      : uploadBundleResources(fileOrDirectoryPath));
+  }
+}
+
+async function transactBundle(bundle: fhir4.Bundle, url: string) {
+  if (bundle.entry) {
+    // only upload Measures and Libraries
+    bundle.entry = bundle.entry.filter(
+      e => e.resource?.resourceType === 'Measure' || e.resource?.resourceType === 'Library'
+    );
+    for (const entry of bundle.entry) {
+      if (entry.request?.method === 'POST') {
+        entry.request.method = 'PUT';
+      }
+    }
+  }
+
+  try {
+    console.log(`  POST ${url}`);
+
+    const resp = await fetch(`${url}`, {
+      method: 'POST',
+      body: JSON.stringify(bundle),
+      headers: {
+        'Content-Type': 'application/json+fhir'
+      }
+    });
+    console.log(`    ${resp.status}`);
+    if (resp.status !== 200) {
+      console.log(`${JSON.stringify(await resp.json())}`);
+    }
+  } catch (e) {
+    console.error(e);
+  }
+}
+
+async function postBundleResources(filePath: string, url: string) {
+  console.log(`Loading bundle from path ${filePath}`);
+
+  const data = fs.readFileSync(filePath, 'utf8');
+  if (data) {
+    console.log(`POSTing ${filePath.split('/').slice(-1)}...`);
+    const bundle: fhir4.Bundle = JSON.parse(data);
+    const entries = bundle.entry as fhir4.BundleEntry<fhir4.FhirResource>[];
+    // modify bundles before posting
+    if (entries) {
+      const modifiedEntries = modifyEntriesForUpload(entries);
+      bundle.entry = modifiedEntries;
+    }
+    transactBundle(bundle, url);
   }
 }
 
@@ -77,56 +127,21 @@ async function uploadBundleResources(filePath: string) {
   if (data) {
     console.log(`Uploading ${filePath.split('/').slice(-1)}...`);
     const bundle: fhir4.Bundle = JSON.parse(data);
-    const entries = bundle.entry as DetailedEntry[];
+    const entries = bundle.entry as fhir4.BundleEntry<fhir4.FhirResource>[];
     // retrieve each resource and insert into database
     if (entries) {
+      await Connection.connect(DB_URL);
+      console.log(`Connected to ${DB_URL}`);
       let resourcesUploaded = 0;
       let notUploaded = 0;
-      // pre-process to find owned relationships
-      const ownedUrls: string[] = [];
-      const modifiedEntries = entries.map(ent => {
-        // if the artifact is a Measure, get the main Library from the Measure and add the is owned extension on
-        // that library's entry in the relatedArtifacts of the measure
-        const { modifiedEntry, url } = addIsOwnedExtension(ent);
-        if (url) ownedUrls.push(url);
-        // check if there are other isOwned urls but already in the relatedArtifacts
-        if (ent.resource?.resourceType === 'Measure' || ent.resource?.resourceType === 'Library') {
-          ent.resource.relatedArtifact?.forEach(ra => {
-            if (ra.type === 'composed-of') {
-              if (
-                ra.extension?.some(
-                  e => e.url === 'http://hl7.org/fhir/StructureDefinition/artifact-isOwned' && e.valueBoolean === true
-                )
-              ) {
-                if (ra.resource) {
-                  ownedUrls.push(ra.resource);
-                }
-              }
-            }
-          });
-        }
-        return modifiedEntry;
-      });
+      const modifiedEntries = modifyEntriesForUpload(entries);
       const uploads = modifiedEntries.map(async entry => {
         // add Library owned extension
-        entry = addLibraryIsOwned(entry, ownedUrls);
-        if (
-          entry.resource?.resourceType &&
-          (entry.resource?.resourceType === 'Library' || entry.resource?.resourceType === 'Measure')
-        ) {
+        if (entry.resource?.resourceType === 'Library' || entry.resource?.resourceType === 'Measure') {
           // Only upload Library or Measure resources
           try {
-            if (!entry.resource.id) {
-              entry.resource.id = uuidv4();
-            }
-            if (entry.resource?.status != 'active') {
-              entry.resource.status = 'active';
-              console.warn(
-                `Resource ${entry?.resource?.resourceType}/${entry.resource.id} status has been coerced to 'active'.`
-              );
-            }
             const collection = Connection.db.collection<fhir4.FhirResource>(entry.resource.resourceType);
-            console.log(`Inserting ${entry?.resource?.resourceType}/${entry.resource.id} into database`);
+            console.log(`Inserting ${entry.resource.resourceType}/${entry.resource.id} into database`);
             await collection.insertOne(entry.resource);
             resourcesUploaded += 1;
           } catch (e) {
@@ -140,7 +155,7 @@ async function uploadBundleResources(filePath: string) {
             }
           }
         } else {
-          if (entry?.resource?.resourceType) {
+          if (entry.resource?.resourceType) {
             notUploaded += 1;
           } else {
             console.log('Resource or resource type undefined');
@@ -154,6 +169,52 @@ async function uploadBundleResources(filePath: string) {
       console.error('Unable to identify bundle entries.');
     }
   }
+}
+
+function modifyEntriesForUpload(entries: fhir4.BundleEntry<fhir4.FhirResource>[]) {
+  // pre-process to find owned relationships
+  const ownedUrls: string[] = [];
+  const modifiedEntries = entries.map(ent => {
+    // if the artifact is a Measure, get the main Library from the Measure and add the is owned extension on
+    // that library's entry in the relatedArtifacts of the measure
+    const { modifiedEntry, url } = addIsOwnedExtension(ent);
+    if (url) ownedUrls.push(url);
+    // check if there are other isOwned urls but already in the relatedArtifacts
+    if (ent.resource?.resourceType === 'Measure' || ent.resource?.resourceType === 'Library') {
+      ent.resource.relatedArtifact?.forEach(ra => {
+        if (ra.type === 'composed-of') {
+          if (
+            ra.extension?.some(
+              e => e.url === 'http://hl7.org/fhir/StructureDefinition/artifact-isOwned' && e.valueBoolean === true
+            )
+          ) {
+            if (ra.resource) {
+              ownedUrls.push(ra.resource);
+            }
+          }
+        }
+      });
+    }
+    return modifiedEntry;
+  });
+  const updatedEntries = modifiedEntries.map(entry => {
+    // add Library owned extension
+    const updatedEntry = addLibraryIsOwned(entry, ownedUrls);
+    if (updatedEntry.resource?.resourceType === 'Library' || updatedEntry.resource?.resourceType === 'Measure') {
+      // Only upload Library or Measure resources
+      if (!updatedEntry.resource.id) {
+        updatedEntry.resource.id = uuidv4();
+      }
+      if (updatedEntry.resource.status != 'active') {
+        updatedEntry.resource.status = 'active';
+        console.warn(
+          `Resource ${updatedEntry.resource.resourceType}/${updatedEntry.resource.id} status has been coerced to 'active'.`
+        );
+      }
+    }
+    return updatedEntry;
+  });
+  return updatedEntries;
 }
 
 /*
@@ -216,6 +277,22 @@ if (process.argv[2] === 'delete') {
     .finally(() => {
       Connection.connection?.close();
     });
+} else if (process.argv[2] === 'postBundle') {
+  if (process.argv.length < 4) {
+    throw new Error('Filename argument required.');
+  }
+  let url = 'http://localhost:3000/4_0_1';
+  if (process.argv.length < 5) {
+    console.log('Given only filename input. Defaulting service url to http://localhost:3000/4_0_1');
+  } else {
+    url = process.argv[4];
+  }
+
+  loadBundle(process.argv[3], url)
+    .then(() => {
+      console.log('Done');
+    })
+    .catch(console.error);
 } else {
   console.log('Usage: ts-node src/scripts/dbSetup.ts <create|delete|reset>');
 }

--- a/service/src/config/capabilityStatementResources.json
+++ b/service/src/config/capabilityStatementResources.json
@@ -51,6 +51,16 @@
           ],
           "code": "update",
           "documentation": "Update allows authoring workflows to update existing libraries in _draft_ (**revise**) status, add comments to existing libraries (**review** and **approve**), and **release** or **retire** a library."
+        },
+        {
+          "extension" : [
+            {
+              "url" : "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode" : "SHALL"
+            }
+          ],
+          "code" : "delete",
+          "documentation" : "Delete allows authoring workflows to **withdraw** _draft_ libraries or **archive** _retired_ libraries."
         }
       ],
       "searchParam": [
@@ -207,6 +217,16 @@
           ],
           "code": "update",
           "documentation": "Update allows authoring workflows to update existing measures in _draft_ (**revise**) status, add comments to existing measures (**review** and **approve**), and **release** or **retire** a measure."
+        },
+        {
+          "extension" : [
+            {
+              "url" : "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode" : "SHALL"
+            }
+          ],
+          "code" : "delete",
+          "documentation" : "Delete allows authoring workflows to **withdraw** _draft_ measures or **archive** _retired_ measures."
         }
       ],
       "searchParam": [

--- a/service/src/db/dbOperations.ts
+++ b/service/src/db/dbOperations.ts
@@ -99,3 +99,16 @@ export async function updateResource(id: string, data: fhir4.FhirResource, resou
 
   return { id, created: false };
 }
+
+/**
+ * Searches for a document for a resource and deletes it if found
+ */
+export async function deleteResource(id: string, resourceType: string) {
+  const collection = Connection.db.collection(resourceType);
+  logger.debug(`Finding and deleting ${resourceType}/${id} from database`);
+  const results = await collection.deleteOne({ id });
+  if (results.deletedCount === 1) {
+    return { id, deleted: true };
+  }
+  return { id, deleted: false };
+}

--- a/service/src/services/BaseService.ts
+++ b/service/src/services/BaseService.ts
@@ -64,7 +64,7 @@ async function uploadResourcesFromBundle(entries: DetailedEntry[]) {
   const requestsArray = modifedRequestsArray.map(async entry => {
     // add library owned extension
     entry = addLibraryIsOwned(entry, ownedUrls);
-    return insertBundleResources(entry);
+    return insertBundleResources(entry as DetailedEntry);
   });
   return Promise.all(requestsArray);
 }

--- a/service/src/services/BaseService.ts
+++ b/service/src/services/BaseService.ts
@@ -1,8 +1,8 @@
 import { loggers, constants, resolveSchema } from '@projecttacoma/node-fhir-server-core';
 import { BadRequestError } from '../util/errorUtils';
-import { checkContentTypeHeader } from '../util/inputUtils';
+import { checkContentTypeHeader, checkFieldsForCreate, checkFieldsForUpdate } from '../util/inputUtils';
 import { v4 as uuidv4 } from 'uuid';
-import { createResource, updateResource } from '../db/dbOperations';
+import { createResource, findResourceById, updateResource } from '../db/dbOperations';
 import path from 'path';
 import { DetailedEntry, addIsOwnedExtension, addLibraryIsOwned, replaceReferences } from '../util/baseUtils';
 
@@ -73,23 +73,10 @@ async function uploadResourcesFromBundle(entries: DetailedEntry[]) {
  * Inserts Library or Measure resources from Bundle into the database through create or update.
  */
 async function insertBundleResources(entry: DetailedEntry) {
+  // TODO: make updates here for AUHTHORING/PUBLISHABLE
   if (entry.resource?.resourceType === 'Library' || entry.resource?.resourceType === 'Measure') {
-    if (entry.resource.status != 'active') {
-      entry.resource.status = 'active';
-      entry.outcome = {
-        resourceType: 'OperationOutcome',
-        issue: [
-          {
-            severity: 'warning',
-            code: 'value', // code from: https://build.fhir.org/valueset-issue-type.html
-            details: { text: 'Artifact status has been coerced to active to meet server specifications' },
-            expression: [`${entry.resource.resourceType}.status`]
-          }
-        ]
-      };
-    }
-
     if (entry.isPost) {
+      checkFieldsForCreate(entry.resource);
       entry.resource.id = uuidv4();
       const { id } = await createResource(entry.resource, entry.resource.resourceType);
       if (id != null) {
@@ -98,6 +85,15 @@ async function insertBundleResources(entry: DetailedEntry) {
       }
     } else {
       if (entry.resource.id) {
+        const oldResource = (await findResourceById(
+          entry.resource.id,
+          entry.resource.resourceType
+        )) as fhir4.Library | null;
+        if (oldResource) {
+          checkFieldsForUpdate(entry.resource, oldResource);
+        } else {
+          checkFieldsForCreate(entry.resource);
+        }
         const { id, created } = await updateResource(entry.resource.id, entry.resource, entry.resource.resourceType);
         if (created === true) {
           entry.status = 201;

--- a/service/src/services/LibraryService.ts
+++ b/service/src/services/LibraryService.ts
@@ -133,7 +133,7 @@ export class LibraryService implements Service<fhir4.Library> {
    * result of sending a DELETE request to {BASE_URL}/4_0_1/Library/{id}
    * deletes the library with the passed in id if it exists in the database
    */
-  async delete(args: RequestArgs, { req }: RequestCtx) {
+  async remove(args: RequestArgs, { req }: RequestCtx) {
     const resource = (await findResourceById(args.id, 'Library')) as fhir4.Library | null;
     if (!resource) {
       throw new ResourceNotFoundError(`Existing resource not found with id ${args.id}`);

--- a/service/src/services/LibraryService.ts
+++ b/service/src/services/LibraryService.ts
@@ -20,8 +20,8 @@ import {
   validateParamIdSource,
   checkContentTypeHeader,
   checkExpectedResourceType,
-  updateFields,
-  checkFieldsforUpdate,
+  checkFieldsForCreate,
+  checkFieldsForUpdate,
   checkFieldsForDelete
 } from '../util/inputUtils';
 import { v4 as uuidv4 } from 'uuid';
@@ -101,7 +101,8 @@ export class LibraryService implements Service<fhir4.Library> {
     checkContentTypeHeader(contentType);
     const resource = req.body;
     checkExpectedResourceType(resource.resourceType, 'Library');
-    updateFields(resource);
+    checkFieldsForCreate(resource);
+    resource['id'] = uuidv4();
     return createResource(resource, 'Library');
   }
 
@@ -120,7 +121,11 @@ export class LibraryService implements Service<fhir4.Library> {
       throw new BadRequestError('Argument id must match request body id for PUT request');
     }
     const oldResource = (await findResourceById(resource.id, resource.resourceType)) as fhir4.Library | null;
-    checkFieldsforUpdate(resource, oldResource);
+    if (oldResource) {
+      checkFieldsForUpdate(resource, oldResource);
+    } else {
+      checkFieldsForCreate(resource);
+    }
     return updateResource(args.id, resource, 'Library');
   }
 

--- a/service/src/services/LibraryService.ts
+++ b/service/src/services/LibraryService.ts
@@ -133,7 +133,7 @@ export class LibraryService implements Service<fhir4.Library> {
    * result of sending a DELETE request to {BASE_URL}/4_0_1/Library/{id}
    * deletes the library with the passed in id if it exists in the database
    */
-  async remove(args: RequestArgs, { req }: RequestCtx) {
+  async remove(args: RequestArgs) {
     const resource = (await findResourceById(args.id, 'Library')) as fhir4.Library | null;
     if (!resource) {
       throw new ResourceNotFoundError(`Existing resource not found with id ${args.id}`);

--- a/service/src/services/MeasureService.ts
+++ b/service/src/services/MeasureService.ts
@@ -19,8 +19,8 @@ import {
   validateParamIdSource,
   checkContentTypeHeader,
   checkExpectedResourceType,
-  updateFields,
-  checkFieldsforUpdate,
+  checkFieldsForCreate,
+  checkFieldsForUpdate,
   checkFieldsForDelete
 } from '../util/inputUtils';
 import { Calculator } from 'fqm-execution';
@@ -102,7 +102,8 @@ export class MeasureService implements Service<fhir4.Measure> {
     checkContentTypeHeader(contentType);
     const resource = req.body;
     checkExpectedResourceType(resource.resourceType, 'Measure');
-    updateFields(resource);
+    checkFieldsForCreate(resource);
+    resource['id'] = uuidv4();
     return createResource(resource, 'Measure');
   }
 
@@ -122,7 +123,12 @@ export class MeasureService implements Service<fhir4.Measure> {
       throw new BadRequestError('Argument id must match request body id for PUT request');
     }
     const oldResource = (await findResourceById(resource.id, resource.resourceType)) as fhir4.Measure | null;
-    checkFieldsforUpdate(resource, oldResource);
+    if (oldResource) {
+      checkFieldsForUpdate(resource, oldResource);
+    } else {
+      checkFieldsForCreate(resource);
+    }
+
     return updateResource(args.id, resource, 'Measure');
   }
 

--- a/service/src/services/MeasureService.ts
+++ b/service/src/services/MeasureService.ts
@@ -136,7 +136,7 @@ export class MeasureService implements Service<fhir4.Measure> {
    * result of sending a DELETE request to {BASE_URL}/4_0_1/Library/{id}
    * deletes the library with the passed in id if it exists in the database
    */
-  async delete(args: RequestArgs, { req }: RequestCtx) {
+  async remove(args: RequestArgs, { req }: RequestCtx) {
     const resource = (await findResourceById(args.id, 'Measure')) as fhir4.Measure | null;
     if (!resource) {
       throw new ResourceNotFoundError(`Existing resource not found with id ${args.id}`);

--- a/service/src/services/MeasureService.ts
+++ b/service/src/services/MeasureService.ts
@@ -1,6 +1,7 @@
 import { loggers, RequestArgs, RequestCtx } from '@projecttacoma/node-fhir-server-core';
 import {
   createResource,
+  deleteResource,
   findDataRequirementsWithQuery,
   findResourceById,
   findResourceCountWithQuery,
@@ -17,7 +18,10 @@ import {
   gatherParams,
   validateParamIdSource,
   checkContentTypeHeader,
-  checkExpectedResourceType
+  checkExpectedResourceType,
+  updateFields,
+  checkFieldsforUpdate,
+  checkFieldsForDelete
 } from '../util/inputUtils';
 import { Calculator } from 'fqm-execution';
 import { MeasureSearchArgs, MeasureDataRequirementsArgs, PackageArgs, parseRequestSchema } from '../requestSchemas';
@@ -98,11 +102,7 @@ export class MeasureService implements Service<fhir4.Measure> {
     checkContentTypeHeader(contentType);
     const resource = req.body;
     checkExpectedResourceType(resource.resourceType, 'Measure');
-    resource['id'] = uuidv4();
-    if (resource.status != 'active') {
-      resource.status = 'active';
-      logger.warn(`Resource ${resource.id} has been coerced to active`);
-    }
+    updateFields(resource);
     return createResource(resource, 'Measure');
   }
 
@@ -121,11 +121,22 @@ export class MeasureService implements Service<fhir4.Measure> {
     if (resource.id !== args.id) {
       throw new BadRequestError('Argument id must match request body id for PUT request');
     }
-    if (resource.status != 'active') {
-      resource.status = 'active';
-      logger.warn(`Resource ${resource.id} has been coerced to active`);
-    }
+    const oldResource = (await findResourceById(resource.id, resource.resourceType)) as fhir4.Measure | null;
+    checkFieldsforUpdate(resource, oldResource);
     return updateResource(args.id, resource, 'Measure');
+  }
+
+  /**
+   * result of sending a DELETE request to {BASE_URL}/4_0_1/Library/{id}
+   * deletes the library with the passed in id if it exists in the database
+   */
+  async delete(args: RequestArgs, { req }: RequestCtx) {
+    const resource = (await findResourceById(args.id, 'Measure')) as fhir4.Measure | null;
+    if (!resource) {
+      throw new ResourceNotFoundError(`Existing resource not found with id ${args.id}`);
+    }
+    checkFieldsForDelete(resource);
+    return deleteResource(args.id, 'Measure');
   }
 
   /**

--- a/service/src/services/MeasureService.ts
+++ b/service/src/services/MeasureService.ts
@@ -136,7 +136,7 @@ export class MeasureService implements Service<fhir4.Measure> {
    * result of sending a DELETE request to {BASE_URL}/4_0_1/Library/{id}
    * deletes the library with the passed in id if it exists in the database
    */
-  async remove(args: RequestArgs, { req }: RequestCtx) {
+  async remove(args: RequestArgs) {
     const resource = (await findResourceById(args.id, 'Measure')) as fhir4.Measure | null;
     if (!resource) {
       throw new ResourceNotFoundError(`Existing resource not found with id ${args.id}`);

--- a/service/src/util/baseUtils.ts
+++ b/service/src/util/baseUtils.ts
@@ -19,7 +19,7 @@ export type DetailedEntry = fhir4.BundleEntry<FhirResource> & {
  *
  * returns modified entry and url of owned library
  */
-export function addIsOwnedExtension(entry: DetailedEntry) {
+export function addIsOwnedExtension(entry: fhir4.BundleEntry<fhir4.FhirResource>) {
   if (entry.resource?.resourceType && entry.resource?.resourceType === 'Measure' && entry.resource?.library) {
     // get the main Library of the Measure from the library property and the version
     const mainLibrary = entry.resource.library[0];
@@ -70,7 +70,7 @@ export function addIsOwnedExtension(entry: DetailedEntry) {
 /**
  * Checks ownedUrls for entry url and adds isOwned extension to the resource if found in ownedUrls
  */
-export function addLibraryIsOwned(entry: DetailedEntry, ownedUrls: string[]) {
+export function addLibraryIsOwned(entry: fhir4.BundleEntry<fhir4.FhirResource>, ownedUrls: string[]) {
   // add owned to identified resources (currently assumes these will only be Libraries)
   if (entry.resource?.resourceType === 'Library' && entry.resource.url) {
     const libraryUrl = entry.resource.version

--- a/service/src/util/inputUtils.ts
+++ b/service/src/util/inputUtils.ts
@@ -1,10 +1,7 @@
 import { RequestArgs, RequestQuery, FhirResourceType } from '@projecttacoma/node-fhir-server-core';
 import { Filter } from 'mongodb';
-import { BadRequestError, ResourceNotFoundError } from './errorUtils';
-import { v4 as uuidv4 } from 'uuid';
+import { BadRequestError } from './errorUtils';
 import _ from 'lodash';
-import { loggers } from '@projecttacoma/node-fhir-server-core';
-const logger = loggers.get('default');
 
 /*
  * Gathers parameters from both the query and the FHIR parameter request body resource

--- a/service/src/util/inputUtils.ts
+++ b/service/src/util/inputUtils.ts
@@ -70,7 +70,7 @@ export function checkExpectedResourceType(resourceType: string, expectedResource
 }
 
 export function checkFieldsForCreate(resource: fhir4.Measure | fhir4.Library) {
-  if (process.env.AUTHORING) {
+  if (process.env.AUTHORING === 'true') {
     // authoring requires active or draft status
     if (resource.status !== 'active' && resource.status !== 'draft') {
       throw new BadRequestError(
@@ -91,10 +91,10 @@ export function checkFieldsForUpdate(
   resource: fhir4.Measure | fhir4.Library,
   oldResource: fhir4.Measure | fhir4.Library
 ) {
-  if (!process.env.AUTHORING || oldResource.status === 'active') {
+  if (process.env.AUTHORING !== 'true' || oldResource.status === 'active') {
     // publishable or active status requires retire functionality
     // TODO: is there any other metadata we should allow to update for the retire functionality?
-    if (!process.env.AUTHORING && oldResource.status !== 'active') {
+    if (process.env.AUTHORING !== 'true' && oldResource.status !== 'active') {
       throw new BadRequestError(
         `Resource status is currently ${oldResource.status}. Publishable repository service updates may only be made to active status resources.`
       );
@@ -120,10 +120,12 @@ export function checkFieldsForUpdate(
 }
 
 export function checkFieldsForDelete(resource: fhir4.Measure | fhir4.Library) {
-  if (process.env.AUTHORING) {
-    // authoring requires draft status
-    if (resource.status !== 'draft') {
-      throw new BadRequestError('Authoring repository service deletions may only be made to draft status resources.');
+  if (process.env.AUTHORING === 'true') {
+    // authoring requires draft or retired status
+    if (resource.status !== 'draft' && resource.status !== 'retired') {
+      throw new BadRequestError(
+        'Authoring repository service deletions may only be made to draft or retired status resources.'
+      );
     }
   } else {
     // publishable requires retired status

--- a/service/test/services/BaseService.test.ts
+++ b/service/test/services/BaseService.test.ts
@@ -96,7 +96,8 @@ const VALID_PUT_REQ = {
       resource: {
         resourceType: 'Measure',
         id: 'test-measure',
-        library: ['Library/test-library']
+        library: ['Library/test-library'],
+        status: 'draft'
       },
       request: {
         method: 'PUT',
@@ -113,7 +114,8 @@ const VALID_POST_REQ = {
     {
       resource: {
         resourceType: 'Library',
-        id: 'test-library'
+        id: 'test-library',
+        status: 'draft'
       },
       request: {
         method: 'POST',
@@ -126,6 +128,7 @@ const VALID_POST_REQ = {
 describe('BaseService', () => {
   beforeAll(async () => {
     server = initialize(serverConfig, app);
+    process.env.AUTHORING = 'true';
     return setupTestDatabase([]);
   });
 

--- a/service/test/services/LibraryService.test.ts
+++ b/service/test/services/LibraryService.test.ts
@@ -256,7 +256,13 @@ describe('LibraryService', () => {
   describe('update', () => {
     beforeAll(() => {
       return createTestResource(
-        { resourceType: 'Library', type: { coding: [{ code: 'logic-library' }] }, id: 'exampleId', status: 'draft' },
+        {
+          resourceType: 'Library',
+          type: { coding: [{ code: 'logic-library' }] },
+          id: 'exampleId',
+          status: 'draft',
+          title: 'test'
+        },
         'Library'
       );
     });
@@ -264,7 +270,7 @@ describe('LibraryService', () => {
     it('returns 200 when provided correct headers and a FHIR Library whose id is in the database', async () => {
       await supertest(server.app)
         .put('/4_0_1/Library/exampleId')
-        .send({ resourceType: 'Library', id: 'exampleId', status: 'active' })
+        .send({ resourceType: 'Library', id: 'exampleId', status: 'draft', title: 'updated' })
         .set('content-type', 'application/json+fhir')
         .expect(200)
         .then(response => {

--- a/service/test/services/LibraryService.test.ts
+++ b/service/test/services/LibraryService.test.ts
@@ -106,6 +106,7 @@ const LIBRARY_WITH_SAME_SYSTEM2: fhir4.Library = {
 describe('LibraryService', () => {
   beforeAll(() => {
     server = initialize(serverConfig);
+    process.env.AUTHORING = 'true';
     return setupTestDatabase([
       LIBRARY_WITH_URL,
       LIBRARY_WITH_NO_DEPS,
@@ -240,11 +241,93 @@ describe('LibraryService', () => {
     });
   });
 
-  describe('create', () => {
-    it('returns 201 status with populated location when provided correct headers and a FHIR Library', async () => {
+  describe('publishable repository validation', () => {
+    const ORIGINAL_AUTHORING = process.env.AUTHORING;
+    beforeAll(() => {
+      process.env.AUTHORING = 'false';
+      createTestResource(
+        {
+          resourceType: 'Library',
+          type: { coding: [{ code: 'logic-library' }] },
+          id: 'publishable-retired',
+          status: 'retired',
+          title: 'test'
+        },
+        'Library'
+      );
+      return createTestResource(
+        {
+          resourceType: 'Library',
+          type: { coding: [{ code: 'logic-library' }] },
+          id: 'publishable-active',
+          status: 'active',
+          title: 'test'
+        },
+        'Library'
+      );
+    });
+    it('publish: returns 400 status when provided with artifact in non-active status', async () => {
       await supertest(server.app)
         .post('/4_0_1/Library')
         .send({ resourceType: 'Library', status: 'draft' })
+        .set('content-type', 'application/json+fhir')
+        .expect(400);
+    });
+    it('retire: returns 400 when artifact to update is not in active status', async () => {
+      await supertest(server.app)
+        .put('/4_0_1/Library/publishable-retired')
+        .send({
+          resourceType: 'Library',
+          id: 'publishable-retired',
+          status: 'active',
+          title: 'test',
+          type: { coding: [{ code: 'logic-library' }] }
+        })
+        .set('content-type', 'application/json+fhir')
+        .expect(400);
+    });
+
+    it('retire: returns 400 when attempting to update non-date/non-status fields', async () => {
+      await supertest(server.app)
+        .put('/4_0_1/Library/publishable-active')
+        .send({
+          resourceType: 'Library',
+          id: 'publishable-active',
+          status: 'retired',
+          title: 'updated',
+          type: { coding: [{ code: 'logic-library' }] }
+        })
+        .set('content-type', 'application/json+fhir')
+        .expect(400);
+    });
+    it('archive: returns 400 status when deleting an active artifact', async () => {
+      await supertest(server.app)
+        .delete('/4_0_1/Library/publishable-active')
+        .send()
+        .set('content-type', 'application/json+fhir')
+        .expect(400);
+    });
+    afterAll(() => {
+      process.env.AUTHORING = ORIGINAL_AUTHORING;
+    });
+  });
+
+  describe('create', () => {
+    it('submit: returns 201 status with populated location when provided correct headers and a FHIR Library', async () => {
+      await supertest(server.app)
+        .post('/4_0_1/Library')
+        .send({ resourceType: 'Library', status: 'draft' })
+        .set('content-type', 'application/json+fhir')
+        .expect(201)
+        .then(response => {
+          expect(response.headers.location).toBeDefined();
+        });
+    });
+
+    it('publish: returns 201 status with populated location when provided correct headers and a FHIR Library', async () => {
+      await supertest(server.app)
+        .post('/4_0_1/Library')
+        .send({ resourceType: 'Library', status: 'active' })
         .set('content-type', 'application/json+fhir')
         .expect(201)
         .then(response => {
@@ -255,6 +338,16 @@ describe('LibraryService', () => {
 
   describe('update', () => {
     beforeAll(() => {
+      createTestResource(
+        {
+          resourceType: 'Library',
+          type: { coding: [{ code: 'logic-library' }] },
+          id: 'exampleId-active',
+          status: 'active',
+          title: 'test'
+        },
+        'Library'
+      );
       return createTestResource(
         {
           resourceType: 'Library',
@@ -267,10 +360,35 @@ describe('LibraryService', () => {
       );
     });
 
-    it('returns 200 when provided correct headers and a FHIR Library whose id is in the database', async () => {
+    it('revise: returns 200 when provided correct headers and a FHIR Library whose id is in the database', async () => {
       await supertest(server.app)
         .put('/4_0_1/Library/exampleId')
         .send({ resourceType: 'Library', id: 'exampleId', status: 'draft', title: 'updated' })
+        .set('content-type', 'application/json+fhir')
+        .expect(200)
+        .then(response => {
+          expect(response.headers.location).toBeDefined();
+        });
+    });
+
+    it('revise: returns 400 when status changes', async () => {
+      await supertest(server.app)
+        .put('/4_0_1/Library/exampleId')
+        .send({ resourceType: 'Library', id: 'exampleId', status: 'active', title: 'updated' })
+        .set('content-type', 'application/json+fhir')
+        .expect(400);
+    });
+
+    it('retire: returns 200 when provided updated status for retiring', async () => {
+      await supertest(server.app)
+        .put('/4_0_1/Library/exampleId-active')
+        .send({
+          resourceType: 'Library',
+          id: 'exampleId-active',
+          status: 'retired',
+          title: 'test',
+          type: { coding: [{ code: 'logic-library' }] }
+        })
         .set('content-type', 'application/json+fhir')
         .expect(200)
         .then(response => {
@@ -303,6 +421,62 @@ describe('LibraryService', () => {
           expect(response.body.issue[0].code).toEqual('invalid');
           expect(response.body.issue[0].details.text).toEqual('Argument id must match request body id for PUT request');
         });
+    });
+  });
+
+  describe('delete', () => {
+    beforeAll(() => {
+      createTestResource(
+        {
+          resourceType: 'Library',
+          type: { coding: [{ code: 'logic-library' }] },
+          id: 'delete-active',
+          status: 'active',
+          title: 'test'
+        },
+        'Library'
+      );
+      createTestResource(
+        {
+          resourceType: 'Library',
+          type: { coding: [{ code: 'logic-library' }] },
+          id: 'delete-retired',
+          status: 'retired',
+          title: 'test'
+        },
+        'Library'
+      );
+      return createTestResource(
+        {
+          resourceType: 'Library',
+          type: { coding: [{ code: 'logic-library' }] },
+          id: 'delete-draft',
+          status: 'draft',
+          title: 'test'
+        },
+        'Library'
+      );
+    });
+    it('withdraw: returns 204 status when deleting a draft artifact', async () => {
+      await supertest(server.app)
+        .delete('/4_0_1/Library/delete-draft')
+        .send()
+        .set('content-type', 'application/json+fhir')
+        .expect(204);
+    });
+    it('archive: returns 204 status when deleting a retired artifact', async () => {
+      await supertest(server.app)
+        .delete('/4_0_1/Library/delete-retired')
+        .send()
+        .set('content-type', 'application/json+fhir')
+        .expect(204);
+    });
+    it('archive: returns 400 status when deleting an active artifact', async () => {
+      await supertest(server.app)
+        .delete('/4_0_1/Library/delete-active')
+        .send()
+        .set('content-type', 'application/json+fhir')
+        .expect(400);
     });
   });
 

--- a/service/test/services/MeasureService.test.ts
+++ b/service/test/services/MeasureService.test.ts
@@ -246,13 +246,16 @@ describe('MeasureService', () => {
 
   describe('update', () => {
     beforeAll(() => {
-      return createTestResource({ resourceType: 'Measure', id: 'exampleId', status: 'draft' }, 'Measure');
+      return createTestResource(
+        { resourceType: 'Measure', id: 'exampleId', status: 'draft', title: 'test' },
+        'Measure'
+      );
     });
 
     it('returns 200 when provided correct headers and a FHIR Measure whose id is in the database', async () => {
       await supertest(server.app)
         .put('/4_0_1/Measure/exampleId')
-        .send({ resourceType: 'Measure', id: 'exampleId', status: 'active' })
+        .send({ resourceType: 'Measure', id: 'exampleId', status: 'draft', title: 'updated' })
         .set('content-type', 'application/json+fhir')
         .expect(200)
         .then(response => {


### PR DESCRIPTION
# Summary
Implement/ensure publishable artifact repository minimum write capabilities (Publish, Retire, Archive) as defined in the CRMI IG [here](https://hl7.org/fhir/uv/crmi/1.0.0-snapshot/artifact-repository-service.html#publishable-artifact-repository).

## New behavior

## Code changes

# Testing guidance
- `npm run check`
- Set the AUTHORING environment variable to false in your local .env file to test publishable-limited capabilities.
- `npm run start:service`
- Run db:postBundle, example `npm run db:postBundle {bundle path}`
  - Default assumes that the server is running on http://localhost:3000/4_0_1, or you can specify a server path as an additional argument on the end
- Test out the capabilities and limitations listed in the README for the publishable repository server (and authoring if it makes sense) using Insomnia
  - Can see added jest tests for more specific examples of things to test