### PR TITLE
Transition to use CRMI definitions for Measure and Library

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Measure Repository
 
-A prototype implementation of a [FHIR Measure Repository Service](http://hl7.org/fhir/us/cqfmeasures/measure-repository-service.html) and associated frontend application. This repository is a monorepo that consists of:
+A prototype implementation of a [FHIR Measure Repository Service](http://hl7.org/fhir/us/cqfmeasures/measure-repository-service.html) and associated frontend application. The Measure Repository Service is a specific case of the more general [Artifact Repository Service](https://hl7.org/fhir/uv/crmi/artifact-repository-service.html#artifact-repository-service) that supports measures and libraries that exist in the CRMI Artifact Lifecycle as [CRMIShareableMeasure](https://hl7.org/fhir/uv/crmi/StructureDefinition-crmi-shareablemeasure.html) and [CRMIShareableLibrary](https://hl7.org/fhir/uv/crmi/StructureDefinition-crmi-shareablelibrary.html) artifacts. This repository is a monorepo that consists of:
 
 - [Measure Repository Service](https://github.com/projecttacoma/measure-repository/blob/main/service/README.md)
   - Implements portions of the [FHIR Measure Repository Service](http://hl7.org/fhir/us/cqfmeasures/measure-repository-service.html) specification
@@ -43,12 +43,12 @@ cp app/.env.example app/.env.local
 cp service/.env.example service/.env
 ```
 
-Make any changes to point to the measure repository service, Mongo database, and optionally the VSAC API. `0.0.0.0` may be a more appropriate database address than `localhost` for certain environment setups. 
+Make any changes to point to the measure repository service, Mongo database, and optionally the VSAC API. `0.0.0.0` may be a more appropriate database address than `localhost` for certain environment setups.
 Additionally, some versions of tooling may have issues with running `next dev` within workspaces. Disabling telemetry can prevent the disallowed npm command from running under the hood.
+
 ```bash
 npx next telemetry disable
 ```
-
 
 ### Mongo Replica Set Setup
 

--- a/app/src/pages/[resourceType]/[id].tsx
+++ b/app/src/pages/[resourceType]/[id].tsx
@@ -17,7 +17,7 @@ import {
 import { notifications } from '@mantine/notifications';
 import React, { useEffect, useMemo, useState } from 'react';
 import { GetServerSideProps, InferGetServerSidePropsType } from 'next';
-import { FhirArtifact } from '@/util/types/fhir';
+import { CRMIShareableLibrary, FhirArtifact } from '@/util/types/fhir';
 import CQLRegex from '../../util/prismCQL';
 import { Prism as PrismRenderer } from 'prism-react-renderer';
 import parse from 'html-react-parser';
@@ -299,7 +299,7 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
  */
 function decode(link: string, jsonData: FhirArtifact) {
   if (jsonData.resourceType === 'Measure') return null;
-  const encodedLanguage = (jsonData as fhir4.Library).content?.find(e => e.contentType === link)?.data;
+  const encodedLanguage = (jsonData as CRMIShareableLibrary).content?.find(e => e.contentType === link)?.data;
   return encodedLanguage ? Buffer.from(encodedLanguage, 'base64').toString() : null;
 }
 

--- a/app/src/server/trpc/routers/service.ts
+++ b/app/src/server/trpc/routers/service.ts
@@ -1,7 +1,7 @@
 import { publicProcedure, router } from '../trpc';
 import { batchCreateDraft, getDraftById, getDraftByUrl } from '@/server/db/dbOperations';
 import { modifyResource } from '@/util/modifyResourceFields';
-import { FhirArtifact } from '@/util/types/fhir';
+import { CRMIShareableLibrary, FhirArtifact } from '@/util/types/fhir';
 import { z } from 'zod';
 import { TRPCError } from '@trpc/server';
 import { DateTime } from 'luxon';
@@ -61,7 +61,7 @@ export const serviceRouter = router({
           message: resource?.issue[0]?.details?.text
         });
       }
-      return resource as fhir4.Library;
+      return resource as CRMIShareableLibrary;
     }),
 
   getArtifactById: publicProcedure

--- a/app/src/util/authoringFixtures.ts
+++ b/app/src/util/authoringFixtures.ts
@@ -1,10 +1,17 @@
-export const MeasureSkeleton: fhir4.Measure = {
+import { CRMIShareableLibrary, CRMIShareableMeasure } from './types/fhir';
+
+export const MeasureSkeleton: CRMIShareableMeasure = {
+  id: 'tempMeasureId',
   resourceType: 'Measure',
   status: 'draft',
-  version: '0.0.1'
+  version: '0.0.1',
+  url: 'http://example.com',
+  title: 'Sample title',
+  description: 'Sample description'
 };
 
-export const LibrarySkeleton: fhir4.Library = {
+export const LibrarySkeleton: CRMIShareableLibrary = {
+  id: 'tempLibraryId',
   resourceType: 'Library',
   status: 'draft',
   version: '0.0.1',
@@ -14,5 +21,8 @@ export const LibrarySkeleton: fhir4.Library = {
         code: 'logic-library'
       }
     ]
-  }
+  },
+  url: 'http://example.com',
+  title: 'Sample title',
+  description: 'Sample description'
 };

--- a/app/src/util/types/fhir.ts
+++ b/app/src/util/types/fhir.ts
@@ -1,15 +1,15 @@
-export interface CQFMMeasure extends fhir4.Measure {
+export interface CRMIShareableMeasure extends fhir4.Measure {
   id: string;
   version: string;
 }
 
-export interface CQFMLibrary extends fhir4.Library {
+export interface CRMIShareableLibrary extends fhir4.Library {
   id: string;
   version: string;
 }
 
 // type representing the resource types that are relevant to the Measure Repository Service
-export type FhirArtifact = CQFMMeasure | CQFMLibrary;
+export type FhirArtifact = CRMIShareableMeasure | CRMIShareableLibrary;
 export type ArtifactResourceType = FhirArtifact['resourceType'];
 
 /**

--- a/app/src/util/types/fhir.ts
+++ b/app/src/util/types/fhir.ts
@@ -1,11 +1,17 @@
 export interface CRMIShareableMeasure extends fhir4.Measure {
   id: string;
+  url: string;
   version: string;
+  title: string;
+  description: string;
 }
 
 export interface CRMIShareableLibrary extends fhir4.Library {
   id: string;
+  url: string;
   version: string;
+  title: string;
+  description: string;
 }
 
 // type representing the resource types that are relevant to the Measure Repository Service

--- a/service/scripts/dbSetup.ts
+++ b/service/scripts/dbSetup.ts
@@ -5,11 +5,11 @@ import { MongoError } from 'mongodb';
 import { v4 as uuidv4 } from 'uuid';
 import path from 'path';
 import { addIsOwnedExtension, addLibraryIsOwned } from '../src/util/baseUtils';
-import { FhirArtifact } from '../src/types/service-types';
+import { CRMIShareableLibrary, FhirArtifact } from '../src/types/service-types';
 dotenv.config();
 
 const DB_URL = process.env.DATABASE_URL || 'mongodb://localhost:27017/measure-repository';
-const COLLECTION_NAMES = ['Measure', 'Library', 'MeasureReport'];
+const COLLECTION_NAMES = ['Measure', 'Library'];
 
 async function createCollections() {
   await Connection.connect(DB_URL);
@@ -148,9 +148,9 @@ async function uploadBundleResources(filePath: string) {
         if (entry.resource?.resourceType === 'Library' || entry.resource?.resourceType === 'Measure') {
           // Only upload Library or Measure resources
           try {
-            const collection = Connection.db.collection<fhir4.FhirResource>(entry.resource.resourceType);
+            const collection = Connection.db.collection<FhirArtifact>(entry.resource.resourceType);
             console.log(`Inserting ${entry.resource.resourceType}/${entry.resource.id} into database`);
-            await collection.insertOne(entry.resource);
+            await collection.insertOne(entry.resource as FhirArtifact);
             resourcesUploaded += 1;
           } catch (e) {
             // ignore duplicate key errors for Libraries, Note: if ValueSets added, also ignore for those
@@ -234,9 +234,9 @@ function modifyEntriesForUpload(entries: fhir4.BundleEntry<fhir4.FhirResource>[]
  */
 async function insertFHIRModelInfoLibrary() {
   const fhirModelInfo = fs.readFileSync('scripts/fixtures/Library-FHIR-ModelInfo.json', 'utf8');
-  const fhirModelInfoLibrary: fhir4.Library = JSON.parse(fhirModelInfo);
+  const fhirModelInfoLibrary: CRMIShareableLibrary = JSON.parse(fhirModelInfo);
 
-  const collection = Connection.db.collection<fhir4.FhirResource>('Library');
+  const collection = Connection.db.collection<FhirArtifact>('Library');
   console.log(`Inserting Library/${fhirModelInfoLibrary.id} into database`);
   await collection.insertOne(fhirModelInfoLibrary);
 }

--- a/service/scripts/dbSetup.ts
+++ b/service/scripts/dbSetup.ts
@@ -5,6 +5,7 @@ import { MongoError } from 'mongodb';
 import { v4 as uuidv4 } from 'uuid';
 import path from 'path';
 import { addIsOwnedExtension, addLibraryIsOwned } from '../src/util/baseUtils';
+import { FhirArtifact } from '../src/types/service-types';
 dotenv.config();
 
 const DB_URL = process.env.DATABASE_URL || 'mongodb://localhost:27017/measure-repository';
@@ -39,7 +40,7 @@ async function deleteCollections() {
 /*
  * Gathers necessary file path(s) for bundle(s) to upload, then uploads all measure and
  * library resources found in the bundle(s).
- * If a connectionURL is provided, then posts the resources to the server at the 
+ * If a connectionURL is provided, then posts the resources to the server at the
  * connectionURL (as a transaction bundle), otherwise, loads the resources directly to the database
  */
 async function loadBundle(fileOrDirectoryPath: string, connectionURL?: string) {
@@ -114,7 +115,7 @@ async function postBundleResources(filePath: string, url: string) {
   if (data) {
     console.log(`POSTing ${filePath.split('/').slice(-1)}...`);
     const bundle: fhir4.Bundle = JSON.parse(data);
-    const entries = bundle.entry as fhir4.BundleEntry<fhir4.FhirResource>[];
+    const entries = bundle.entry as fhir4.BundleEntry<FhirArtifact>[];
     // modify bundles before posting
     if (entries) {
       const modifiedEntries = modifyEntriesForUpload(entries);

--- a/service/src/config/capabilityStatementResources.json
+++ b/service/src/config/capabilityStatementResources.json
@@ -3,13 +3,13 @@
   "resource": [
     {
       "type": "Library",
-      "profile": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/library-cqfm",
+      "profile": "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-shareablelibrary",
       "supportedProfile": [
-        "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/computable-library-cqfm",
-        "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/publishable-library-cqfm",
-        "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/executable-library-cqfm",
-        "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/modelinfo-library-cqfm",
-        "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/quality-program-cqfm"
+        "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablelibrary",
+        "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-publishablelibrary",
+        "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-executablelibrary",
+        "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-moduledefinitionlibrary",
+        "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-manifestlibrary"
       ],
       "interaction": [
         {
@@ -187,16 +187,8 @@
     },
     {
       "type": "Measure",
-      "profile": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/measure-cqfm",
-      "supportedProfile": [
-        "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/computable-measure-cqfm",
-        "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/publishable-measure-cqfm",
-        "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cohort-measure-cqfm",
-        "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/proportion-measure-cqfm",
-        "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/ratio-measure-cqfm",
-        "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cv-measure-cqfm",
-        "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/composite-measure-cqfm"
-      ],
+      "profile": "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-shareablemeasure",
+      "supportedProfile": ["http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-publishablemeasure"],
       "interaction": [
         {
           "extension": [

--- a/service/src/db/dbOperations.ts
+++ b/service/src/db/dbOperations.ts
@@ -1,14 +1,14 @@
 import { FhirResourceType, loggers } from '@projecttacoma/node-fhir-server-core';
 import { Filter } from 'mongodb';
 import { Connection } from './Connection';
-import { ArtifactResourceType, FhirArtifact } from '../types/service-types';
+import { ArtifactResourceType, CRMIShareableLibrary, FhirArtifact } from '../types/service-types';
 
 const logger = loggers.get('default');
 
 /**
  * searches the database for the desired resource and returns the data
  */
-export async function findResourceById<T extends fhir4.FhirResource>(id: string, resourceType: FhirResourceType) {
+export async function findResourceById<T extends FhirArtifact>(id: string, resourceType: FhirResourceType) {
   const collection = Connection.db.collection(resourceType);
   return collection.findOne<T>({ id: id }, { projection: { _id: 0, _dataRequirements: 0 } });
 }
@@ -28,7 +28,7 @@ export async function findArtifactByUrlAndVersion<T extends FhirArtifact>(
 /**
  * searches the database and returns an array of all resources of the given type that match the given query
  */
-export async function findResourcesWithQuery<T extends fhir4.FhirResource>(
+export async function findResourcesWithQuery<T extends FhirArtifact>(
   query: Filter<any>,
   resourceType: FhirResourceType
 ) {
@@ -43,7 +43,7 @@ export async function findResourcesWithQuery<T extends fhir4.FhirResource>(
  * searches the database and returns an array of all resources of the given type that match the given query
  * but the resources only include the elements specified by the _elements parameter
  */
-export async function findResourceElementsWithQuery<T extends fhir4.FhirResource>(
+export async function findResourceElementsWithQuery<T extends FhirArtifact>(
   query: Filter<any>,
   resourceType: FhirResourceType
 ) {
@@ -51,7 +51,9 @@ export async function findResourceElementsWithQuery<T extends fhir4.FhirResource
 
   // if the resourceType is Library, then we want to include type in the projection
   const projection: any =
-    resourceType === 'Library' ? { status: 1, resourceType: 1, type: 1 } : { status: 1, resourceType: 1 };
+    resourceType === 'Library'
+      ? { id: 1, status: 1, resourceType: 1, type: 1, url: 1, title: 1, description: 1, version: 1 }
+      : { id: 1, status: 1, resourceType: 1, url: 1, title: 1, description: 1, version: 1 };
 
   (query._elements as string[]).forEach(elem => {
     projection[elem] = 1;
@@ -79,7 +81,7 @@ export async function findResourceCountWithQuery(query: Filter<any>, resourceTyp
 /**
  * searches the database for the data requirements Library resource of the desired artifact and parameters
  */
-export async function findDataRequirementsWithQuery<T extends fhir4.Library>(query: Filter<any>) {
+export async function findDataRequirementsWithQuery<T extends CRMIShareableLibrary>(query: Filter<any>) {
   const collection = Connection.db.collection('Library');
   return collection.findOne<T>({ _dataRequirements: query }, { projection: { _id: 0, _dataRequirements: 0, url: 0 } });
 }
@@ -87,8 +89,8 @@ export async function findDataRequirementsWithQuery<T extends fhir4.Library>(que
 /**
  * Inserts one data object into database with specified FHIR resource type
  */
-export async function createResource(data: fhir4.FhirResource, resourceType: string) {
-  const collection = Connection.db.collection<fhir4.FhirResource>(resourceType);
+export async function createResource(data: FhirArtifact, resourceType: string) {
+  const collection = Connection.db.collection<FhirArtifact>(resourceType);
   logger.info(`Inserting ${resourceType}/${data.id} into database`);
   await collection.insertOne(data);
   return { id: data.id as string };
@@ -97,7 +99,7 @@ export async function createResource(data: fhir4.FhirResource, resourceType: str
 /**
  * Searches for a document for a resource and updates it if found, creates it if not
  */
-export async function updateResource(id: string, data: fhir4.FhirResource, resourceType: string) {
+export async function updateResource(id: string, data: FhirArtifact, resourceType: string) {
   const collection = Connection.db.collection(resourceType);
   logger.debug(`Finding and updating ${resourceType}/${data.id} in database`);
 

--- a/service/src/db/dbOperations.ts
+++ b/service/src/db/dbOperations.ts
@@ -1,4 +1,4 @@
-import { FhirResourceType, loggers } from '@projecttacoma/node-fhir-server-core';
+import { loggers } from '@projecttacoma/node-fhir-server-core';
 import { Filter } from 'mongodb';
 import { Connection } from './Connection';
 import { ArtifactResourceType, CRMIShareableLibrary, FhirArtifact } from '../types/service-types';
@@ -8,7 +8,7 @@ const logger = loggers.get('default');
 /**
  * searches the database for the desired resource and returns the data
  */
-export async function findResourceById<T extends FhirArtifact>(id: string, resourceType: FhirResourceType) {
+export async function findResourceById<T extends FhirArtifact>(id: string, resourceType: ArtifactResourceType) {
   const collection = Connection.db.collection(resourceType);
   return collection.findOne<T>({ id: id }, { projection: { _id: 0, _dataRequirements: 0 } });
 }
@@ -30,7 +30,7 @@ export async function findArtifactByUrlAndVersion<T extends FhirArtifact>(
  */
 export async function findResourcesWithQuery<T extends FhirArtifact>(
   query: Filter<any>,
-  resourceType: FhirResourceType
+  resourceType: ArtifactResourceType
 ) {
   const collection = Connection.db.collection(resourceType);
   query._dataRequirements = { $exists: false };
@@ -45,7 +45,7 @@ export async function findResourcesWithQuery<T extends FhirArtifact>(
  */
 export async function findResourceElementsWithQuery<T extends FhirArtifact>(
   query: Filter<any>,
-  resourceType: FhirResourceType
+  resourceType: ArtifactResourceType
 ) {
   const collection = Connection.db.collection(resourceType);
 
@@ -70,7 +70,7 @@ export async function findResourceElementsWithQuery<T extends FhirArtifact>(
  * searches the database for all resources of the given type that match the given query
  * but only returns the number of matches
  */
-export async function findResourceCountWithQuery(query: Filter<any>, resourceType: FhirResourceType) {
+export async function findResourceCountWithQuery(query: Filter<any>, resourceType: ArtifactResourceType) {
   const collection = Connection.db.collection(resourceType);
   query._dataRequirements = { $exists: false };
   query._summary = { $exists: false };

--- a/service/src/services/BaseService.ts
+++ b/service/src/services/BaseService.ts
@@ -91,7 +91,7 @@ async function insertBundleResources(entry: DetailedEntry) {
           entry.resource.resourceType
         )) as FhirArtifact | null;
         if (oldResource) {
-          checkFieldsForUpdate(entry.resource as FhirArtifact, oldResource);
+          checkFieldsForUpdate(entry.resource, oldResource);
         } else {
           checkFieldsForCreate(entry.resource);
         }

--- a/service/src/services/LibraryService.ts
+++ b/service/src/services/LibraryService.ts
@@ -43,14 +43,14 @@ import { v4 as uuidv4 } from 'uuid';
 import { Calculator } from 'fqm-execution';
 const logger = loggers.get('default');
 import { Filter } from 'mongodb';
-import { CRMILibrary, FhirLibraryWithDR } from '../types/service-types';
+import { CRMIShareableLibrary, FhirLibraryWithDR } from '../types/service-types';
 import { getChildren, modifyResourcesForClone, modifyResourcesForDraft } from '../util/serviceUtils';
 
 /*
  * Implementation of a service for the `Library` resource
  * The Service interface contains all possible functions
  */
-export class LibraryService implements Service<fhir4.Library> {
+export class LibraryService implements Service<CRMIShareableLibrary> {
   /**
    * result of sending a GET request to {BASE_URL}/4_0_1/Library?{QUERY}
    * searches for all libraries that match the included query and returns a FHIR searchset Bundle
@@ -66,13 +66,13 @@ export class LibraryService implements Service<fhir4.Library> {
     // return a searchset bundle that excludes the entries
     if (parsedQuery._summary && parsedQuery._summary === 'count') {
       const count = await findResourceCountWithQuery(mongoQuery, 'Library');
-      return createSummarySearchsetBundle<fhir4.Library>(count);
+      return createSummarySearchsetBundle<CRMIShareableLibrary>(count);
     }
     // if the _elements parameter with a comma-separated string is included
     // then return a searchset bundle that includes only those elements
     // on those resource entries
     else if (parsedQuery._elements) {
-      const entries = await findResourceElementsWithQuery<fhir4.Library>(mongoQuery, 'Library');
+      const entries = await findResourceElementsWithQuery<CRMIShareableLibrary>(mongoQuery, 'Library');
       // add the SUBSETTED tag to the resources returned by the _elements parameter
       entries.map(e => {
         if (e.meta) {
@@ -89,7 +89,7 @@ export class LibraryService implements Service<fhir4.Library> {
       });
       return createSearchsetBundle(entries);
     } else {
-      const entries = await findResourcesWithQuery<fhir4.Library>(mongoQuery, 'Library');
+      const entries = await findResourcesWithQuery<CRMIShareableLibrary>(mongoQuery, 'Library');
       return createSearchsetBundle(entries);
     }
   }
@@ -100,7 +100,7 @@ export class LibraryService implements Service<fhir4.Library> {
    */
   async searchById(args: RequestArgs) {
     logger.info(`GET /Library/${args.id}`);
-    const result = await findResourceById<fhir4.Library>(args.id, 'Library');
+    const result = await findResourceById<CRMIShareableLibrary>(args.id, 'Library');
     if (!result) {
       throw new ResourceNotFoundError(`No resource found in collection: Library, with id: ${args.id}`);
     }
@@ -138,7 +138,7 @@ export class LibraryService implements Service<fhir4.Library> {
       throw new BadRequestError('Argument id must match request body id for PUT request');
     }
     // note: the distance between this database call and the update resource call, could cause a race condition
-    const oldResource = (await findResourceById(resource.id, resource.resourceType)) as fhir4.Library | null;
+    const oldResource = (await findResourceById(resource.id, resource.resourceType)) as CRMIShareableLibrary | null;
     if (oldResource) {
       checkFieldsForUpdate(resource, oldResource);
     } else {
@@ -152,7 +152,7 @@ export class LibraryService implements Service<fhir4.Library> {
    * deletes the library with the passed in id if it exists in the database
    */
   async remove(args: RequestArgs) {
-    const resource = (await findResourceById(args.id, 'Library')) as fhir4.Library | null;
+    const resource = (await findResourceById(args.id, 'Library')) as CRMIShareableLibrary | null;
     if (!resource) {
       throw new ResourceNotFoundError(`Existing resource not found with id ${args.id}`);
     }
@@ -185,7 +185,7 @@ export class LibraryService implements Service<fhir4.Library> {
 
     const parsedParams = parseRequestSchema({ ...params, ...query }, DraftArgs);
 
-    const activeLibrary = await findResourceById<CRMILibrary>(parsedParams.id, 'Library');
+    const activeLibrary = await findResourceById<CRMIShareableLibrary>(parsedParams.id, 'Library');
     if (!activeLibrary) {
       throw new ResourceNotFoundError(`No resource found in collection: Library, with id: ${args.id}`);
     }
@@ -231,7 +231,7 @@ export class LibraryService implements Service<fhir4.Library> {
 
     const parsedParams = parseRequestSchema({ ...params, ...query }, CloneArgs);
 
-    const activeLibrary = await findResourceById<CRMILibrary>(parsedParams.id, 'Library');
+    const activeLibrary = await findResourceById<CRMIShareableLibrary>(parsedParams.id, 'Library');
     if (!activeLibrary) {
       throw new ResourceNotFoundError(`No resource found in collection: Library, with id: ${args.id}`);
     }

--- a/service/src/services/MeasureService.ts
+++ b/service/src/services/MeasureService.ts
@@ -42,7 +42,7 @@ import {
 } from '../requestSchemas';
 import { v4 as uuidv4 } from 'uuid';
 import { Filter } from 'mongodb';
-import { CRMIMeasure, FhirLibraryWithDR } from '../types/service-types';
+import { CRMIShareableMeasure, FhirLibraryWithDR } from '../types/service-types';
 import { getChildren, modifyResourcesForClone, modifyResourcesForDraft } from '../util/serviceUtils';
 
 const logger = loggers.get('default');
@@ -51,7 +51,7 @@ const logger = loggers.get('default');
  * Implementation of a service for the `Measure` resource
  * The Service interface contains all possible functions
  */
-export class MeasureService implements Service<fhir4.Measure> {
+export class MeasureService implements Service<CRMIShareableMeasure> {
   /**
    * result of sending a GET request to {BASE_URL}/4_0_1/Measure?{QUERY}
    * searches for all measures that match the included query and returns a FHIR searchset Bundle
@@ -67,13 +67,13 @@ export class MeasureService implements Service<fhir4.Measure> {
     // return a searchset bundle that excludes the entries
     if (parsedQuery._summary && parsedQuery._summary === 'count') {
       const count = await findResourceCountWithQuery(mongoQuery, 'Measure');
-      return createSummarySearchsetBundle<fhir4.Measure>(count);
+      return createSummarySearchsetBundle<CRMIShareableMeasure>(count);
     }
     // if the _elements parameter with a comma-separated string is included
     // then return a searchset bundle that includes only those elements
     // on those resource entries
     else if (parsedQuery._elements) {
-      const entries = await findResourceElementsWithQuery<fhir4.Measure>(mongoQuery, 'Measure');
+      const entries = await findResourceElementsWithQuery<CRMIShareableMeasure>(mongoQuery, 'Measure');
       // add the SUBSETTED tag to the resources returned by the _elements parameter
       entries.map(e => {
         if (e.meta) {
@@ -90,7 +90,7 @@ export class MeasureService implements Service<fhir4.Measure> {
       });
       return createSearchsetBundle(entries);
     } else {
-      const entries = await findResourcesWithQuery<fhir4.Measure>(mongoQuery, 'Measure');
+      const entries = await findResourcesWithQuery<CRMIShareableMeasure>(mongoQuery, 'Measure');
       return createSearchsetBundle(entries);
     }
   }
@@ -101,7 +101,7 @@ export class MeasureService implements Service<fhir4.Measure> {
    */
   async searchById(args: RequestArgs) {
     logger.info(`GET /Measure/${args.id}`);
-    const result = await findResourceById<fhir4.Measure>(args.id, 'Measure');
+    const result = await findResourceById<CRMIShareableMeasure>(args.id, 'Measure');
     if (!result) {
       throw new ResourceNotFoundError(`No resource found in collection: Measure, with id: ${args.id}`);
     }
@@ -138,7 +138,7 @@ export class MeasureService implements Service<fhir4.Measure> {
     if (resource.id !== args.id) {
       throw new BadRequestError('Argument id must match request body id for PUT request');
     }
-    const oldResource = (await findResourceById(resource.id, resource.resourceType)) as fhir4.Measure | null;
+    const oldResource = (await findResourceById(resource.id, resource.resourceType)) as CRMIShareableMeasure | null;
     // note: the distance between this database call and the update resource call, could cause a race condition
     if (oldResource) {
       checkFieldsForUpdate(resource, oldResource);
@@ -154,7 +154,7 @@ export class MeasureService implements Service<fhir4.Measure> {
    * deletes the measure with the passed in id if it exists in the database
    */
   async remove(args: RequestArgs) {
-    const resource = (await findResourceById(args.id, 'Measure')) as fhir4.Measure | null;
+    const resource = (await findResourceById(args.id, 'Measure')) as CRMIShareableMeasure | null;
     if (!resource) {
       throw new ResourceNotFoundError(`Existing resource not found with id ${args.id}`);
     }
@@ -187,7 +187,7 @@ export class MeasureService implements Service<fhir4.Measure> {
 
     const parsedParams = parseRequestSchema({ ...params, ...query }, DraftArgs);
 
-    const activeMeasure = await findResourceById<CRMIMeasure>(parsedParams.id, 'Measure');
+    const activeMeasure = await findResourceById<CRMIShareableMeasure>(parsedParams.id, 'Measure');
     if (!activeMeasure) {
       throw new ResourceNotFoundError(`No resource found in collection: Measure, with id: ${args.id}`);
     }
@@ -233,7 +233,7 @@ export class MeasureService implements Service<fhir4.Measure> {
 
     const parsedParams = parseRequestSchema({ ...params, ...query }, CloneArgs);
 
-    const activeMeasure = await findResourceById<CRMIMeasure>(parsedParams.id, 'Measure');
+    const activeMeasure = await findResourceById<CRMIShareableMeasure>(parsedParams.id, 'Measure');
     if (!activeMeasure) {
       throw new ResourceNotFoundError(`No resource found in collection: Measure, with id: ${args.id}`);
     }

--- a/service/src/types/service-types.ts
+++ b/service/src/types/service-types.ts
@@ -1,10 +1,10 @@
 import { Filter } from 'mongodb';
 
-export type FhirLibraryWithDR = fhir4.Library & {
+export type FhirLibraryWithDR = CRMIShareableLibrary & {
   _dataRequirements?: Filter<any>;
 };
 
-export interface CRMIMeasure extends fhir4.Measure {
+export interface CRMIShareableMeasure extends fhir4.Measure {
   id: string;
   url: string;
   version: string;
@@ -12,7 +12,7 @@ export interface CRMIMeasure extends fhir4.Measure {
   description: string;
 }
 
-export interface CRMILibrary extends fhir4.Library {
+export interface CRMIShareableLibrary extends fhir4.Library {
   id: string;
   url: string;
   version: string;
@@ -21,5 +21,5 @@ export interface CRMILibrary extends fhir4.Library {
 }
 
 // type representing the resource types that are relevant to the Measure Repository Service
-export type FhirArtifact = CRMIMeasure | CRMILibrary;
+export type FhirArtifact = CRMIShareableMeasure | CRMIShareableLibrary;
 export type ArtifactResourceType = FhirArtifact['resourceType'];

--- a/service/src/types/service.ts
+++ b/service/src/types/service.ts
@@ -1,7 +1,8 @@
 import { RequestArgs, RequestCtx } from '@projecttacoma/node-fhir-server-core';
+import { FhirArtifact } from './service-types';
 
 // See https://github.com/projecttacoma/node-fhir-server-core/blob/master/docs/ConfiguringProfiles.md
-export interface Service<T extends fhir4.FhirResource> {
+export interface Service<T extends FhirArtifact> {
   /*
    * GET /:base_version/[profile_name]
    * POST /:base_version/[profile_name]/_search

--- a/service/src/util/baseUtils.ts
+++ b/service/src/util/baseUtils.ts
@@ -1,17 +1,17 @@
 import { v4 as uuidv4 } from 'uuid';
 import { loggers } from '@projecttacoma/node-fhir-server-core';
-import { FhirResource, OperationOutcome } from 'fhir/r4';
+import { FhirArtifact } from '../types/service-types';
 
 const logger = loggers.get('default');
 
-export type DetailedEntry = fhir4.BundleEntry<FhirResource> & {
+export type DetailedEntry = fhir4.BundleEntry<FhirArtifact> & {
   isPost: boolean;
   oldId?: string;
   newId: string;
   status?: number;
   statusText?: string;
   data?: string;
-  outcome?: OperationOutcome;
+  outcome?: fhir4.OperationOutcome;
 };
 
 /**

--- a/service/src/util/baseUtils.ts
+++ b/service/src/util/baseUtils.ts
@@ -1,10 +1,9 @@
 import { v4 as uuidv4 } from 'uuid';
 import { loggers } from '@projecttacoma/node-fhir-server-core';
-import { FhirArtifact } from '../types/service-types';
 
 const logger = loggers.get('default');
 
-export type DetailedEntry = fhir4.BundleEntry<FhirArtifact> & {
+export type DetailedEntry = fhir4.BundleEntry<fhir4.FhirResource> & {
   isPost: boolean;
   oldId?: string;
   newId: string;

--- a/service/src/util/inputUtils.ts
+++ b/service/src/util/inputUtils.ts
@@ -109,7 +109,7 @@ export function checkAuthoring() {
   }
 }
 
-export function checkFieldsForUpdate(resource: FhirArtifact, oldResource: FhirArtifact) {
+export function checkFieldsForUpdate(resource: fhir4.Measure | fhir4.Library, oldResource: FhirArtifact) {
   if (process.env.AUTHORING !== 'true' || oldResource.status === 'active') {
     // publishable or active status requires retire functionality
     if (process.env.AUTHORING !== 'true' && oldResource.status !== 'active') {

--- a/service/src/util/inputUtils.ts
+++ b/service/src/util/inputUtils.ts
@@ -1,7 +1,8 @@
-import { RequestArgs, RequestQuery, FhirResourceType } from '@projecttacoma/node-fhir-server-core';
+import { RequestArgs, RequestQuery } from '@projecttacoma/node-fhir-server-core';
 import { Filter } from 'mongodb';
 import { BadRequestError } from './errorUtils';
 import _ from 'lodash';
+import { ArtifactResourceType, FhirArtifact } from '../types/service-types';
 
 /*
  * Gathers parameters from both the query and the FHIR parameter request body resource
@@ -63,7 +64,7 @@ export function checkContentTypeHeader(contentType?: string) {
 /**
  * Checks that the type of the resource in the body matches the resource type we expect.
  */
-export function checkExpectedResourceType(resourceType: string, expectedResourceType: FhirResourceType) {
+export function checkExpectedResourceType(resourceType: string, expectedResourceType: ArtifactResourceType) {
   if (resourceType !== expectedResourceType) {
     throw new BadRequestError(`Expected resourceType '${expectedResourceType}' in body. Received '${resourceType}'.`);
   }
@@ -92,7 +93,7 @@ export function checkFieldsForCreate(resource: fhir4.Measure | fhir4.Library) {
   }
 }
 
-export function checkIsOwned(resource: fhir4.Measure | fhir4.Library, message: string) {
+export function checkIsOwned(resource: FhirArtifact, message: string) {
   if (
     resource.extension?.some(
       e => e.url === 'http://hl7.org/fhir/StructureDefinition/artifact-isOwned' && e.valueBoolean === true
@@ -108,10 +109,7 @@ export function checkAuthoring() {
   }
 }
 
-export function checkFieldsForUpdate(
-  resource: fhir4.Measure | fhir4.Library,
-  oldResource: fhir4.Measure | fhir4.Library
-) {
+export function checkFieldsForUpdate(resource: FhirArtifact, oldResource: FhirArtifact) {
   if (process.env.AUTHORING !== 'true' || oldResource.status === 'active') {
     // publishable or active status requires retire functionality
     if (process.env.AUTHORING !== 'true' && oldResource.status !== 'active') {
@@ -143,7 +141,7 @@ export function checkFieldsForUpdate(
   }
 }
 
-export function checkFieldsForDelete(resource: fhir4.Measure | fhir4.Library) {
+export function checkFieldsForDelete(resource: FhirArtifact) {
   if (process.env.AUTHORING === 'true') {
     // authoring requires draft or retired status
     if (resource.status !== 'draft' && resource.status !== 'retired') {

--- a/service/test/services/LibraryService.test.ts
+++ b/service/test/services/LibraryService.test.ts
@@ -141,7 +141,7 @@ const LIBRARY_WITH_SAME_SYSTEM: CRMIShareableLibrary = {
   ...LIBRARY_BASE
 };
 
-const LIBRARY_WITH_SAME_SYSTEM2: fhir4.Library = {
+const LIBRARY_WITH_SAME_SYSTEM2: CRMIShareableLibrary = {
   resourceType: 'Library',
   id: 'libraryWithSameSystem2',
   url: 'http://example.com/libraryWithSameSystem2',

--- a/service/test/services/LibraryService.test.ts
+++ b/service/test/services/LibraryService.test.ts
@@ -3,44 +3,39 @@ import { serverConfig } from '../../src/config/serverConfig';
 import { cleanUpTestDatabase, setupTestDatabase, createTestResource } from '../utils';
 import supertest from 'supertest';
 import { Calculator } from 'fqm-execution';
-import { CRMILibrary } from '../../src/types/service-types';
+import { CRMIShareableLibrary } from '../../src/types/service-types';
 
 let server: Server;
 
-// boiler plate required fields
 const LIBRARY_BASE = {
   type: { coding: [{ code: 'logic-library' }] },
-  url: 'http://example.com',
   version: '1',
   title: 'Sample title',
   description: 'Sample description'
 };
 
-const LIBRARY_WITH_URL: fhir4.Library = {
+const ACTIVE_LIBRARY: CRMIShareableLibrary = {
   resourceType: 'Library',
-  id: 'testWithUrl',
+  id: 'testActiveLibrary',
+  url: 'http://example.com/testActiveLibrary',
   status: 'active',
+  name: 'sampleName',
   ...LIBRARY_BASE
 };
 
-const LIBRARY_WITH_URL_2: fhir4.Library = {
+const ACTIVE_LIBRARY_2: CRMIShareableLibrary = {
   resourceType: 'Library',
-  id: 'testWithUrl2',
-  status: 'draft',
+  id: 'testActiveLibrary2',
+  url: 'http://example.com/testActiveLibrary2',
+  status: 'active',
+  name: 'sampleName',
   ...LIBRARY_BASE
 };
 
-const DRAFT_LIBRARY_WITH_URL: fhir4.Library = {
+const ACTIVE_LIBRARY_NO_NAME: CRMIShareableLibrary = {
   resourceType: 'Library',
-  id: 'testWithUrl',
-  status: 'draft',
-  ...LIBRARY_BASE
-};
-
-const LIBRARY_WITH_URL_ONLY_ID: fhir4.Library = {
-  resourceType: 'Library',
-  type: { coding: [{ code: 'logic-library' }] },
-  id: 'testWithUrl',
+  id: 'testActiveLibrary',
+  url: 'http://example.com/testActiveLibrary',
   status: 'active',
   meta: {
     tag: [
@@ -49,88 +44,117 @@ const LIBRARY_WITH_URL_ONLY_ID: fhir4.Library = {
         system: 'http://terminology.hl7.org/CodeSystem/v3-ObservationValue'
       }
     ]
-  }
+  },
+  ...LIBRARY_BASE
 };
 
-const LIBRARY_WITH_IDENTIFIER_VALUE: fhir4.Library = {
+const NEW_ACTIVE_LIBRARY: CRMIShareableLibrary = {
   resourceType: 'Library',
+  id: 'newTestActiveLibrary',
+  url: 'http://example.com/newTestActiveLibrary',
+  status: 'active',
+  ...LIBRARY_BASE
+};
+
+const DRAFT_LIBRARY: CRMIShareableLibrary = {
+  resourceType: 'Library',
+  id: 'testDraftLibrary',
+  url: 'http://example.com/testDraftLibrary',
+  status: 'draft',
+  ...LIBRARY_BASE
+};
+
+const DRAFT_LIBRARY_2: CRMIShareableLibrary = {
+  resourceType: 'Library',
+  id: 'testDraftLibrary2',
+  url: 'http://example.com/testDraftLibrary2',
+  status: 'draft',
+  ...LIBRARY_BASE
+};
+
+const LIBRARY_WITH_IDENTIFIER_VALUE: CRMIShareableLibrary = {
+  resourceType: 'Library',
+  id: 'libraryWithIdentifierValue',
+  url: 'http://example.com/libraryWithIdentifierValue',
+  status: 'active',
   identifier: [{ value: 'libraryWithIdentifierValue' }],
-  status: 'active',
   ...LIBRARY_BASE
 };
 
-const LIBRARY_WITH_IDENTIFIER_SYSTEM: fhir4.Library = {
+const LIBRARY_WITH_IDENTIFIER_SYSTEM: CRMIShareableLibrary = {
   resourceType: 'Library',
+  id: 'libraryWithIdentifierSystem',
+  url: 'http://example.com/libraryWithIdentifierSystem',
+  status: 'active',
   identifier: [{ system: 'http://example.com/libraryWithIdentifierSystem' }],
-  status: 'active',
   ...LIBRARY_BASE
 };
 
-const LIBRARY_WITH_IDENTIFIER_SYSTEM_AND_VALUE: fhir4.Library = {
+const LIBRARY_WITH_IDENTIFIER_SYSTEM_AND_VALUE: CRMIShareableLibrary = {
   resourceType: 'Library',
+  id: 'libraryWithIdentifierSystemAndValue',
+  url: 'http://example.com/libraryWithIdentifierSystemAndValue',
+  status: 'active',
   identifier: [
     { system: 'http://example.com/libraryWithIdentifierSystemAndValue', value: 'libraryWithIdentifierSystemAndValue' }
   ],
-  status: 'active',
   ...LIBRARY_BASE
 };
 
-const LIBRARY_WITH_NO_DEPS: fhir4.Library = {
+const LIBRARY_WITH_DEPS: CRMIShareableLibrary = {
   resourceType: 'Library',
-  id: 'testLibraryWithNoDeps',
-  status: 'active',
-  url: 'http://example.com/testLibrary',
-  type: { coding: [{ code: 'logic-library' }] }
-};
-
-const LIBRARY_WITH_DEPS: fhir4.Library = {
-  resourceType: 'Library',
-  id: 'testLibraryWithDeps2',
+  id: 'testActiveLibraryWithDeps',
+  url: 'http://example.com/testActiveLibraryWithDeps',
   status: 'draft',
-  url: 'http://example.com/testLibraryWithDeps2',
-  type: { coding: [{ code: 'logic-library' }] },
   relatedArtifact: [
     {
       type: 'depends-on',
-      resource: 'http://example.com/testLibrary'
+      resource: 'http://example.com/testActiveLibrary'
     }
-  ]
+  ],
+  ...LIBRARY_BASE
 };
 
-const LIBRARY_WITH_NESTED_DEPS: fhir4.Library = {
+const LIBRARY_WITH_NESTED_DEPS: CRMIShareableLibrary = {
   resourceType: 'Library',
-  id: 'testLibraryWithDeps',
+  id: 'testActiveLibraryWithDeps2',
+  url: 'http://example.com/testActiveLibraryWithDeps2',
   status: 'draft',
   version: '0.0.1-test',
-  url: 'http://example.com/testLibraryWithDeps',
   type: { coding: [{ code: 'logic-library' }] },
+  title: 'Sample title',
+  description: 'Sample description',
   relatedArtifact: [
     {
       type: 'depends-on',
-      resource: 'http://example.com/testLibraryWithDeps2'
+      resource: 'http://example.com/testActiveLibraryWithDeps'
     }
   ]
 };
 
-const LIBRARY_WITH_SAME_SYSTEM: fhir4.Library = {
+const LIBRARY_WITH_SAME_SYSTEM: CRMIShareableLibrary = {
   resourceType: 'Library',
-  type: { coding: [{ code: 'logic-library' }] },
+  id: 'libraryWithSameSystem',
+  url: 'http://example.com/libraryWithSameSystem',
+  status: 'active',
   identifier: [{ system: 'http://example.com/libraryWithSameSystem', value: 'libraryWithValue' }],
-  status: 'active'
+  ...LIBRARY_BASE
 };
 
 const LIBRARY_WITH_SAME_SYSTEM2: fhir4.Library = {
   resourceType: 'Library',
-  type: { coding: [{ code: 'logic-library' }] },
+  id: 'libraryWithSameSystem2',
+  url: 'http://example.com/libraryWithSameSystem2',
+  status: 'active',
   identifier: [{ system: 'http://example.com/libraryWithSameSystem', value: 'libraryWithDifferentValue' }],
-  status: 'active'
+  ...LIBRARY_BASE
 };
 
-const PARENT_ACTIVE_LIBRARY: CRMILibrary = {
+const PARENT_ACTIVE_LIBRARY: CRMIShareableLibrary = {
   resourceType: 'Library',
-  type: { coding: [{ code: 'logic-library' }] },
-  status: 'active',
   id: 'parentLibrary',
+  url: 'http://parent-library.com',
+  status: 'active',
   relatedArtifact: [
     {
       type: 'composed-of',
@@ -143,27 +167,21 @@ const PARENT_ACTIVE_LIBRARY: CRMILibrary = {
       ]
     }
   ],
-  url: 'http://parent-library.com',
-  version: '1',
-  description: 'Example description',
-  title: 'Parent Active Library'
+  ...LIBRARY_BASE
 };
 
-const CHILD_ACTIVE_LIBRARY: CRMILibrary = {
+const CHILD_ACTIVE_LIBRARY: CRMIShareableLibrary = {
   resourceType: 'Library',
   id: 'childLibrary',
-  type: { coding: [{ code: 'logic-library' }] },
+  url: 'http://child-library.com',
+  status: 'active',
   extension: [
     {
       url: 'http://hl7.org/fhir/StructureDefinition/artifact-isOwned',
       valueBoolean: true
     }
   ],
-  status: 'active',
-  version: '1',
-  url: 'http://child-library.com',
-  description: 'Example description',
-  title: 'Child Active Library'
+  ...LIBRARY_BASE
 };
 
 describe('LibraryService', () => {
@@ -171,8 +189,8 @@ describe('LibraryService', () => {
     server = initialize(serverConfig);
     process.env.AUTHORING = 'true';
     return setupTestDatabase([
-      LIBRARY_WITH_URL,
-      LIBRARY_WITH_NO_DEPS,
+      ACTIVE_LIBRARY,
+      ACTIVE_LIBRARY_2,
       LIBRARY_WITH_NESTED_DEPS,
       LIBRARY_WITH_DEPS,
       LIBRARY_WITH_IDENTIFIER_VALUE,
@@ -188,11 +206,11 @@ describe('LibraryService', () => {
   describe('searchById', () => {
     it('returns 200 when passed correct headers and the id is in database', async () => {
       await supertest(server.app)
-        .get('/4_0_1/Library/testLibraryWithNoDeps')
+        .get('/4_0_1/Library/testActiveLibrary')
         .set('Accept', 'application/json+fhir')
         .expect(200)
         .then(response => {
-          expect(response.body.id).toEqual(LIBRARY_WITH_NO_DEPS.id);
+          expect(response.body.id).toEqual(ACTIVE_LIBRARY.id);
         });
     });
 
@@ -214,13 +232,13 @@ describe('LibraryService', () => {
     it('returns 200 and correct searchset bundle when query matches single resource', async () => {
       await supertest(server.app)
         .get('/4_0_1/Library')
-        .query({ url: 'http://example.com', status: 'active', id: 'testWithUrl' })
+        .query({ url: 'http://example.com/testActiveLibrary', status: 'active', id: 'testActiveLibrary' })
         .set('Accept', 'application/json+fhir')
         .expect(200)
         .then(response => {
           expect(response.body.resourceType).toEqual('Bundle');
           expect(response.body.total).toEqual(1);
-          expect(response.body.entry[0].resource).toEqual(LIBRARY_WITH_URL);
+          expect(response.body.entry[0].resource).toEqual(ACTIVE_LIBRARY);
         });
     });
 
@@ -236,10 +254,10 @@ describe('LibraryService', () => {
           expect(response.body.entry).toEqual(
             expect.arrayContaining([
               expect.objectContaining<fhir4.BundleEntry>({
-                resource: LIBRARY_WITH_NO_DEPS
+                resource: ACTIVE_LIBRARY
               }),
               expect.objectContaining<fhir4.BundleEntry>({
-                resource: LIBRARY_WITH_URL
+                resource: ACTIVE_LIBRARY_2
               })
             ])
           );
@@ -249,13 +267,18 @@ describe('LibraryService', () => {
     it('returns 200 and correct searchset bundle with only id element when query matches single resource', async () => {
       await supertest(server.app)
         .get('/4_0_1/Library')
-        .query({ _elements: 'id', status: 'active', url: 'http://example.com', id: 'testWithUrl' })
+        .query({
+          _elements: 'id',
+          status: 'active',
+          url: 'http://example.com/testActiveLibrary',
+          id: 'testActiveLibrary'
+        })
         .set('Accept', 'application/json+fhir')
         .expect(200)
         .then(response => {
           expect(response.body.resourceType).toEqual('Bundle');
           expect(response.body.total).toEqual(1);
-          expect(response.body.entry[0].resource).toEqual(LIBRARY_WITH_URL_ONLY_ID);
+          expect(response.body.entry[0].resource).toEqual(ACTIVE_LIBRARY_NO_NAME);
         });
     });
 
@@ -271,7 +294,7 @@ describe('LibraryService', () => {
           expect(response.body.entry).toEqual(
             expect.arrayContaining([
               expect.objectContaining<fhir4.BundleEntry>({
-                resource: LIBRARY_WITH_URL_ONLY_ID
+                resource: ACTIVE_LIBRARY_NO_NAME
               })
             ])
           );
@@ -314,6 +337,7 @@ describe('LibraryService', () => {
         {
           resourceType: 'Library',
           id: 'publishable-retired',
+          url: 'http://example.com/publishable-retired',
           status: 'retired',
           ...LIBRARY_BASE
         },
@@ -323,12 +347,14 @@ describe('LibraryService', () => {
         {
           resourceType: 'Library',
           id: 'publishable-active',
+          url: 'http://example.com/publishable-active',
           status: 'active',
           ...LIBRARY_BASE
         },
         'Library'
       );
     });
+
     it('publish: returns 400 status when provided with artifact in non-active status', async () => {
       await supertest(server.app)
         .post('/4_0_1/Library')
@@ -336,12 +362,14 @@ describe('LibraryService', () => {
         .set('content-type', 'application/json+fhir')
         .expect(400);
     });
+
     it('retire: returns 400 when artifact to update is not in active status', async () => {
       await supertest(server.app)
         .put('/4_0_1/Library/publishable-retired')
         .send({
           resourceType: 'Library',
           id: 'publishable-retired',
+          url: 'http://example.com/publishable-retired',
           status: 'active',
           ...LIBRARY_BASE
         })
@@ -355,18 +383,19 @@ describe('LibraryService', () => {
         .send({
           resourceType: 'Library',
           id: 'publishable-active',
+          url: 'http://example.com/publishable-active',
+          version: '1',
           status: 'retired',
           title: 'updated',
           type: {
-            coding: [{ code: 'logic-library' }],
-            url: 'http://example.com',
-            version: '1',
-            description: 'Sample description'
-          }
+            coding: [{ code: 'logic-library' }]
+          },
+          description: 'Sample description'
         })
         .set('content-type', 'application/json+fhir')
         .expect(400);
     });
+
     it('archive: returns 400 status when deleting an active artifact', async () => {
       await supertest(server.app)
         .delete('/4_0_1/Library/publishable-active')
@@ -374,6 +403,7 @@ describe('LibraryService', () => {
         .set('content-type', 'application/json+fhir')
         .expect(400);
     });
+
     afterAll(() => {
       process.env.AUTHORING = ORIGINAL_AUTHORING;
     });
@@ -383,7 +413,7 @@ describe('LibraryService', () => {
     it('submit: returns 201 status with populated location when provided correct headers and a FHIR Library', async () => {
       await supertest(server.app)
         .post('/4_0_1/Library')
-        .send(DRAFT_LIBRARY_WITH_URL)
+        .send(DRAFT_LIBRARY)
         .set('content-type', 'application/json+fhir')
         .expect(201)
         .then(response => {
@@ -394,7 +424,7 @@ describe('LibraryService', () => {
     it('publish: returns 201 status with populated location when provided correct headers and a FHIR Library', async () => {
       await supertest(server.app)
         .post('/4_0_1/Library')
-        .send(LIBRARY_WITH_URL)
+        .send(NEW_ACTIVE_LIBRARY)
         .set('content-type', 'application/json+fhir')
         .expect(201)
         .then(response => {
@@ -409,6 +439,7 @@ describe('LibraryService', () => {
         {
           resourceType: 'Library',
           id: 'exampleId-active',
+          url: 'http://example.com/exampleId-active',
           status: 'active',
           ...LIBRARY_BASE
         },
@@ -418,6 +449,7 @@ describe('LibraryService', () => {
         {
           resourceType: 'Library',
           id: 'exampleId',
+          url: 'http://example.com/exampleId',
           status: 'draft',
           ...LIBRARY_BASE
         },
@@ -467,6 +499,7 @@ describe('LibraryService', () => {
         .send({
           resourceType: 'Library',
           id: 'exampleId-active',
+          url: 'http://example.com/exampleId-active',
           status: 'retired',
           ...LIBRARY_BASE
         })
@@ -479,8 +512,8 @@ describe('LibraryService', () => {
 
     it('returns 201 when provided correct headers and a FHIR Library whose id is not in the database', async () => {
       await supertest(server.app)
-        .put('/4_0_1/Library/testWithUrl2')
-        .send(LIBRARY_WITH_URL_2)
+        .put('/4_0_1/Library/testDraftLibrary2')
+        .send(DRAFT_LIBRARY_2)
         .set('content-type', 'application/json+fhir')
         .expect(201)
         .then(response => {
@@ -511,6 +544,7 @@ describe('LibraryService', () => {
         {
           resourceType: 'Library',
           id: 'delete-active',
+          url: 'http://example.com/delete-active',
           status: 'active',
           ...LIBRARY_BASE
         },
@@ -520,6 +554,7 @@ describe('LibraryService', () => {
         {
           resourceType: 'Library',
           id: 'delete-retired',
+          url: 'http://example.com/delete-retired',
           status: 'retired',
           ...LIBRARY_BASE
         },
@@ -529,6 +564,7 @@ describe('LibraryService', () => {
         {
           resourceType: 'Library',
           id: 'delete-draft',
+          url: 'http://example.com/delete-draft',
           status: 'draft',
           ...LIBRARY_BASE
         },
@@ -648,31 +684,31 @@ describe('LibraryService', () => {
   describe('$cqfm.package', () => {
     it('returns a Bundle including the Library when the Library has no dependencies and id passed through args', async () => {
       await supertest(server.app)
-        .get('/4_0_1/Library/testLibraryWithNoDeps/$cqfm.package')
+        .get('/4_0_1/Library/testActiveLibrary/$cqfm.package')
         .expect(200)
         .then(response => {
           expect(response.body.resourceType).toEqual('Bundle');
           expect(response.body.entry).toHaveLength(1);
-          expect(response.body.entry).toEqual(expect.arrayContaining([{ resource: LIBRARY_WITH_NO_DEPS }]));
+          expect(response.body.entry).toEqual(expect.arrayContaining([{ resource: ACTIVE_LIBRARY }]));
         });
     });
 
     it('returns a Bundle including the Library when the Library has no dependencies and id passed through body', async () => {
       await supertest(server.app)
         .post('/4_0_1/Library/$cqfm.package')
-        .send({ resourceType: 'Parameters', parameter: [{ name: 'id', valueString: 'testLibraryWithNoDeps' }] })
+        .send({ resourceType: 'Parameters', parameter: [{ name: 'id', valueString: 'testActiveLibrary' }] })
         .set('content-type', 'application/fhir+json')
         .expect(200)
         .then(response => {
           expect(response.body.resourceType).toEqual('Bundle');
           expect(response.body.entry).toHaveLength(1);
-          expect(response.body.entry).toEqual(expect.arrayContaining([{ resource: LIBRARY_WITH_NO_DEPS }]));
+          expect(response.body.entry).toEqual(expect.arrayContaining([{ resource: ACTIVE_LIBRARY }]));
         });
     });
 
     it('returns a Bundle including the Library and its dependent libraries when the Library has dependencies and id passed through args', async () => {
       await supertest(server.app)
-        .get('/4_0_1/Library/testLibraryWithDeps/$cqfm.package')
+        .get('/4_0_1/Library/testActiveLibraryWithDeps2/$cqfm.package')
         .expect(200)
         .expect(200)
         .then(response => {
@@ -681,7 +717,7 @@ describe('LibraryService', () => {
           expect(response.body.entry).toEqual(
             expect.arrayContaining([
               { resource: LIBRARY_WITH_NESTED_DEPS },
-              { resource: LIBRARY_WITH_NO_DEPS },
+              { resource: ACTIVE_LIBRARY },
               { resource: LIBRARY_WITH_DEPS }
             ])
           );
@@ -691,7 +727,7 @@ describe('LibraryService', () => {
     it('returns a Bundle including the Library and its dependent libraries when the Library has dependencies and id passed through body', async () => {
       await supertest(server.app)
         .post('/4_0_1/Library/$cqfm.package')
-        .send({ resourceType: 'Parameters', parameter: [{ name: 'id', valueString: 'testLibraryWithDeps' }] })
+        .send({ resourceType: 'Parameters', parameter: [{ name: 'id', valueString: 'testActiveLibraryWithDeps2' }] })
         .set('content-type', 'application/fhir+json')
         .expect(200)
         .then(response => {
@@ -700,7 +736,7 @@ describe('LibraryService', () => {
           expect(response.body.entry).toEqual(
             expect.arrayContaining([
               { resource: LIBRARY_WITH_NESTED_DEPS },
-              { resource: LIBRARY_WITH_NO_DEPS },
+              { resource: ACTIVE_LIBRARY },
               { resource: LIBRARY_WITH_DEPS }
             ])
           );
@@ -886,7 +922,7 @@ describe('LibraryService', () => {
     it('returns 200 and a Library for a simple Library with url, version, dependencies', async () => {
       await supertest(server.app)
         .post('/4_0_1/Library/$data-requirements')
-        .send({ resourceType: 'Parameters', parameter: [{ name: 'id', valueString: 'testLibraryWithDeps' }] })
+        .send({ resourceType: 'Parameters', parameter: [{ name: 'id', valueString: 'testActiveLibraryWithDeps2' }] })
         .set('content-type', 'application/fhir+json')
         .expect(200)
         .then(response => {
@@ -897,14 +933,14 @@ describe('LibraryService', () => {
             expect.objectContaining({
               resourceType: 'Bundle'
             }),
-            { rootLibRef: 'http://example.com/testLibraryWithDeps|0.0.1-test' }
+            { rootLibRef: 'http://example.com/testActiveLibraryWithDeps2|0.0.1-test' }
           );
         });
     });
 
     it('returns 200 and a Library for a request with id in the url', async () => {
       await supertest(server.app)
-        .get('/4_0_1/Library/testLibraryWithDeps/$data-requirements')
+        .get('/4_0_1/Library/testActiveLibraryWithDeps2/$data-requirements')
         .expect(200)
         .then(response => {
           expect(response.body.resourceType).toEqual('Library');
@@ -914,7 +950,7 @@ describe('LibraryService', () => {
             expect.objectContaining({
               resourceType: 'Bundle'
             }),
-            { rootLibRef: 'http://example.com/testLibraryWithDeps|0.0.1-test' }
+            { rootLibRef: 'http://example.com/testActiveLibraryWithDeps2|0.0.1-test' }
           );
         });
     });
@@ -922,7 +958,7 @@ describe('LibraryService', () => {
     it('returns 200 with query params', async () => {
       await supertest(server.app)
         .get('/4_0_1/Library/$data-requirements')
-        .query({ id: 'testLibraryWithDeps' })
+        .query({ id: 'testActiveLibraryWithDeps2' })
         .expect(200)
         .then(response => {
           expect(response.body.resourceType).toEqual('Library');
@@ -933,7 +969,7 @@ describe('LibraryService', () => {
               resourceType: 'Bundle'
             }),
             expect.objectContaining({
-              rootLibRef: 'http://example.com/testLibraryWithDeps|0.0.1-test'
+              rootLibRef: 'http://example.com/testActiveLibraryWithDeps2|0.0.1-test'
             })
           );
         });
@@ -945,7 +981,7 @@ describe('LibraryService', () => {
         .send({
           resourceType: 'Parameters',
           parameter: [
-            { name: 'id', valueString: 'testLibraryWithDeps' },
+            { name: 'id', valueString: 'testActiveLibraryWithDeps2' },
             { name: 'periodStart', valueDate: '2021-01-01' }
           ]
         })
@@ -963,7 +999,7 @@ describe('LibraryService', () => {
         .send({
           resourceType: 'Parameters',
           parameter: [
-            { name: 'id', valueString: 'testLibraryWithDeps' },
+            { name: 'id', valueString: 'tesActivetLibraryWithDeps2' },
             { name: 'periodEnd', valueDate: '2021-12-31' }
           ]
         })
@@ -977,8 +1013,8 @@ describe('LibraryService', () => {
 
     it('throws a 400 error when an id is included in both the path and a FHIR parameter', async () => {
       await supertest(server.app)
-        .post('/4_0_1/Library/testLibraryWithDeps/$data-requirements')
-        .send({ resourceType: 'Parameters', parameter: [{ name: 'id', valueString: 'testLibraryWithDeps' }] })
+        .post('/4_0_1/Library/testActiveLibraryWithDeps/$data-requirements')
+        .send({ resourceType: 'Parameters', parameter: [{ name: 'id', valueString: 'testLibraryWithDeps2' }] })
         .set('content-type', 'application/fhir+json')
         .expect(400)
         .then(response => {
@@ -991,7 +1027,7 @@ describe('LibraryService', () => {
 
     it('throws a 400 error when an id is included in both the path and a query parameter', async () => {
       await supertest(server.app)
-        .get('/4_0_1/Library/testLibraryWithDeps/$data-requirements')
+        .get('/4_0_1/Library/testActiveLibraryWithDeps2/$data-requirements')
         .query({ id: 'testLibraryWithDeps' })
         .set('content-type', 'application/fhir+json')
         .expect(400)
@@ -1003,6 +1039,7 @@ describe('LibraryService', () => {
         });
     });
   });
+
   afterAll(() => {
     return cleanUpTestDatabase();
   });

--- a/service/test/services/MeasureService.test.ts
+++ b/service/test/services/MeasureService.test.ts
@@ -3,43 +3,43 @@ import { serverConfig } from '../../src/config/serverConfig';
 import { cleanUpTestDatabase, createTestResource, setupTestDatabase } from '../utils';
 import supertest from 'supertest';
 import { Calculator } from 'fqm-execution';
-import { CRMILibrary, CRMIMeasure } from '../../src/types/service-types';
+import { CRMIShareableLibrary, CRMIShareableMeasure } from '../../src/types/service-types';
 
 let server: Server;
 // boiler plate required fields
-const MEASURE_BASE = {
-  url: 'http://example.com',
+const LIBRARY_BASE = {
+  type: { coding: [{ code: 'logic-library' }] },
   version: '1',
   title: 'Sample title',
   description: 'Sample description'
 };
 
-const MEASURE: fhir4.Measure = { resourceType: 'Measure', id: 'test', status: 'active', ...MEASURE_BASE };
+const MEASURE_BASE = {
+  version: '1',
+  title: 'Sample title',
+  description: 'Sample description'
+};
 
-const MEASURE_WITH_URL: fhir4.Measure = {
+const ACTIVE_MEASURE: CRMIShareableMeasure = {
   resourceType: 'Measure',
-  id: 'testWithUrl',
+  id: 'testActiveMeasure',
+  url: 'http://example.com/testActiveMeasure',
   status: 'active',
   ...MEASURE_BASE
 };
 
-const MEASURE_WITH_URL_2: fhir4.Measure = {
+const ACTIVE_MEASURE_2: CRMIShareableMeasure = {
   resourceType: 'Measure',
-  id: 'testWithUrl2',
-  status: 'draft',
-  ...MEASURE_BASE
-};
-
-const DRAFT_MEASURE_WITH_URL: fhir4.Measure = {
-  resourceType: 'Measure',
-  id: 'testWithUrl',
+  id: 'testActiveMeasure2',
+  url: 'http://example.com/testActiveMeasure2',
   status: 'active',
   ...MEASURE_BASE
 };
 
-const MEASURE_WITH_URL_ONLY_ID: fhir4.Measure = {
+const ACTIVE_MEASURE_NO_NAME: CRMIShareableMeasure = {
   resourceType: 'Measure',
-  id: 'testWithUrl',
+  id: 'testActiveMeasure',
+  url: 'http://example.com/testActiveMeasure',
   status: 'active',
   meta: {
     tag: [
@@ -48,77 +48,102 @@ const MEASURE_WITH_URL_ONLY_ID: fhir4.Measure = {
         system: 'http://terminology.hl7.org/CodeSystem/v3-ObservationValue'
       }
     ]
-  }
+  },
+  ...MEASURE_BASE
 };
 
-const MEASURE_WITH_IDENTIFIER_VALUE_ROOT_LIB: fhir4.Measure = {
+const NEW_ACTIVE_MEASURE: CRMIShareableMeasure = {
   resourceType: 'Measure',
+  id: 'newTestActiveMeasure',
+  url: 'http://example.com/newTestActiveMeasure',
+  status: 'active',
+  ...MEASURE_BASE
+};
+
+const DRAFT_MEASURE: CRMIShareableMeasure = {
+  resourceType: 'Measure',
+  id: 'testDraftMeasure',
+  url: 'http://example.com/testDraftMeasure',
+  status: 'draft',
+  ...MEASURE_BASE
+};
+
+const MEASURE_WITH_IDENTIFIER_VALUE_ROOT_LIB: CRMIShareableMeasure = {
+  resourceType: 'Measure',
+  id: 'measureWithIdentifierValueRootLib',
+  url: 'http://example.com/measureWithIdentifierValueRootLib',
   identifier: [{ value: 'measureWithIdentifierValueRootLib' }],
-  library: ['http://example.com/testLibrary'],
+  library: ['http://example.com/testActiveLibraryWithNoDeps'],
   status: 'active',
   ...MEASURE_BASE
 };
 
-const MEASURE_WITH_IDENTIFIER_SYSTEM_ROOT_LIB: fhir4.Measure = {
+const MEASURE_WITH_IDENTIFIER_SYSTEM_ROOT_LIB: CRMIShareableMeasure = {
   resourceType: 'Measure',
+  id: 'measureWithIdentifierSystemRootLib',
+  url: 'http://example.com/measureWithIdentifierSystemRootLib',
   identifier: [{ system: 'http://example.com/measureWithIdentifierSystemRootLib' }],
-  library: ['http://example.com/testLibrary'],
+  library: ['http://example.com/testActiveLibraryWithNoDeps'],
   status: 'active',
   ...MEASURE_BASE
 };
 
-const MEASURE_WITH_IDENTIFIER_SYSTEM_AND_VALUE_ROOT_LIB: fhir4.Measure = {
+const MEASURE_WITH_IDENTIFIER_SYSTEM_AND_VALUE_ROOT_LIB: CRMIShareableMeasure = {
   resourceType: 'Measure',
+  id: 'measureWithIdentifierSystemAndValueRootLib',
+  url: 'http://example.com/measureWithIdentifierSystemAndValueRootLib',
   identifier: [
     {
       value: 'measureWithIdentifierSystemAndValueRootLib',
       system: 'http://example.com/measureWithIdentifierSystemAndValueRootLib'
     }
   ],
-  library: ['http://example.com/testLibrary'],
+  library: ['http://example.com/testActiveLibraryWithNoDeps'],
   status: 'active',
   ...MEASURE_BASE
 };
 
-const MEASURE_WITH_ROOT_LIB: fhir4.Measure = {
+const MEASURE_WITH_ROOT_LIB: CRMIShareableMeasure = {
   resourceType: 'Measure',
-  id: 'testWithRootLib',
-  status: 'active',
+  id: 'testMeasureWithRootLib',
   url: 'http://example.com/testMeasureWithRootLib',
-  library: ['http://example.com/testLibrary']
-};
-
-const MEASURE_WITH_ROOT_LIB_AND_DEPS: fhir4.Measure = {
-  resourceType: 'Measure',
-  id: 'testWithRootLibAndDeps',
   status: 'active',
-  url: 'http://example.com/testMeasureWithDeps',
-  library: ['http://example.com/testLibraryWithDeps']
+  library: ['http://example.com/testActiveLibraryWithNoDeps'],
+  ...MEASURE_BASE
 };
 
-const LIBRARY_WITH_NO_DEPS: fhir4.Library = {
-  resourceType: 'Library',
-  id: 'testLibraryWithNoDeps',
-  status: 'draft',
-  url: 'http://example.com/testLibrary',
-  type: { coding: [{ code: 'logic-library' }] }
+const MEASURE_WITH_ROOT_LIB_AND_DEPS: CRMIShareableMeasure = {
+  resourceType: 'Measure',
+  id: 'testMeasureWithRootLibAndDeps',
+  url: 'http://example.com/testMeasureWithRootLibAndDeps',
+  status: 'active',
+  library: ['http://example.com/testActiveLibraryWithDeps'],
+  ...MEASURE_BASE
 };
 
-const LIBRARY_WITH_DEPS: fhir4.Library = {
+const ACTIVE_LIBRARY: CRMIShareableLibrary = {
   resourceType: 'Library',
-  id: 'testLibraryWithDeps',
+  id: 'testActiveLibraryWithNoDeps',
+  url: 'http://example.com/testActiveLibraryWithNoDeps',
+  status: 'active',
+  ...LIBRARY_BASE
+};
+
+const ACTIVE_LIBRARY_WITH_DEPS: CRMIShareableLibrary = {
+  resourceType: 'Library',
+  id: 'testActiveLibraryWithDeps',
+  url: 'http://example.com/testActiveLibraryWithDeps',
   status: 'draft',
-  url: 'http://example.com/testLibraryWithDeps',
-  type: { coding: [{ code: 'logic-library' }] },
   relatedArtifact: [
     {
       type: 'depends-on',
-      resource: 'http://example.com/testLibrary'
+      resource: 'http://example.com/testActiveLibraryWithNoDeps'
     }
-  ]
+  ],
+  ...LIBRARY_BASE
 };
 
-const PARENT_ACTIVE_MEASURE: CRMIMeasure = {
+const PARENT_ACTIVE_MEASURE: CRMIShareableMeasure = {
   resourceType: 'Measure',
   status: 'active',
   id: 'parentMeasure',
@@ -140,7 +165,7 @@ const PARENT_ACTIVE_MEASURE: CRMIMeasure = {
   title: 'Parent Active Measure'
 };
 
-const CHILD_ACTIVE_LIBRARY: CRMILibrary = {
+const CHILD_ACTIVE_LIBRARY: CRMIShareableLibrary = {
   resourceType: 'Library',
   id: 'childLibrary',
   type: { coding: [{ code: 'logic-library' }] },
@@ -162,12 +187,12 @@ describe('MeasureService', () => {
     server = initialize(serverConfig);
     process.env.AUTHORING = 'true';
     return setupTestDatabase([
-      MEASURE,
-      MEASURE_WITH_URL,
+      ACTIVE_MEASURE,
+      ACTIVE_MEASURE_2,
       MEASURE_WITH_ROOT_LIB,
       MEASURE_WITH_ROOT_LIB_AND_DEPS,
-      LIBRARY_WITH_NO_DEPS,
-      LIBRARY_WITH_DEPS,
+      ACTIVE_LIBRARY,
+      ACTIVE_LIBRARY_WITH_DEPS,
       MEASURE_WITH_IDENTIFIER_VALUE_ROOT_LIB,
       MEASURE_WITH_IDENTIFIER_SYSTEM_AND_VALUE_ROOT_LIB,
       MEASURE_WITH_IDENTIFIER_SYSTEM_ROOT_LIB,
@@ -179,11 +204,11 @@ describe('MeasureService', () => {
   describe('searchById', () => {
     it('returns 200 when passed correct headers and the id is in database', async () => {
       await supertest(server.app)
-        .get('/4_0_1/Measure/test')
+        .get('/4_0_1/Measure/testActiveMeasure')
         .set('Accept', 'application/json+fhir')
         .expect(200)
         .then(response => {
-          expect(response.body.id).toEqual(MEASURE.id);
+          expect(response.body.id).toEqual(ACTIVE_MEASURE.id);
         });
     });
 
@@ -205,13 +230,13 @@ describe('MeasureService', () => {
     it('returns 200 and correct searchset bundle when query matches single resource', async () => {
       await supertest(server.app)
         .get('/4_0_1/Measure')
-        .query({ url: 'http://example.com', status: 'active', id: 'testWithUrl' })
+        .query({ url: 'http://example.com/testActiveMeasure', status: 'active', id: 'testActiveMeasure' })
         .set('Accept', 'application/json+fhir')
         .expect(200)
         .then(response => {
           expect(response.body.resourceType).toEqual('Bundle');
           expect(response.body.total).toEqual(1);
-          expect(response.body.entry[0].resource).toEqual(MEASURE_WITH_URL);
+          expect(response.body.entry[0].resource).toEqual(ACTIVE_MEASURE);
         });
     });
 
@@ -227,10 +252,10 @@ describe('MeasureService', () => {
           expect(response.body.entry).toEqual(
             expect.arrayContaining([
               expect.objectContaining<fhir4.BundleEntry>({
-                resource: MEASURE
+                resource: ACTIVE_MEASURE
               }),
               expect.objectContaining<fhir4.BundleEntry>({
-                resource: MEASURE_WITH_URL
+                resource: ACTIVE_MEASURE_2
               })
             ])
           );
@@ -240,13 +265,18 @@ describe('MeasureService', () => {
     it('returns 200 and correct searchset bundle with only id element when query matches single resource', async () => {
       await supertest(server.app)
         .get('/4_0_1/Measure')
-        .query({ _elements: 'id', status: 'active', url: 'http://example.com', id: 'testWithUrl' })
+        .query({
+          _elements: 'id',
+          status: 'active',
+          url: 'http://example.com/testActiveMeasure',
+          id: 'testActiveMeasure'
+        })
         .set('Accept', 'application/json+fhir')
         .expect(200)
         .then(response => {
           expect(response.body.resourceType).toEqual('Bundle');
           expect(response.body.total).toEqual(1);
-          expect(response.body.entry[0].resource).toEqual(MEASURE_WITH_URL_ONLY_ID);
+          expect(response.body.entry[0].resource).toEqual(ACTIVE_MEASURE_NO_NAME);
         });
     });
 
@@ -262,7 +292,7 @@ describe('MeasureService', () => {
           expect(response.body.entry).toEqual(
             expect.arrayContaining([
               expect.objectContaining<fhir4.BundleEntry>({
-                resource: MEASURE_WITH_URL_ONLY_ID
+                resource: ACTIVE_MEASURE_NO_NAME
               })
             ])
           );
@@ -305,6 +335,7 @@ describe('MeasureService', () => {
         {
           resourceType: 'Measure',
           id: 'publishable-retired',
+          url: 'http://example.com/publishable-retired',
           status: 'retired',
           ...MEASURE_BASE
         },
@@ -314,12 +345,14 @@ describe('MeasureService', () => {
         {
           resourceType: 'Measure',
           id: 'publishable-active',
+          url: 'http://example.com/publishable-active',
           status: 'active',
           ...MEASURE_BASE
         },
         'Measure'
       );
     });
+
     it('publish: returns 400 status when provided with artifact in non-active status', async () => {
       await supertest(server.app)
         .post('/4_0_1/Measure')
@@ -327,12 +360,14 @@ describe('MeasureService', () => {
         .set('content-type', 'application/json+fhir')
         .expect(400);
     });
+
     it('retire: returns 400 when artifact to update is not in active status', async () => {
       await supertest(server.app)
         .put('/4_0_1/Measure/publishable-retired')
         .send({
           resourceType: 'Measure',
           id: 'publishable-retired',
+          url: 'http://example.com/publishable-retired',
           status: 'active',
           ...MEASURE_BASE
         })
@@ -348,13 +383,14 @@ describe('MeasureService', () => {
           id: 'publishable-active',
           status: 'retired',
           title: 'updated',
-          url: 'http://example.com',
+          url: 'http://example.com/publishable-active',
           version: '1',
           description: 'Sample description'
         })
         .set('content-type', 'application/json+fhir')
         .expect(400);
     });
+
     it('archive: returns 400 status when deleting an active artifact', async () => {
       await supertest(server.app)
         .delete('/4_0_1/Measure/publishable-active')
@@ -362,6 +398,7 @@ describe('MeasureService', () => {
         .set('content-type', 'application/json+fhir')
         .expect(400);
     });
+
     afterAll(() => {
       process.env.AUTHORING = ORIGINAL_AUTHORING;
     });
@@ -371,17 +408,18 @@ describe('MeasureService', () => {
     it('submit: returns 201 status with populated location when provided correct headers and a FHIR Measure', async () => {
       await supertest(server.app)
         .post('/4_0_1/Measure')
-        .send(DRAFT_MEASURE_WITH_URL)
+        .send(DRAFT_MEASURE)
         .set('content-type', 'application/json+fhir')
         .expect(201)
         .then(response => {
           expect(response.headers.location).toBeDefined();
         });
     });
+
     it('publish: returns 201 status with populated location when provided correct headers and a FHIR Measure', async () => {
       await supertest(server.app)
         .post('/4_0_1/Measure')
-        .send(MEASURE_WITH_URL)
+        .send(ACTIVE_MEASURE)
         .set('content-type', 'application/json+fhir')
         .expect(201)
         .then(response => {
@@ -393,11 +431,23 @@ describe('MeasureService', () => {
   describe('update', () => {
     beforeAll(() => {
       createTestResource(
-        { resourceType: 'Measure', id: 'exampleId-active', status: 'active', ...MEASURE_BASE },
+        {
+          resourceType: 'Measure',
+          id: 'exampleId-active',
+          url: 'http://example.com/exampleId-active',
+          status: 'active',
+          ...MEASURE_BASE
+        },
         'Measure'
       );
       return createTestResource(
-        { resourceType: 'Measure', id: 'exampleId', status: 'draft', ...MEASURE_BASE },
+        {
+          resourceType: 'Measure',
+          id: 'exampleId',
+          url: 'http://example.com/exampleId',
+          status: 'draft',
+          ...MEASURE_BASE
+        },
         'Measure'
       );
     });
@@ -410,7 +460,7 @@ describe('MeasureService', () => {
           id: 'exampleId',
           status: 'draft',
           title: 'updated',
-          url: 'http://example.com',
+          url: 'http://example.com/exampleId',
           version: '1',
           description: 'Sample description'
         })
@@ -429,7 +479,7 @@ describe('MeasureService', () => {
           id: 'exampleId',
           status: 'active',
           title: 'updated',
-          url: 'http://example.com',
+          url: 'http://example.com/exampleId',
           version: '1',
           description: 'Sample description'
         })
@@ -440,7 +490,13 @@ describe('MeasureService', () => {
     it('retire: returns 200 when provided updated status for retiring', async () => {
       await supertest(server.app)
         .put('/4_0_1/Measure/exampleId-active')
-        .send({ resourceType: 'Measure', id: 'exampleId-active', status: 'retired', ...MEASURE_BASE })
+        .send({
+          resourceType: 'Measure',
+          id: 'exampleId-active',
+          url: 'http://example.com/exampleId-active',
+          status: 'retired',
+          ...MEASURE_BASE
+        })
         .set('content-type', 'application/json+fhir')
         .expect(200)
         .then(response => {
@@ -450,8 +506,8 @@ describe('MeasureService', () => {
 
     it('returns 201 when provided correct headers and a FHIR Measure whose id is not in the database', async () => {
       await supertest(server.app)
-        .put('/4_0_1/Measure/testWithUrl2')
-        .send(MEASURE_WITH_URL_2)
+        .put('/4_0_1/Measure/newTestActiveMeasure')
+        .send(NEW_ACTIVE_MEASURE)
         .set('content-type', 'application/json+fhir')
         .expect(201)
         .then(response => {
@@ -482,6 +538,7 @@ describe('MeasureService', () => {
         {
           resourceType: 'Measure',
           id: 'delete-active',
+          url: 'http://example.com/delete-active',
           status: 'active',
           ...MEASURE_BASE
         },
@@ -491,6 +548,7 @@ describe('MeasureService', () => {
         {
           resourceType: 'Measure',
           id: 'delete-retired',
+          url: 'http://example.com/delete-retired',
           status: 'retired',
           ...MEASURE_BASE
         },
@@ -500,12 +558,14 @@ describe('MeasureService', () => {
         {
           resourceType: 'Measure',
           id: 'delete-draft',
+          url: 'http://example.com/delete-draft',
           status: 'draft',
           ...MEASURE_BASE
         },
         'Measure'
       );
     });
+
     it('withdraw: returns 204 status when deleting a draft artifact', async () => {
       await supertest(server.app)
         .delete('/4_0_1/Measure/delete-draft')
@@ -513,6 +573,7 @@ describe('MeasureService', () => {
         .set('content-type', 'application/json+fhir')
         .expect(204);
     });
+
     it('archive: returns 204 status when deleting a retired artifact', async () => {
       await supertest(server.app)
         .delete('/4_0_1/Measure/delete-retired')
@@ -520,6 +581,7 @@ describe('MeasureService', () => {
         .set('content-type', 'application/json+fhir')
         .expect(204);
     });
+
     it('archive: returns 400 status when deleting an active artifact', async () => {
       await supertest(server.app)
         .delete('/4_0_1/Measure/delete-active')
@@ -619,13 +681,13 @@ describe('MeasureService', () => {
   describe('$cqfm.package', () => {
     it('returns a Bundle including the root lib and Measure when root lib has no dependencies and id passed through args', async () => {
       await supertest(server.app)
-        .get('/4_0_1/Measure/testWithRootLib/$cqfm.package')
+        .get('/4_0_1/Measure/testMeasureWithRootLib/$cqfm.package')
         .expect(200)
         .then(response => {
           expect(response.body.resourceType).toEqual('Bundle');
           expect(response.body.entry).toHaveLength(2);
           expect(response.body.entry).toEqual(
-            expect.arrayContaining([{ resource: LIBRARY_WITH_NO_DEPS }, { resource: MEASURE_WITH_ROOT_LIB }])
+            expect.arrayContaining([{ resource: ACTIVE_LIBRARY }, { resource: MEASURE_WITH_ROOT_LIB }])
           );
         });
     });
@@ -633,29 +695,29 @@ describe('MeasureService', () => {
     it('returns a Bundle including the root lib and Measure when root lib has no dependencies and id passed through body', async () => {
       await supertest(server.app)
         .post('/4_0_1/Measure/$cqfm.package')
-        .send({ resourceType: 'Parameters', parameter: [{ name: 'id', valueUrl: 'testWithRootLib' }] })
+        .send({ resourceType: 'Parameters', parameter: [{ name: 'id', valueUrl: 'testMeasureWithRootLib' }] })
         .set('content-type', 'application/fhir+json')
         .expect(200)
         .then(response => {
           expect(response.body.resourceType).toEqual('Bundle');
           expect(response.body.entry).toHaveLength(2);
           expect(response.body.entry).toEqual(
-            expect.arrayContaining([{ resource: LIBRARY_WITH_NO_DEPS }, { resource: MEASURE_WITH_ROOT_LIB }])
+            expect.arrayContaining([{ resource: ACTIVE_LIBRARY }, { resource: MEASURE_WITH_ROOT_LIB }])
           );
         });
     });
 
     it('returns a Bundle including the root lib, Measure and dependent libraries when root lib has dependencies and id passed through args', async () => {
       await supertest(server.app)
-        .get('/4_0_1/Measure/testWithRootLibAndDeps/$cqfm.package')
+        .get('/4_0_1/Measure/testMeasureWithRootLibAndDeps/$cqfm.package')
         .expect(200)
         .then(response => {
           expect(response.body.resourceType).toEqual('Bundle');
           expect(response.body.entry).toHaveLength(3);
           expect(response.body.entry).toEqual(
             expect.arrayContaining([
-              { resource: LIBRARY_WITH_DEPS },
-              { resource: LIBRARY_WITH_NO_DEPS },
+              { resource: ACTIVE_LIBRARY_WITH_DEPS },
+              { resource: ACTIVE_LIBRARY },
               { resource: MEASURE_WITH_ROOT_LIB_AND_DEPS }
             ])
           );
@@ -665,7 +727,7 @@ describe('MeasureService', () => {
     it('returns a Bundle including the root lib, Measure, and dependent libraries when root lib has dependencies and id passed through body', async () => {
       await supertest(server.app)
         .post('/4_0_1/Measure/$cqfm.package')
-        .send({ resourceType: 'Parameters', parameter: [{ name: 'id', valueString: 'testWithRootLibAndDeps' }] })
+        .send({ resourceType: 'Parameters', parameter: [{ name: 'id', valueString: 'testMeasureWithRootLibAndDeps' }] })
         .set('content-type', 'application/fhir+json')
         .expect(200)
         .then(response => {
@@ -673,8 +735,8 @@ describe('MeasureService', () => {
           expect(response.body.entry).toHaveLength(3);
           expect(response.body.entry).toEqual(
             expect.arrayContaining([
-              { resource: LIBRARY_WITH_DEPS },
-              { resource: LIBRARY_WITH_NO_DEPS },
+              { resource: ACTIVE_LIBRARY_WITH_DEPS },
+              { resource: ACTIVE_LIBRARY },
               { resource: MEASURE_WITH_ROOT_LIB_AND_DEPS }
             ])
           );
@@ -694,10 +756,7 @@ describe('MeasureService', () => {
           expect(response.body.resourceType).toEqual('Bundle');
           expect(response.body.entry).toHaveLength(2);
           expect(response.body.entry).toEqual(
-            expect.arrayContaining([
-              { resource: LIBRARY_WITH_NO_DEPS },
-              { resource: MEASURE_WITH_IDENTIFIER_VALUE_ROOT_LIB }
-            ])
+            expect.arrayContaining([{ resource: ACTIVE_LIBRARY }, { resource: MEASURE_WITH_IDENTIFIER_VALUE_ROOT_LIB }])
           );
         });
     });
@@ -716,7 +775,7 @@ describe('MeasureService', () => {
           expect(response.body.entry).toHaveLength(2);
           expect(response.body.entry).toEqual(
             expect.arrayContaining([
-              { resource: LIBRARY_WITH_NO_DEPS },
+              { resource: ACTIVE_LIBRARY },
               { resource: MEASURE_WITH_IDENTIFIER_SYSTEM_ROOT_LIB }
             ])
           );
@@ -743,7 +802,7 @@ describe('MeasureService', () => {
           expect(response.body.entry).toHaveLength(2);
           expect(response.body.entry).toEqual(
             expect.arrayContaining([
-              { resource: LIBRARY_WITH_NO_DEPS },
+              { resource: ACTIVE_LIBRARY },
               { resource: MEASURE_WITH_IDENTIFIER_SYSTEM_AND_VALUE_ROOT_LIB }
             ])
           );
@@ -786,8 +845,8 @@ describe('MeasureService', () => {
 
     it('throws a 400 error when an id is included in both the path and a FHIR parameter', async () => {
       await supertest(server.app)
-        .post('/4_0_1/Measure/testWithRootLib/$cqfm.package')
-        .send({ resourceType: 'Parameters', parameter: [{ name: 'id', valueString: 'testWithRootLib' }] })
+        .post('/4_0_1/Measure/testMeasureWithRootLib/$cqfm.package')
+        .send({ resourceType: 'Parameters', parameter: [{ name: 'id', valueString: 'testMeasureWithRootLib' }] })
         .set('content-type', 'application/fhir+json')
         .expect(400)
         .then(response => {
@@ -800,8 +859,8 @@ describe('MeasureService', () => {
 
     it('throws a 400 error when an id is included in both the path and a query parameter', async () => {
       await supertest(server.app)
-        .get('/4_0_1/Measure/testWithRootLib/$cqfm.package')
-        .query({ id: 'testWithRootLib' })
+        .get('/4_0_1/Measure/testMeasureWithRootLib/$cqfm.package')
+        .query({ id: 'testMeasureWithRootLib' })
         .set('content-type', 'application/fhir+json')
         .expect(400)
         .then(response => {
@@ -852,7 +911,7 @@ describe('MeasureService', () => {
     it('returns 200 and a Library for a simple measure with dependencies and no period params', async () => {
       await supertest(server.app)
         .post('/4_0_1/Measure/$data-requirements')
-        .send({ resourceType: 'Parameters', parameter: [{ name: 'id', valueString: 'testWithRootLibAndDeps' }] })
+        .send({ resourceType: 'Parameters', parameter: [{ name: 'id', valueString: 'testMeasureWithRootLibAndDeps' }] })
         .set('content-type', 'application/fhir+json')
         .expect(200)
         .then(response => {
@@ -870,7 +929,7 @@ describe('MeasureService', () => {
 
     it('returns 200 and a Library for a request with id in the url', async () => {
       await supertest(server.app)
-        .get('/4_0_1/Measure/testWithRootLibAndDeps/$data-requirements')
+        .get('/4_0_1/Measure/testMeasureWithRootLibAndDeps/$data-requirements')
         .expect(200)
         .then(response => {
           expect(response.body.resourceType).toEqual('Library');
@@ -891,7 +950,7 @@ describe('MeasureService', () => {
         .send({
           resourceType: 'Parameters',
           parameter: [
-            { name: 'id', valueString: 'testWithRootLibAndDeps' },
+            { name: 'id', valueString: 'testMeasureWithRootLibAndDeps' },
             { name: 'periodStart', valueDate: '2021-01-01' },
             { name: 'periodEnd', valueDate: '2021-12-31' }
           ]
@@ -917,7 +976,7 @@ describe('MeasureService', () => {
     it('returns 200 with query params', async () => {
       await supertest(server.app)
         .get('/4_0_1/Measure/$data-requirements')
-        .query({ id: 'testWithRootLibAndDeps', periodStart: '2021-01-01', periodEnd: '2021-12-31' })
+        .query({ id: 'testMeasureWithRootLibAndDeps', periodStart: '2021-01-01', periodEnd: '2021-12-31' })
         .expect(200)
         .then(response => {
           expect(response.body.resourceType).toEqual('Library');
@@ -937,8 +996,8 @@ describe('MeasureService', () => {
 
     it('throws a 400 error when an id is included in both the path and a FHIR parameter', async () => {
       await supertest(server.app)
-        .post('/4_0_1/Measure/testWithRootLib/$data-requirements')
-        .send({ resourceType: 'Parameters', parameter: [{ name: 'id', valueString: 'testWithRootLib' }] })
+        .post('/4_0_1/Measure/testMeasureWithRootLib/$data-requirements')
+        .send({ resourceType: 'Parameters', parameter: [{ name: 'id', valueString: 'testMeasureWithRootLib' }] })
         .set('content-type', 'application/fhir+json')
         .expect(400)
         .then(response => {
@@ -951,8 +1010,8 @@ describe('MeasureService', () => {
 
     it('throws a 400 error when an id is included in both the path and a query parameter', async () => {
       await supertest(server.app)
-        .get('/4_0_1/Measure/testWithRootLib/$data-requirements')
-        .query({ id: 'testWithRootLib' })
+        .get('/4_0_1/Measure/testMeasureWithRootLib/$data-requirements')
+        .query({ id: 'testMeasureWithRootLib' })
         .set('content-type', 'application/fhir+json')
         .expect(400)
         .then(response => {

--- a/service/test/util/serviceUtils.test.ts
+++ b/service/test/util/serviceUtils.test.ts
@@ -1,4 +1,4 @@
-import { CRMILibrary } from '../../src/types/service-types';
+import { CRMIShareableLibrary } from '../../src/types/service-types';
 import { cleanUpTestDatabase, setupTestDatabase } from '../utils';
 import { getChildren, modifyResourcesForDraft } from '../../src/util/serviceUtils';
 
@@ -15,7 +15,7 @@ const PARENT_RELATED_ARTIFACTS: fhir4.RelatedArtifact[] = [
   }
 ];
 
-const CHILD_LIBRARY_1: CRMILibrary = {
+const CHILD_LIBRARY_1: CRMIShareableLibrary = {
   resourceType: 'Library',
   status: 'active',
   type: { coding: [{ code: 'logic-library' }] },
@@ -44,7 +44,7 @@ const CHILD_LIBRARY_1: CRMILibrary = {
   ]
 };
 
-const CHILD_LIBRARY_2: CRMILibrary = {
+const CHILD_LIBRARY_2: CRMIShareableLibrary = {
   resourceType: 'Library',
   status: 'active',
   type: { coding: [{ code: 'logic-library' }] },

--- a/service/test/utils.ts
+++ b/service/test/utils.ts
@@ -1,8 +1,8 @@
-import { FhirResourceType } from '@projecttacoma/node-fhir-server-core';
 import { Connection } from '../src/db/Connection';
+import { ArtifactResourceType, FhirArtifact } from '../src/types/service-types';
 
-export async function createTestResource(data: fhir4.FhirResource, resourceType: FhirResourceType) {
-  const collection = Connection.db.collection<fhir4.FhirResource>(resourceType);
+export async function createTestResource(data: FhirArtifact, resourceType: ArtifactResourceType) {
+  const collection = Connection.db.collection<FhirArtifact>(resourceType);
   await collection.insertOne({ ...data });
 }
 
@@ -11,7 +11,7 @@ export async function cleanUpTestDatabase() {
   await Connection.connection?.close();
 }
 
-export async function setupTestDatabase(testFixtureList: fhir4.FhirResource[]) {
+export async function setupTestDatabase(testFixtureList: FhirArtifact[]) {
   await Connection.connect((global as any).__MONGO_URI__);
 
   for (const resource of testFixtureList) {


### PR DESCRIPTION
# Summary
This PR updates the typing of Libraries and Measures by using (when possible) [CRMIShareableMeasure](https://hl7.org/fhir/uv/crmi/StructureDefinition-crmi-shareablemeasure.html) and [CRMIShareableLibrary](https://hl7.org/fhir/uv/crmi/StructureDefinition-crmi-shareablelibrary.html) type definitions. 

## New behavior
The CRMIShareableMeasure and CRMIShareableLibrary definitions only vary slightly from that of fhir4.Measure and fhir4.Library- they are both extended from them but also require `version`, `url`, `title`, `status` and `description`. 

## Code changes
- A lot of changing `fhir4.FhirResource` to `fhir4.Measure` and `fhir4.Library` to `CRMIShareableMeasure` and `CRMIShareableLibrary`. 
- A lot of making sure test fixtures have additional attributes (`url`, `version`, `title`, `description`)
- Deleting some no longer relevant unit tests

# Testing guidance
- `npm run check:all`
- `npm run build:all`
- `npm run start:all`
- Make sure the functionality is the same.
- Go through the code to make sure I didn't miss any places where the new types can be used. Note: I purposely did not change anything related to uploading bundles because I did not want to mess with the existing error handling there. Open to alternative ways to do this though.
- Make sure that all unit tests are still relevant.