### PR TITLE
Expose clone operation

### DIFF
--- a/service/README.md
+++ b/service/README.md
@@ -94,12 +94,13 @@ When sending requests, ensure that the `"Content-type": "application/json+fhir"`
 
 ### CRUD Operations
 
-This server can be configured as a [Publishable Measure Repository](https://build.fhir.org/ig/HL7/cqf-measures/measure-repository-service.html#publishable-measure-repository) or an  [Authoring Measure Repository](https://build.fhir.org/ig/HL7/cqf-measures/measure-repository-service.html#authoring-measure-repository) using the `AUTHORING` environment variable. The minimum write capabilities for these repositories are described further in the [CRMI Publishable Artifact Repository](https://hl7.org/fhir/uv/crmi/1.0.0-snapshot/artifact-repository-service.html#publishable-artifact-repository) and [CRMI Authoring Artifact Repository](https://hl7.org/fhir/uv/crmi/1.0.0-snapshot/artifact-repository-service.html#authoring-artifact-repository) specifications, respectively. The write capabilities implemented in this server are further detailed for the create, update, and delete operations described below.
+This server can be configured as a [Publishable Measure Repository](https://build.fhir.org/ig/HL7/cqf-measures/measure-repository-service.html#publishable-measure-repository) or an [Authoring Measure Repository](https://build.fhir.org/ig/HL7/cqf-measures/measure-repository-service.html#authoring-measure-repository) using the `AUTHORING` environment variable. The minimum write capabilities for these repositories are described further in the [CRMI Publishable Artifact Repository](https://hl7.org/fhir/uv/crmi/1.0.0-snapshot/artifact-repository-service.html#publishable-artifact-repository) and [CRMI Authoring Artifact Repository](https://hl7.org/fhir/uv/crmi/1.0.0-snapshot/artifact-repository-service.html#authoring-artifact-repository) specifications, respectively. The write capabilities implemented in this server are further detailed for the create, update, and delete operations described below.
 
 This server currently supports the following CRUD operations:
 
 - Read by ID with `GET` to endpoint: `4_0_1/<resourceType>/<resourceId>`
 - Create resource (Library or Measure) with `POST` to endpoint: `4_0_1/<resourceType>`
+
   - Publishable:
     - Supports the _Publishable_ minimum write capability _publish_
     - Artifact must be in active status and conform to appropriate shareable and publishable profiles
@@ -108,6 +109,7 @@ This server currently supports the following CRUD operations:
     - Artifact must be in draft status
 
 - Update resource (Library or Measure) with `PUT` to endpoint: `4_0_1/<resourceType>/<resourceId>`
+
   - Publishable:
     - Supports the _Publishable_ minimum write capability _retire_
     - Artifact must be in active status and may only change the status to retired and update the date (and other metadata appropriate to indicate retired status)
@@ -167,6 +169,23 @@ Supported optional parameters for `Measure` are:
 
 - periodStart
 - periodEnd
+
+### Draft
+
+The Measure Repository Service Authoring Repository Service server supports the `Measure` and `Library` `$draft` operations as defined by the [Canonical Resource Management Infrastructure IG](https://build.fhir.org/ig/HL7/crmi-ig/OperationDefinition-crmi-draft.html). It requires the following parameters:
+
+- id
+- version
+
+### Clone
+
+The Measure Repository Service Authoring Repository Service server supports the `Measure` and `Library` `$clone` operations as defined by the [Canonical Resource Management Infrastructure IG](https://build.fhir.org/ig/HL7/crmi-ig/OperationDefinition-crmi-clone.html). It requires the following parameters:
+
+- id
+- version
+- url
+
+Note: `url` is not currently a required parameter in the $clone OperationDefinition, but it will be in future IG versions.
 
 ## License
 

--- a/service/src/config/capabilityStatementResources.json
+++ b/service/src/config/capabilityStatementResources.json
@@ -53,14 +53,14 @@
           "documentation": "Update allows authoring workflows to update existing libraries in _draft_ (**revise**) status, add comments to existing libraries (**review** and **approve**), and **release** or **retire** a library."
         },
         {
-          "extension" : [
+          "extension": [
             {
-              "url" : "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-              "valueCode" : "SHALL"
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHALL"
             }
           ],
-          "code" : "delete",
-          "documentation" : "Delete allows authoring workflows to **withdraw** _draft_ libraries or **archive** _retired_ libraries."
+          "code": "delete",
+          "documentation": "Delete allows authoring workflows to **withdraw** _draft_ libraries or **archive** _retired_ libraries."
         }
       ],
       "searchParam": [
@@ -162,6 +162,26 @@
           ],
           "name": "data-requirements",
           "definition": "https://hl7.org/fhir/us/cqfmeasures/OperationDefinition/Library-data-requirements"
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHALL"
+            }
+          ],
+          "name": "draft",
+          "definition": "http://hl7.org/fhir/uv/crmi/OperationDefinition/crmi-draft"
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHALL"
+            }
+          ],
+          "name": "clone",
+          "definition": "http://hl7.org/fhir/uv/crmi/OperationDefinition/crmi-clone"
         }
       ]
     },
