### PR TITLE
Expose  operation

### DIFF
--- a/service/.env.test
+++ b/service/.env.test
@@ -1,2 +1,3 @@
 VSAC_API_KEY="example-api-key"
 AUTHORING=true
+DATABASE_URL='mongodb://localhost:27017/measure-repository?replicaSet=rs0'

--- a/service/jest-mongodb-config.js
+++ b/service/jest-mongodb-config.js
@@ -1,12 +1,14 @@
 module.exports = {
   mongodbMemoryServerOptions: {
     binary: {
-      verison: '6.0.1',
+      version: '6.0.1',
       skipMD5: true
     },
     autoStart: false,
-    instance: {}
-  },
-
-  useSharedDBForAllJestWorkers: false
+    instance: {},
+    replSet: {
+      count: 3,
+      storageEngine: 'wiredTiger'
+    }
+  }
 };

--- a/service/package.json
+++ b/service/package.json
@@ -22,7 +22,7 @@
     "dev:watch": "nodemon ./src/index.ts",
     "dev:clean": "npm run db:reset && npm run dev",
     "start": "node ./dist/index.js",
-    "test": "jest",
+    "test": "jest --runInBand --silent",
     "test:watch": "jest --watch"
   },
   "devDependencies": {

--- a/service/src/config/serverConfig.ts
+++ b/service/src/config/serverConfig.ts
@@ -85,6 +85,30 @@ export const serverConfig: ServerConfig = {
           route: '/:id/$data-requirements',
           method: 'POST',
           reference: 'http://hl7.org/fhir/us/cqfmeasures/OperationDefinition/Measure-data-requirements'
+        },
+        {
+          name: 'draft',
+          route: '/$draft',
+          method: 'GET',
+          reference: 'https://hl7.org/fhir/uv/crmi/STU1/OperationDefinition-crmi-draft.html'
+        },
+        {
+          name: 'draft',
+          route: '/$draft',
+          method: 'POST',
+          reference: 'https://hl7.org/fhir/uv/crmi/STU1/OperationDefinition-crmi-draft.html'
+        },
+        {
+          name: 'draft',
+          route: '/:id/$draft',
+          method: 'GET',
+          reference: 'https://hl7.org/fhir/uv/crmi/STU1/OperationDefinition-crmi-draft.html'
+        },
+        {
+          name: 'draft',
+          route: '/:id/$draft',
+          method: 'POST',
+          reference: 'https://hl7.org/fhir/uv/crmi/STU1/OperationDefinition-crmi-draft.html'
         }
       ]
     },
@@ -139,6 +163,30 @@ export const serverConfig: ServerConfig = {
           route: '/:id/$data-requirements',
           method: 'POST',
           reference: 'http://hl7.org/fhir/us/cqfmeasures/OperationDefinition/Library-data-requirements'
+        },
+        {
+          name: 'draft',
+          route: '/$draft',
+          method: 'GET',
+          reference: 'https://hl7.org/fhir/uv/crmi/STU1/OperationDefinition-crmi-draft.html'
+        },
+        {
+          name: 'draft',
+          route: '/$draft',
+          method: 'POST',
+          reference: 'https://hl7.org/fhir/uv/crmi/STU1/OperationDefinition-crmi-draft.html'
+        },
+        {
+          name: 'draft',
+          route: '/:id/$draft',
+          method: 'GET',
+          reference: 'https://hl7.org/fhir/uv/crmi/STU1/OperationDefinition-crmi-draft.html'
+        },
+        {
+          name: 'draft',
+          route: '/:id/$draft',
+          method: 'POST',
+          reference: 'https://hl7.org/fhir/uv/crmi/STU1/OperationDefinition-crmi-draft.html'
         }
       ]
     }

--- a/service/src/types/service-types.ts
+++ b/service/src/types/service-types.ts
@@ -3,3 +3,23 @@ import { Filter } from 'mongodb';
 export type FhirLibraryWithDR = fhir4.Library & {
   _dataRequirements?: Filter<any>;
 };
+
+export interface CRMIMeasure extends fhir4.Measure {
+  id: string;
+  url: string;
+  version: string;
+  title: string;
+  description: string;
+}
+
+export interface CRMILibrary extends fhir4.Library {
+  id: string;
+  url: string;
+  version: string;
+  title: string;
+  description: string;
+}
+
+// type representing the resource types that are relevant to the Measure Repository Service
+export type FhirArtifact = CRMIMeasure | CRMILibrary;
+export type ArtifactResourceType = FhirArtifact['resourceType'];

--- a/service/src/util/bundleUtils.ts
+++ b/service/src/util/bundleUtils.ts
@@ -8,6 +8,7 @@ import { PackageArgs } from '../requestSchemas';
 import fs from 'fs';
 import { getMongoQueryFromRequest } from './queryUtils';
 import { z } from 'zod';
+import { FhirArtifact } from '../types/service-types';
 
 const logger = loggers.get('default');
 