@@ -219,14 +239,14 @@
           "documentation": "Update allows authoring workflows to update existing measures in _draft_ (**revise**) status, add comments to existing measures (**review** and **approve**), and **release** or **retire** a measure."
         },
         {
-          "extension" : [
+          "extension": [
             {
-              "url" : "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-              "valueCode" : "SHALL"
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHALL"
             }
           ],
-          "code" : "delete",
-          "documentation" : "Delete allows authoring workflows to **withdraw** _draft_ measures or **archive** _retired_ measures."
+          "code": "delete",
+          "documentation": "Delete allows authoring workflows to **withdraw** _draft_ measures or **archive** _retired_ measures."
         }
       ],
       "searchParam": [
@@ -328,6 +348,26 @@
           ],
           "name": "data-requirements",
           "definition": "http://hl7.org/fhir/us/cqfmeasures/OperationDefinition/Measure-data-requirements"
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHALL"
+            }
+          ],
+          "name": "draft",
+          "definition": "http://hl7.org/fhir/uv/crmi/OperationDefinition/crmi-draft"
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHALL"
+            }
+          ],
+          "name": "clone",
+          "definition": "http://hl7.org/fhir/uv/crmi/OperationDefinition/crmi-clone"
         }
       ]
     }

--- a/service/src/config/serverConfig.ts
+++ b/service/src/config/serverConfig.ts
@@ -109,6 +109,30 @@ export const serverConfig: ServerConfig = {
           route: '/:id/$draft',
           method: 'POST',
           reference: 'https://hl7.org/fhir/uv/crmi/STU1/OperationDefinition-crmi-draft.html'
+        },
+        {
+          name: 'clone',
+          route: '/$clone',
+          method: 'GET',
+          reference: 'https://hl7.org/fhir/uv/crmi/STU1/OperationDefinition-crmi-clone.html'
+        },
+        {
+          name: 'clone',
+          route: '/$clone',
+          method: 'POST',
+          reference: 'https://hl7.org/fhir/uv/crmi/STU1/OperationDefinition-crmi-clone.html'
+        },
+        {
+          name: 'clone',
+          route: '/:id/$clone',
+          method: 'GET',
+          reference: 'https://hl7.org/fhir/uv/crmi/STU1/OperationDefinition-crmi-clone.html'
+        },
+        {
+          name: 'clone',
+          route: '/:id/$clone',
+          method: 'POST',
+          reference: 'https://hl7.org/fhir/uv/crmi/STU1/OperationDefinition-crmi-clone.html'
         }
       ]
     },
@@ -187,6 +211,30 @@ export const serverConfig: ServerConfig = {
           route: '/:id/$draft',
           method: 'POST',
           reference: 'https://hl7.org/fhir/uv/crmi/STU1/OperationDefinition-crmi-draft.html'
+        },
+        {
+          name: 'clone',
+          route: '/$clone',
+          method: 'GET',
+          reference: 'https://hl7.org/fhir/uv/crmi/STU1/OperationDefinition-crmi-clone.html'
+        },
+        {
+          name: 'clone',
+          route: '/$clone',
+          method: 'POST',
+          reference: 'https://hl7.org/fhir/uv/crmi/STU1/OperationDefinition-crmi-clone.html'
+        },
+        {
+          name: 'clone',
+          route: '/:id/$clone',
+          method: 'GET',
+          reference: 'https://hl7.org/fhir/uv/crmi/STU1/OperationDefinition-crmi-clone.html'
+        },
+        {
+          name: 'clone',
+          route: '/:id/$clone',
+          method: 'POST',
+          reference: 'https://hl7.org/fhir/uv/crmi/STU1/OperationDefinition-crmi-clone.html'
         }
       ]
     }

--- a/service/src/db/dbOperations.ts
+++ b/service/src/db/dbOperations.ts
@@ -127,52 +127,27 @@ export async function deleteResource(id: string, resourceType: string) {
 }
 
 /**
- * Drafts an active parent artifact and all of its children (if applicable) in a batch
+ * Inserts a parent artifact and all of its children (if applicable) in a batch
+ * Error message depends on whether draft or cloned artifacts are being inserted
  */