@@ -21,6 +22,24 @@ export function createSearchsetBundle<T extends fhir4.FhirResource>(entries: T[]
     meta: { lastUpdated: new Date().toISOString() },
     id: v4(),
     type: 'searchset',
+    total: entries.length,
+    entry: entries.map(e => ({ resource: e }))
+  };
+}
+
+/**
+ * Takes in an array of FHIR resources and creates a FHIR batch-response Bundle with the
+ * created resources as entries
+ * TODO: should this response bundle be of type batch-response or something else?
+ * The CRMI IG only says the following: The Bundle result containing the new resource(s)
+ * https://build.fhir.org/ig/HL7/crmi-ig/OperationDefinition-crmi-draft.html
+ */
+export function createBatchResponseBundle<T extends FhirArtifact>(entries: T[]): fhir4.Bundle<T> {
+  return {
+    resourceType: 'Bundle',
+    meta: { lastUpdated: new Date().toISOString() },
+    id: v4(),
+    type: 'batch-response',
     total: entries.length,
     entry: entries.map(e => ({ resource: e }))
   };

--- a/service/src/util/serviceUtils.ts
+++ b/service/src/util/serviceUtils.ts
@@ -1,0 +1,89 @@
+import { findArtifactByUrlAndVersion } from '../db/dbOperations';
+import { ArtifactResourceType, FhirArtifact } from '../types/service-types';
+import { v4 as uuidv4 } from 'uuid';
+import { BadRequestError } from './errorUtils';
+
+export type ChildArtifactInfo = {
+  resourceType: 'Measure' | 'Library';
+  url: string;
+  version: string;
+};
+
+/**
+ * Helper function that takes an array of related artifacts and recursively
+ * finds all of the child artifacts (related artifacts whose type is composed-of
+ * and has the isOwned extension)
+ */
+export async function getChildren(relatedArtifacts: fhir4.RelatedArtifact[]) {
+  let children: FhirArtifact[] = [];
+
+  for (const ra of relatedArtifacts) {
+    if (
+      ra.type === 'composed-of' &&
+      ra.resource &&
+      ra.extension?.some(
+        e => e.url === 'http://hl7.org/fhir/StructureDefinition/artifact-isOwned' && e.valueBoolean === true
+      )
+    ) {
+      let resourceType: ArtifactResourceType;
+      if (ra.resource.includes('Measure')) {
+        resourceType = 'Measure';
+      } else {
+        resourceType = 'Library';
+      }
+
+      const [url, version] = ra.resource.split('|');
+
+      // search for the related artifact in the published measure repository
+      const childArtifact = (await findArtifactByUrlAndVersion(url, version, resourceType)) as FhirArtifact;
+      if (!childArtifact) {
+        throw new Error('No artifacts found in search');
+      }
+
+      children.push(childArtifact);
+
+      if (childArtifact.relatedArtifact) {
+        const nested = await getChildren(childArtifact.relatedArtifact);
+        children = children.concat(nested);
+      }
+    }
+  }
+  return children;
+}
+
+/**
+ * Helper function that takes an active artifact and returns it with a new id,
+ * draft status, and version (from the $draft parameter). It also removes
+ * effectivePeriod, approvalDate, and any extensions which are only valid for
+ * active artifacts
+ */
+export async function modifyResourcesForDraft(artifacts: FhirArtifact[], version: string) {
+  for (const artifact of artifacts) {
+    artifact.id = uuidv4();
+    artifact.status = 'draft';
+    artifact.version = version;
+    if (artifact.relatedArtifact) {
+      artifact.relatedArtifact.forEach(ra => {
+        if (
+          ra.type === 'composed-of' &&
+          ra.resource &&
+          ra.extension?.some(
+            e => e.url === 'http://hl7.org/fhir/StructureDefinition/artifact-isOwned' && e.valueBoolean === true
+          )
+        ) {
+          const url = ra.resource.split('|')[0];
+          ra.resource = url + '|' + version;
+        }
+      });
+    }
+
+    const checkExisting = await findArtifactByUrlAndVersion(artifact.url, version, artifact.resourceType);
+    if (checkExisting) {
+      throw new BadRequestError(
+        `A ${artifact.resourceType} with url ${artifact.url} and version ${artifact.version} already exists in the database.`
+      );
+    }
+  }
+
+  return artifacts;
+}

--- a/service/test/util/serviceUtils.test.ts
+++ b/service/test/util/serviceUtils.test.ts
@@ -1,0 +1,87 @@
+import { CRMILibrary } from '../../src/types/service-types';
+import { cleanUpTestDatabase, setupTestDatabase } from '../utils';
+import { getChildren, modifyResourcesForDraft } from '../../src/util/serviceUtils';
+
+const PARENT_RELATED_ARTIFACTS: fhir4.RelatedArtifact[] = [
+  {
+    type: 'composed-of',
+    resource: 'http://child-library-1.com|1',
+    extension: [
+      {
+        url: 'http://hl7.org/fhir/StructureDefinition/artifact-isOwned',
+        valueBoolean: true
+      }
+    ]
+  }
+];
+
+const CHILD_LIBRARY_1: CRMILibrary = {
+  resourceType: 'Library',
+  status: 'active',
+  type: { coding: [{ code: 'logic-library' }] },
+  extension: [
+    {
+      url: 'http://hl7.org/fhir/StructureDefinition/artifact-isOwned',
+      valueBoolean: true
+    }
+  ],
+  id: 'childLibrary1',
+  url: 'http://child-library-1.com',
+  version: '1',
+  title: 'Child Library 1',
+  description: 'Child Library 1 description',
+  relatedArtifact: [
+    {
+      type: 'composed-of',
+      resource: 'http://child-library-2.com|1',
+      extension: [
+        {
+          url: 'http://hl7.org/fhir/StructureDefinition/artifact-isOwned',
+          valueBoolean: true
+        }
+      ]
+    }
+  ]
+};
+
+const CHILD_LIBRARY_2: CRMILibrary = {
+  resourceType: 'Library',
+  status: 'active',
+  type: { coding: [{ code: 'logic-library' }] },
+  extension: [
+    {
+      url: 'http://hl7.org/fhir/StructureDefinition/artifact-isOwned',
+      valueBoolean: true
+    }
+  ],
+  id: 'childLibrary2',
+  url: 'http://child-library-2.com',
+  version: '1',
+  title: 'Child Library 2',
+  description: 'Child Library 2 description'
+};
+
+describe('serviceUtils', () => {
+  beforeAll(() => {
+    return setupTestDatabase([CHILD_LIBRARY_1, CHILD_LIBRARY_2]);
+  });
+
+  describe('getChildren', () => {
+    it('returns an array of ChildArtifactInfo objects', async () => {
+      expect(await getChildren(PARENT_RELATED_ARTIFACTS)).toEqual([CHILD_LIBRARY_1, CHILD_LIBRARY_2]);
+    });
+  });
+
+  describe('modifyResourcesForDraft', () => {
+    it('returns an array of modified (new id, new version, draft status, modified relatedArtifacts) FhirArtifacts', async () => {
+      const modifiedResources = await modifyResourcesForDraft([CHILD_LIBRARY_1, CHILD_LIBRARY_2], '1.0.0.1');
+      expect(modifiedResources[0].status).toEqual('draft');
+      expect(modifiedResources[1].status).toEqual('draft');
+      expect(modifiedResources[0].version).toEqual('1.0.0.1');
+      expect(modifiedResources[1].version).toEqual('1.0.0.1');
+      expect(modifiedResources[0].relatedArtifact?.[0].resource).toEqual('http://child-library-2.com|1.0.0.1');
+    });
+  });
+
+  afterAll(cleanUpTestDatabase);
+});


### PR DESCRIPTION
# Summary
This PR exposes the $draft operation as an endpoint on the server. This functionality is defined in the CRMI IG [here](https://build.fhir.org/ig/HL7/crmi-ig/OperationDefinition-crmi-draft.html). 

## New behavior
The user can now create a draft version of a Measure or Library artifact and any resources it is composed of by sending a GET or POST request to `Measure/$draft`, `Measure/:id/$draft`, `Library/$draft` and `Library/:id/$draft`. Since this is only an operation supported in an Authoring Artifact Repository, the `AUTHORING` environment variable must be set to true.

## Code changes
- `service/env.test` / `service/jest.mongodb.config.js` / `service/package.json` - had to make some changes with the jest configuration since we need a replicaSet in order to test the batch draft functionality (was previously in the `/app` directory and there are no unit tests there) Source: https://github.com/shelfio/jest-mongodb?tab=readme-ov-file#2-create-jest-mongodb-configjs
- `service/src/config/serverConfig.ts` - added `$draft` endpoints to server configuration
- `service/src/db/dbOperations` - added `findArtifactByUrlAndVersion` function for getting child artifacts from relatedArtifacts, added `batchDraft` for creating draft artifacts in a batch transaction
- `service/src/requestSchemas.ts` - additional schemas for enforcing `$draft` parameters (must have `id` and `version` and `version` must be in the format `MAJOR.MINOR.PATCH.REVISION`
- `service/src/services/LibraryService.ts` / `service/src/services/MeasureService.ts` - add `draft` endpoint
- `service/src/types/service-types.ts` - new types `CRMILibrary` and `CRMIMeasure`
- `service/src/util/bundleUtils.ts` - `createBatchResponseBundle` function for `$draft` operation output 
- `service/src/util/inputUtils.ts` - adds the following helper functions to validate inputs: `checkDraft`, `checkIsOwned`, and `checkExistingArtifact`
- `service/src/util/serviceUtils.ts` - adds the following helper functions for `$draft`: `getChildren` and `modifyResourcesForDraft`
- `LibraryService.test.ts` / `MeasureService.test.ts` / `serviceUtils.test.ts` - added unit tests

# Testing guidance
- `npm run check:all`
- `npm run build:all`
- `cd service`
- `npm run db:reset`
- `npm run db:loadBundle <your favorite bundles>` (I also recommend using the double nested child artifact bundle I "made" so that the recursion can be properly tested.
- `npm run start:all`
- The attached zip file contains Insomnia requests for testing!

[DraftTesting.json](https://github.com/user-attachments/files/16089632/DraftTesting.json)