-export async function batchDraft(drafts: FhirArtifact[]) {
+export async function batchInsert(artifacts: FhirArtifact[], action: string) {
   let error = null;
   const results: FhirArtifact[] = [];
-  const draftSession = Connection.connection?.startSession();
+  const insertSession = Connection.connection?.startSession();
   try {
-    await draftSession?.withTransaction(async () => {
-      for (const draft of drafts) {
-        const collection = await Connection.db.collection(draft.resourceType);
-        await collection.insertOne(draft as any, { session: draftSession });
-        results.push(draft);
+    await insertSession?.withTransaction(async () => {
+      for (const artifact of artifacts) {
+        const collection = await Connection.db.collection(artifact.resourceType);
+        await collection.insertOne(artifact as any, { session: insertSession });
+        results.push(artifact);
       }
     });
-    console.log('Batch draft transaction committed.');
+    console.log(`Batch ${action} transaction committed.`);
   } catch (err) {
-    console.log('Batch draft transaction failed: ' + err);
+    console.log(`Batch ${action} transaction failed: ` + err);
     error = err;
   } finally {
-    await draftSession?.endSession();
-  }
-  if (error) throw error;
-  return results;
-}
-
-/**
- * Clones a parent artifact and all of its children (if applicable) in a batch
- */
-export async function batchClone(clones: FhirArtifact[]) {
-  let error = null;
-  const results: FhirArtifact[] = [];
-  const cloneSession = Connection.connection?.startSession();
-  try {
-    await cloneSession?.withTransaction(async () => {
-      for (const clone of clones) {
-        const collection = await Connection.db.collection(clone.resourceType);
-        await collection.insertOne(clone as any, { session: cloneSession });
-        results.push(clone);
-      }
-    });
-    console.log('Batch clone transaction committed.');
-  } catch (err) {
-    console.log('Batch clone transaction failed: ' + err);
-    error = err;
-  } finally {
-    await cloneSession?.endSession();
+    await insertSession?.endSession();
   }
   if (error) throw error;
   return results;

--- a/service/src/services/LibraryService.ts
+++ b/service/src/services/LibraryService.ts
@@ -1,7 +1,6 @@
 import { loggers, RequestArgs, RequestCtx } from '@projecttacoma/node-fhir-server-core';
 import {
-  batchClone,
-  batchDraft,
+  batchInsert,
   createResource,
   deleteResource,
   findDataRequirementsWithQuery,
@@ -204,7 +203,7 @@ export class LibraryService implements Service<fhir4.Library> {
     );
 
     // now we want to batch insert the parent Library artifact and any of its children
-    const newDrafts = await batchDraft(draftArtifacts);
+    const newDrafts = await batchInsert(draftArtifacts, 'draft');
 
     // we want to return a Bundle containing the created artifacts
     return createBatchResponseBundle(newDrafts);
@@ -256,7 +255,7 @@ export class LibraryService implements Service<fhir4.Library> {
     );
 
     // now we want to batch insert the cloned parent Library artifact and any of its children
-    const newClones = await batchClone(clonedArtifacts);
+    const newClones = await batchInsert(clonedArtifacts, 'clone');
 
     // we want to return a Bundle containing the created artifacts
     return createBatchResponseBundle(newClones);

--- a/service/src/services/LibraryService.ts
+++ b/service/src/services/LibraryService.ts
@@ -239,16 +239,19 @@ export class LibraryService implements Service<fhir4.Library> {
     if (!activeLibrary) {
       throw new ResourceNotFoundError(`No resource found in collection: Library, with id: ${args.id}`);
     }
+    activeLibrary.url = parsedParams.url;
     checkIsOwned(activeLibrary, 'Child artifacts cannot be directly cloned.');
 
     await checkExistingArtifact(parsedParams.url, parsedParams.version, 'Library');
 
     // recursively get any child artifacts from the artifact if they exist
     const children = activeLibrary.relatedArtifact ? await getChildren(activeLibrary.relatedArtifact) : [];
+    children.forEach(child => {
+      child.url = child.url + '-clone';
+    });
 
     const clonedArtifacts = await modifyResourcesForClone(
       [activeLibrary, ...(await Promise.all(children))],
-      params.url,
       params.version
     );
 

--- a/service/src/services/LibraryService.ts
+++ b/service/src/services/LibraryService.ts
@@ -36,7 +36,6 @@ import {
   checkFieldsForCreate,
   checkFieldsForUpdate,
   checkFieldsForDelete,
-  checkExistingArtifact,
   checkIsOwned,
   checkAuthoring
 } from '../util/inputUtils';
@@ -192,8 +191,6 @@ export class LibraryService implements Service<fhir4.Library> {
     }
     checkIsOwned(activeLibrary, 'Child artifacts cannot be directly drafted');
 
-    await checkExistingArtifact(activeLibrary.url, parsedParams.version, 'Library');
-
     // recursively get any child artifacts from the artifact if they exist
     const children = activeLibrary.relatedArtifact ? await getChildren(activeLibrary.relatedArtifact) : [];
 
@@ -240,8 +237,6 @@ export class LibraryService implements Service<fhir4.Library> {
     }
     activeLibrary.url = parsedParams.url;
     checkIsOwned(activeLibrary, 'Child artifacts cannot be directly cloned.');
-
-    await checkExistingArtifact(parsedParams.url, parsedParams.version, 'Library');
 
     // recursively get any child artifacts from the artifact if they exist
     const children = activeLibrary.relatedArtifact ? await getChildren(activeLibrary.relatedArtifact) : [];

--- a/service/src/services/MeasureService.ts
+++ b/service/src/services/MeasureService.ts
@@ -28,7 +28,6 @@ import {
   checkFieldsForCreate,
   checkFieldsForUpdate,
   checkFieldsForDelete,
-  checkExistingArtifact,
   checkIsOwned,
   checkAuthoring
 } from '../util/inputUtils';
@@ -194,8 +193,6 @@ export class MeasureService implements Service<fhir4.Measure> {
     }
     checkIsOwned(activeMeasure, 'Child artifacts cannot be directly drafted.');
 
-    await checkExistingArtifact(activeMeasure.url, parsedParams.version, 'Measure');
-
     // recursively get any child artifacts from the artifact if they exist
     const children = activeMeasure.relatedArtifact ? await getChildren(activeMeasure.relatedArtifact) : [];
 
@@ -242,8 +239,6 @@ export class MeasureService implements Service<fhir4.Measure> {
     }
     activeMeasure.url = parsedParams.url;
     checkIsOwned(activeMeasure, 'Child artifacts cannot be directly cloned.');
-
-    await checkExistingArtifact(parsedParams.url, parsedParams.version, 'Measure');
 
     // recursively get any child artifacts from the artifact if they exist
     const children = activeMeasure.relatedArtifact ? await getChildren(activeMeasure.relatedArtifact) : [];

--- a/service/src/services/MeasureService.ts
+++ b/service/src/services/MeasureService.ts
@@ -1,7 +1,6 @@
 import { loggers, RequestArgs, RequestCtx } from '@projecttacoma/node-fhir-server-core';
 import {
-  batchClone,
-  batchDraft,
+  batchInsert,
   createResource,
   deleteResource,
   findDataRequirementsWithQuery,
@@ -206,7 +205,7 @@ export class MeasureService implements Service<fhir4.Measure> {
     );
 
     // now we want to batch insert the parent Measure artifact and any of its children
-    const newDrafts = await batchDraft(draftArtifacts);
+    const newDrafts = await batchInsert(draftArtifacts, 'draft');
 
     // we want to return a Bundle containing the created artifacts
     return createBatchResponseBundle(newDrafts);
@@ -255,7 +254,7 @@ export class MeasureService implements Service<fhir4.Measure> {
     const clonedArtifacts = await modifyResourcesForClone([activeMeasure, ...children], parsedParams.version);
 
     // now we want to batch insert the cloned parent Measure artifact and any of its children
-    const newClones = await batchClone(clonedArtifacts);
+    const newClones = await batchInsert(clonedArtifacts, 'clone');
 
     // we want to return a Bundle containing the created artifacts
     return createBatchResponseBundle(newClones);

--- a/service/src/util/inputUtils.ts
+++ b/service/src/util/inputUtils.ts
@@ -104,7 +104,7 @@ export function checkIsOwned(resource: fhir4.Measure | fhir4.Library, message: s
   }
 }
 
-export function checkDraft() {
+export function checkAuthoring() {
   if (process.env.AUTHORING === 'false') {
     throw new BadRequestError('The Publishable repository service does not support the $draft operation.');
   }

--- a/service/src/util/inputUtils.ts
+++ b/service/src/util/inputUtils.ts
@@ -2,8 +2,6 @@ import { RequestArgs, RequestQuery, FhirResourceType } from '@projecttacoma/node
 import { Filter } from 'mongodb';
 import { BadRequestError } from './errorUtils';
 import _ from 'lodash';
-import { ArtifactResourceType } from '../types/service-types';
-import { findArtifactByUrlAndVersion } from '../db/dbOperations';
 
 /*
  * Gathers parameters from both the query and the FHIR parameter request body resource
@@ -107,15 +105,6 @@ export function checkIsOwned(resource: fhir4.Measure | fhir4.Library, message: s
 export function checkAuthoring() {
   if (process.env.AUTHORING === 'false') {
     throw new BadRequestError('The Publishable repository service does not support this operation.');
-  }
-}
-
-export async function checkExistingArtifact(url: string, version: string, resourceType: ArtifactResourceType) {
-  const existingArtifact = await findArtifactByUrlAndVersion(url, version, resourceType);
-  if (existingArtifact) {
-    throw new BadRequestError(
-      `A ${resourceType} artifact with url ${url} and version ${version} already exists in the database`
-    );
   }
 }
 

--- a/service/src/util/inputUtils.ts
+++ b/service/src/util/inputUtils.ts
@@ -106,7 +106,7 @@ export function checkIsOwned(resource: fhir4.Measure | fhir4.Library, message: s
 
 export function checkAuthoring() {
   if (process.env.AUTHORING === 'false') {
-    throw new BadRequestError('The Publishable repository service does not support the $draft operation.');
+    throw new BadRequestError('The Publishable repository service does not support this operation.');
   }
 }
 

--- a/service/src/util/serviceUtils.ts
+++ b/service/src/util/serviceUtils.ts
@@ -92,4 +92,33 @@ export async function modifyResourcesForDraft(artifacts: FhirArtifact[], version
  * Helper function that takes an active or draft artifact and returns it with a new id,
  * same status, url (from the $clone parameter), and version (from the $clone parameter).
  */
-export async function modifyResourcesForClone(artifacts: FhirArtifact[], url: string, version: string) {}
+export async function modifyResourcesForClone(artifacts: FhirArtifact[], url: string, version: string) {
+  for (const artifact of artifacts) {
+    artifact.id = uuidv4();
+    artifact.version = version;
+    artifact.url = url;
+    if (artifact.relatedArtifact) {
+      artifact.relatedArtifact.forEach(ra => {
+        if (
+          ra.type === 'composed-of' &&
+          ra.resource &&
+          ra.extension?.some(
+            e => e.url === 'http://hl7.org/fhir/StructureDefinition/artifact-isOwned' && e.valueBoolean === true
+          )
+        ) {
+          const oldUrl = ra.resource.split('|')[0];
+          ra.resource = oldUrl + '|' + version;
+        }
+      });
+    }
+
+    const checkExisting = await findArtifactByUrlAndVersion(artifact.url, version, artifact.resourceType);
+    if (checkExisting) {
+      throw new BadRequestError(
+        `A ${artifact.resourceType} with url ${artifact.url} and version ${artifact.version} already exists in the database.`
+      );
+    }
+  }
+
+  return artifacts;
+}

--- a/service/src/util/serviceUtils.ts
+++ b/service/src/util/serviceUtils.ts
@@ -92,11 +92,10 @@ export async function modifyResourcesForDraft(artifacts: FhirArtifact[], version
  * Helper function that takes an active or draft artifact and returns it with a new id,
  * same status, url (from the $clone parameter), and version (from the $clone parameter).
  */
-export async function modifyResourcesForClone(artifacts: FhirArtifact[], url: string, version: string) {
+export async function modifyResourcesForClone(artifacts: FhirArtifact[], version: string) {
   for (const artifact of artifacts) {
     artifact.id = uuidv4();
     artifact.version = version;
-    artifact.url = url;
     if (artifact.relatedArtifact) {
       artifact.relatedArtifact.forEach(ra => {
         if (
@@ -107,7 +106,7 @@ export async function modifyResourcesForClone(artifacts: FhirArtifact[], url: st
           )
         ) {
           const oldUrl = ra.resource.split('|')[0];
-          ra.resource = oldUrl + '|' + version;
+          ra.resource = oldUrl + '-clone|' + version;
         }
       });
     }

--- a/service/src/util/serviceUtils.ts
+++ b/service/src/util/serviceUtils.ts
@@ -87,3 +87,9 @@ export async function modifyResourcesForDraft(artifacts: FhirArtifact[], version
 
   return artifacts;
 }
+
+/**
+ * Helper function that takes an active or draft artifact and returns it with a new id,
+ * same status, url (from the $clone parameter), and version (from the $clone parameter).
+ */
+export async function modifyResourcesForClone(artifacts: FhirArtifact[], url: string, version: string) {}

--- a/service/src/util/serviceUtils.ts
+++ b/service/src/util/serviceUtils.ts
@@ -1,7 +1,6 @@
 import { findArtifactByUrlAndVersion } from '../db/dbOperations';
 import { ArtifactResourceType, FhirArtifact } from '../types/service-types';
 import { v4 as uuidv4 } from 'uuid';
-import { BadRequestError } from './errorUtils';
 
 export type ChildArtifactInfo = {
   resourceType: 'Measure' | 'Library';
@@ -76,13 +75,6 @@ export async function modifyResourcesForDraft(artifacts: FhirArtifact[], version
         }
       });
     }
-
-    const checkExisting = await findArtifactByUrlAndVersion(artifact.url, version, artifact.resourceType);
-    if (checkExisting) {
-      throw new BadRequestError(
-        `A ${artifact.resourceType} with url ${artifact.url} and version ${artifact.version} already exists in the database.`
-      );
-    }
   }
 
   return artifacts;
@@ -109,13 +101,6 @@ export async function modifyResourcesForClone(artifacts: FhirArtifact[], version
           ra.resource = oldUrl + '-clone|' + version;
         }
       });
-    }
-
-    const checkExisting = await findArtifactByUrlAndVersion(artifact.url, version, artifact.resourceType);
-    if (checkExisting) {
-      throw new BadRequestError(
-        `A ${artifact.resourceType} with url ${artifact.url} and version ${artifact.version} already exists in the database.`
-      );
     }
   }
 

--- a/service/test/services/LibraryService.test.ts
+++ b/service/test/services/LibraryService.test.ts
@@ -598,6 +598,53 @@ describe('LibraryService', () => {
     });
   });
 
+  describe('$clone', () => {
+    it('returns 200 status with a Bundle result containing the created parent Library artifact and any children it has for GET /Library/$clone', async () => {
+      await supertest(server.app)
+        .get('/4_0_1/Library/$clone')
+        .query({ id: 'parentLibrary', version: '1.0.0.5', url: 'http://clone-example.com' })
+        .set('Accept', 'application/json+fhir')
+        .expect(200);
+    });
+
+    it('returns 200 status with a Bundle result containing the created parent Library artifact and any children it has for GET /Library/:id/$draft', async () => {
+      await supertest(server.app)
+        .get('/4_0_1/Library/parentLibrary/$clone')
+        .query({ version: '1.0.0.6', url: 'http://clone-example.com' })
+        .set('Accept', 'application/json+fhir')
+        .expect(200);
+    });
+
+    it('returns 200 status with a Bundle result containing the created parent Library artifact and any children it has for POST/Library/$clone', async () => {
+      await supertest(server.app)
+        .post('/4_0_1/Library/$clone')
+        .send({
+          resourceType: 'Parameters',
+          parameter: [
+            { name: 'id', valueString: 'parentLibrary' },
+            { name: 'version', valueString: '1.0.0.7' },
+            { name: 'url', valueString: 'http://clone-example.com' }
+          ]
+        })
+        .set('content-type', 'application/fhir+json')
+        .expect(200);
+    });
+
+    it('returns 200 status with a Bundle result containing the created parent Library artifact and any children it has for POST /Library/:id/$clone', async () => {
+      await supertest(server.app)
+        .post('/4_0_1/Library/parentLibrary/$clone')
+        .send({
+          resourceType: 'Parameters',
+          parameter: [
+            { name: 'version', valueString: '1.0.0.8' },
+            { name: 'url', valueString: 'http://clone-example.com' }
+          ]
+        })
+        .set('content-type', 'application/fhir+json')
+        .expect(200);
+    });
+  });
+
   describe('$cqfm.package', () => {
     it('returns a Bundle including the Library when the Library has no dependencies and id passed through args', async () => {
       await supertest(server.app)

--- a/service/test/services/MeasureService.test.ts
+++ b/service/test/services/MeasureService.test.ts
@@ -569,6 +569,53 @@ describe('MeasureService', () => {
     });
   });
 
+  describe('$clone', () => {
+    it('returns 200 status with a Bundle result containing the created parent Measure artifact and any children it has for GET /Measure/$clone', async () => {
+      await supertest(server.app)
+        .get('/4_0_1/Measure/$clone')
+        .query({ id: 'parentMeasure', version: '1.0.0.5', url: 'http://clone-example.com' })
+        .set('Accept', 'application/json+fhir')
+        .expect(200);
+    });
+
+    it('returns 200 status with a Bundle result containing the created parent Measure artifact and any children it has for GET /Measure/:id/$draft', async () => {
+      await supertest(server.app)
+        .get('/4_0_1/Measure/parentMeasure/$clone')
+        .query({ version: '1.0.0.6', url: 'http://clone-example.com' })
+        .set('Accept', 'application/json+fhir')
+        .expect(200);
+    });
+
+    it('returns 200 status with a Bundle result containing the created parent Measure artifact and any children it has for POST/Measure/$clone', async () => {
+      await supertest(server.app)
+        .post('/4_0_1/Measure/$clone')
+        .send({
+          resourceType: 'Parameters',
+          parameter: [
+            { name: 'id', valueString: 'parentMeasure' },
+            { name: 'version', valueString: '1.0.0.7' },
+            { name: 'url', valueString: 'http://clone-example.com' }
+          ]
+        })
+        .set('content-type', 'application/fhir+json')
+        .expect(200);
+    });
+
+    it('returns 200 status with a Bundle result containing the created parent Measure artifact and any children it has for POST /Measure/:id/$clone', async () => {
+      await supertest(server.app)
+        .post('/4_0_1/Measure/parentMeasure/$clone')
+        .send({
+          resourceType: 'Parameters',
+          parameter: [
+            { name: 'version', valueString: '1.0.0.8' },
+            { name: 'url', valueString: 'http://clone-example.com' }
+          ]
+        })
+        .set('content-type', 'application/fhir+json')
+        .expect(200);
+    });
+  });
+
   describe('$cqfm.package', () => {
     it('returns a Bundle including the root lib and Measure when root lib has no dependencies and id passed through args', async () => {
       await supertest(server.app)


### PR DESCRIPTION
# Summary
This PR exposes the $clone operation as an endpoint on the server. This functionality is defined in the CRMI IG [here](https://build.fhir.org/ig/HL7/crmi-ig/OperationDefinition-crmi-clone.html).

## Note
The current OperationDefinition of the clone operation does not include `url` as an input parameter. This is an error and is being tracked in [this](https://jira.hl7.org/browse/FHIR-46385) Jira issue by Paul. Additionally, the spec needs to detail how child artifacts will be handled for clone. For now, I made the decision to simply add `-clone` to the end of the child artifact url when its parent is cloned. This approach made the most sense to me since there is no current guidance for it and the url cannot stay the same but I am open to suggestions!

## New behavior
The user can now clone a Measure or Library artifact and any resources it is composed of regardless of status by sending a GET or POST request to `Measure/$clone`, `Measure/:id/$clone`, `Library/$clone` and `Library/:id/$clone`. Since this is only an operation supported in an Authoring Artifact Repository, the `AUTHORING` environment variable must be set to true.

## Code changes
- `service/src/config/serverConfig.ts` - added `$clone` endpoints to server configuration
- `service/src/config/capabilityStatementResources.json` - adds draft and clone operations to capability statement
- `service/src/db/dbOperations.ts` - added `batchClone` for cloning artifacts in a batch transaction
- `service/src/requestSchemas.ts` - additional schemas for enforcing `$clone` parameters (must have `id`, 'version', and `url`)
- `service/src/services/LibraryService.ts` / `service/src/services/MeasureService.ts` - add `clone` endpoint
- `service/src/util/inputUtils.ts` - change name of function 
- `service/src/util/serviceUtils.ts` - adds helper function `modifyResourcesForClone`
- `LibraryService.test.ts` / `MeasureService.test.ts` - added unit tests

# Testing guidance
- `npm run check:all`
- `npm run build:all`
- `cd service`
- `npm run db:reset`
- `npm run db:loadBundle <your favorite bundle>` (I also recommend using the double nested child artifact bundle I "made" so that the recursion can be properly tested.
- `npm run start:all`
- The attached zip file contains Insomnia requests for testing! (assuming database is loaded with the nested child artifact bundle)

[Clone-Testing.json](https://github.com/user-attachments/files/16418565/Clone-Testing.json)
