### PR TITLE
Expose  operation

### DIFF
--- a/service/README.md
+++ b/service/README.md
@@ -198,6 +198,9 @@ And takes the following optional parameters:
 - approvalDate
 - artifactAssessmentType (must be included with artifactAssessmentSummary if provided)
 - artifactAssessmentSummary (must be included with artifactAssessmentType if provided)
+- artifactAssessmentTarget
+- artifactAssessmentRelatedArtifact
+- artifactAssessmentAuthor
 
 ## License
 

--- a/service/README.md
+++ b/service/README.md
@@ -196,8 +196,8 @@ The Measure Repository Service Authoring Repository Service server supports the 
 And takes the following optional parameters:
 
 - approvalDate
-- artifactAssessmentType (must be included with artifactAssessmentSummary if provided)
-- artifactAssessmentSummary (must be included with artifactAssessmentType if provided)
+- artifactAssessmentType (must be included with any other artifactAssessment parameters, if provided)
+- artifactAssessmentSummary (must be included with any other artifactAssessment parameters, if provided)
 - artifactAssessmentTarget
 - artifactAssessmentRelatedArtifact
 - artifactAssessmentAuthor

--- a/service/README.md
+++ b/service/README.md
@@ -187,6 +187,16 @@ The Measure Repository Service Authoring Repository Service server supports the 
 
 Note: `url` is not currently a required parameter in the $clone OperationDefinition, but it will be in future IG versions.
 
+### Approve
+
+The Measure Repository Service Authoring Repository Service server supports the `Measure` and `Library` `$approve` operations as defined by the [Canonical Resource Management Infrastructure IG](https://hl7.org/fhir/uv/crmi/OperationDefinition-crmi-approve.html). It requires the following parameters:
+
+- id
+
+And takes the following optional parameters:
+
+- approvalDate
+
 ## License
 
 Copyright 2022-2023 The MITRE Corporation

--- a/service/README.md
+++ b/service/README.md
@@ -196,6 +196,8 @@ The Measure Repository Service Authoring Repository Service server supports the 
 And takes the following optional parameters:
 
 - approvalDate
+- artifactAssessmentType (must be included with artifactAssessmentSummary if provided)
+- artifactAssessmentSummary (must be included with artifactAssessmentType if provided)
 
 ## License
 

--- a/service/src/config/capabilityStatementResources.json
+++ b/service/src/config/capabilityStatementResources.json
@@ -182,6 +182,16 @@
           ],
           "name": "clone",
           "definition": "http://hl7.org/fhir/uv/crmi/OperationDefinition/crmi-clone"
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHALL"
+            }
+          ],
+          "name": "approve",
+          "definition": "http://hl7.org/fhir/uv/crmi/OperationDefinition/crmi-approve"
         }
       ]
     },
@@ -360,6 +370,16 @@
           ],
           "name": "clone",
           "definition": "http://hl7.org/fhir/uv/crmi/OperationDefinition/crmi-clone"
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHALL"
+            }
+          ],
+          "name": "approve",
+          "definition": "http://hl7.org/fhir/uv/crmi/OperationDefinition/crmi-approve"
         }
       ]
     }

--- a/service/src/config/serverConfig.ts
+++ b/service/src/config/serverConfig.ts
@@ -133,6 +133,30 @@ export const serverConfig: ServerConfig = {
           route: '/:id/$clone',
           method: 'POST',
           reference: 'https://hl7.org/fhir/uv/crmi/STU1/OperationDefinition-crmi-clone.html'
+        },
+        {
+          name: 'approve',
+          route: '/$approve',
+          method: 'GET',
+          reference: 'https://hl7.org/fhir/uv/crmi/STU1/OperationDefinition-crmi-approve.html'
+        },
+        {
+          name: 'approve',
+          route: '/$approve',
+          method: 'POST',
+          reference: 'https://hl7.org/fhir/uv/crmi/STU1/OperationDefinition-crmi-approve.html'
+        },
+        {
+          name: 'approve',
+          route: '/:id/$approve',
+          method: 'GET',
+          reference: 'https://hl7.org/fhir/uv/crmi/STU1/OperationDefinition-crmi-approve.html'
+        },
+        {
+          name: 'approve',
+          route: '/:id/$approve',
+          method: 'POST',
+          reference: 'https://hl7.org/fhir/uv/crmi/STU1/OperationDefinition-crmi-approve.html'
         }
       ]
     },
@@ -235,6 +259,30 @@ export const serverConfig: ServerConfig = {
           route: '/:id/$clone',
           method: 'POST',
           reference: 'https://hl7.org/fhir/uv/crmi/STU1/OperationDefinition-crmi-clone.html'
+        },
+        {
+          name: 'approve',
+          route: '/$approve',
+          method: 'GET',
+          reference: 'https://hl7.org/fhir/uv/crmi/STU1/OperationDefinition-crmi-approve.html'
+        },
+        {
+          name: 'approve',
+          route: '/$approve',
+          method: 'POST',
+          reference: 'https://hl7.org/fhir/uv/crmi/STU1/OperationDefinition-crmi-approve.html'
+        },
+        {
+          name: 'approve',
+          route: '/:id/$approve',
+          method: 'GET',
+          reference: 'https://hl7.org/fhir/uv/crmi/STU1/OperationDefinition-crmi-approve.html'
+        },
+        {
+          name: 'approve',
+          route: '/:id/$approve',
+          method: 'POST',
+          reference: 'https://hl7.org/fhir/uv/crmi/STU1/OperationDefinition-crmi-approve.html'
         }
       ]
     }

--- a/service/src/db/dbOperations.ts
+++ b/service/src/db/dbOperations.ts
@@ -157,10 +157,9 @@ export async function batchInsert(artifacts: FhirArtifact[], action: string) {
 
 /**
  * Updates a parent artifact and all of its children (if applicable) in a batch
- * to set the date and approvalDate elements of the approved artifacts as well
- * as add an 'Approve' cqfm-artifactComment extension to the artifacts
+ * transaction
  */
-export async function batchUpdate(artifacts: FhirArtifact[]) {
+export async function batchUpdate(artifacts: FhirArtifact[], action: string) {
   let error = null;
   const results: FhirArtifact[] = [];
   const updateSession = Connection.connection?.startSession();
@@ -172,9 +171,9 @@ export async function batchUpdate(artifacts: FhirArtifact[]) {
         results.push(artifact);
       }
     });
-    console.log(`Batch approve transaction committed.`);
+    console.log(`Batch ${action} transaction committed.`);
   } catch (err) {
-    console.log('Batch approve transaction failed: ' + err);
+    console.log(`Batch ${action} transaction failed: ` + err);
     error = err;
   } finally {
     await updateSession?.endSession();

--- a/service/src/requestSchemas.ts
+++ b/service/src/requestSchemas.ts
@@ -4,6 +4,7 @@ import { BadRequestError, NotImplementedError } from './util/errorUtils';
 
 const DATE_REGEX = /([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)(-(0[1-9]|1[0-2])(-(0[1-9]|[1-2][0-9]|3[0-1]))?)/;
 const VERSION_REGEX = /^\d+\.\d+\.\d+(\.\d+|)$/;
+const URI_REGEX = /\S*/; // as defined by the FHIR specification: https://hl7.org/fhir/R4/datatypes.html#uri
 
 // Operation Definition: http://hl7.org/fhir/us/cqfmeasures/STU4/OperationDefinition-cqfm-package.html
 const UNSUPPORTED_PACKAGE_ARGS = [
@@ -178,6 +179,7 @@ const stringToBool = z
 const stringToNumber = z.coerce.number();
 const checkDate = z.string().regex(DATE_REGEX, 'Invalid FHIR date');
 const checkVersion = z.string().regex(VERSION_REGEX, 'Invalid Semantic Version');
+const checkUri = z.string().regex(URI_REGEX, 'Invalid URI');
 
 export const DraftArgs = z
   .object({ id: z.string(), version: checkVersion })
@@ -196,7 +198,10 @@ export const ApproveArgs = z
     artifactAssessmentType: z
       .union([z.literal('documentation'), z.literal('guidance'), z.literal('review')])
       .optional(),
-    artifactAssessmentSummary: z.string().optional()
+    artifactAssessmentSummary: z.string().optional(),
+    artifactAssessmentTarget: checkUri.optional(),
+    artifactAssessmentRelatedArtifact: checkUri.optional(),
+    artifactAssessmentAuthor: z.object({ reference: z.string() }).optional()
   })
   .strict()
   .superRefine(catchInvalidParams([catchMissingId, catchMissingTypeAndSummary]));

--- a/service/src/requestSchemas.ts
+++ b/service/src/requestSchemas.ts
@@ -111,7 +111,7 @@ export function catchMissingTypeAndSummary(val: Record<string, any>, ctx: z.Refi
       code: z.ZodIssueCode.custom,
       params: { serverErrorCode: constants.ISSUE.CODE.REQUIRED },
       message:
-        'Both artifactAssessmentType and artifactAssessmentSummary must be defined if they are doing to be included.'
+        'Both artifactAssessmentType and artifactAssessmentSummary must be defined if they are going to be included.'
     });
   }
 }

--- a/service/src/requestSchemas.ts
+++ b/service/src/requestSchemas.ts
@@ -56,9 +56,14 @@ const hasIdentifyingInfo = (args: Record<string, any>) => args.id || args.url ||
 
 const onlyId = (args: Record<string, any>) => args.id;
 
-const typeAndSummary = (args: Record<string, any>) =>
-  (args.artifactAssessmentType && args.artifactAssessmentSummary) ||
-  (!args.artifactAssessmentType && !args.artifactAssessmentSummary);
+const typeAndSummary = (args: Record<string, any>) => args.artifactAssessmentType && args.artifactAssessmentSummary;
+
+const anyArtifactAssessment = (args: Record<string, any>) =>
+  args.artifactAssessmentType ||
+  args.artifactAssessmentSummary ||
+  args.artifactAssessmentTarget ||
+  args.artifactAssessmentRelatedArtifact ||
+  args.artifactAssessmentAuthor;
 
 const idAndVersion = (args: Record<string, any>) => args.id && args.version;
 
@@ -103,16 +108,15 @@ export function catchMissingIdentifyingInfo(val: Record<string, any>, ctx: z.Ref
 }
 
 /**
- * Checks that if artifactAssessmentType is provided as an input parameter than so is artifactAssessmentSummary
- * and vice versa
+ * Checks that if artifactAssessmentType and artifactAssessmentSummary are both provided alongside any artifactAssessment parameters
  */
 export function catchMissingTypeAndSummary(val: Record<string, any>, ctx: z.RefinementCtx) {
-  if (!typeAndSummary(val)) {
+  if (anyArtifactAssessment(val) && !typeAndSummary(val)) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
       params: { serverErrorCode: constants.ISSUE.CODE.REQUIRED },
       message:
-        'Both artifactAssessmentType and artifactAssessmentSummary must be defined if they are going to be included.'
+        'Both artifactAssessmentType and artifactAssessmentSummary must be defined if any artifactAssessment parameters are provided.'
     });
   }
 }

--- a/service/src/services/LibraryService.ts
+++ b/service/src/services/LibraryService.ts
@@ -291,6 +291,17 @@ export class LibraryService implements Service<CRMIShareableLibrary> {
         { url: 'type', valueCode: parsedParams.artifactAssessmentType },
         { url: 'text', valueMarkdown: parsedParams.artifactAssessmentSummary }
       );
+
+      if (parsedParams.artifactAssessmentTarget) {
+        approveExtension.push({ url: 'target', valueUri: parsedParams.artifactAssessmentTarget });
+      }
+      if (parsedParams.artifactAssessmentRelatedArtifact) {
+        approveExtension.push({ url: 'reference', valueUri: parsedParams.artifactAssessmentRelatedArtifact });
+      }
+      if (parsedParams.artifactAssessmentAuthor) {
+        approveExtension.push({ url: 'user', valueString: parsedParams.artifactAssessmentAuthor.reference });
+      }
+
       if (library.extension) {
         library.extension.push({
           extension: approveExtension,
@@ -318,6 +329,17 @@ export class LibraryService implements Service<CRMIShareableLibrary> {
           { url: 'type', valueCode: parsedParams.artifactAssessmentType },
           { url: 'text', valueMarkdown: parsedParams.artifactAssessmentSummary }
         );
+
+        if (parsedParams.artifactAssessmentTarget) {
+          approveExtension.push({ url: 'target', valueUri: parsedParams.artifactAssessmentTarget });
+        }
+        if (parsedParams.artifactAssessmentRelatedArtifact) {
+          approveExtension.push({ url: 'reference', valueUri: parsedParams.artifactAssessmentRelatedArtifact });
+        }
+        if (parsedParams.artifactAssessmentAuthor) {
+          approveExtension.push({ url: 'user', valueString: parsedParams.artifactAssessmentAuthor.reference });
+        }
+
         if (child.extension) {
           child.extension.push({
             extension: approveExtension,

--- a/service/src/services/LibraryService.ts
+++ b/service/src/services/LibraryService.ts
@@ -337,7 +337,7 @@ export class LibraryService implements Service<CRMIShareableLibrary> {
     });
 
     // now we want to batch update the approved parent Library and any of its children
-    const approvedArtifacts = await batchUpdate([library, ...(await Promise.all(children))]);
+    const approvedArtifacts = await batchUpdate([library, ...(await Promise.all(children))], 'approve');
 
     // we want to return a Bundle containing the updated artifacts
     return createBatchResponseBundle(approvedArtifacts);

--- a/service/src/services/LibraryService.ts
+++ b/service/src/services/LibraryService.ts
@@ -260,7 +260,8 @@ export class LibraryService implements Service<CRMIShareableLibrary> {
    * {BASE_URL}/4_0_1/Library/$approve or {BASE_URL}/4_0_1/Library/[id]/$approve
    * applies an approval to an existing artifact, regardless of status, and sets the
    * date and approvalDate elements of the approved artifact as well as for all resources
-   * it is composed of
+   * it is composed of. The user can optionally provide an artifactAssessmentType and an
+   * artifactAssessmentSummary for an cqfm-artifactComment extension.
    */
   async approve(args: RequestArgs, { req }: RequestCtx) {
     logger.info(`${req.method} ${req.path}`);

--- a/service/src/services/LibraryService.ts
+++ b/service/src/services/LibraryService.ts
@@ -1,6 +1,7 @@
 import { loggers, RequestArgs, RequestCtx } from '@projecttacoma/node-fhir-server-core';
 import {
   batchInsert,
+  batchUpdate,
   createResource,
   deleteResource,
   findDataRequirementsWithQuery,
@@ -16,7 +17,8 @@ import {
   PackageArgs,
   parseRequestSchema,
   DraftArgs,
-  CloneArgs
+  CloneArgs,
+  ApproveArgs
 } from '../requestSchemas';
 import { Service } from '../types/service';
 import {
@@ -231,29 +233,113 @@ export class LibraryService implements Service<CRMIShareableLibrary> {
 
     const parsedParams = parseRequestSchema({ ...params, ...query }, CloneArgs);
 
-    const activeLibrary = await findResourceById<CRMIShareableLibrary>(parsedParams.id, 'Library');
-    if (!activeLibrary) {
-      throw new ResourceNotFoundError(`No resource found in collection: Library, with id: ${args.id}`);
+    const library = await findResourceById<CRMIShareableLibrary>(parsedParams.id, 'Library');
+    if (!library) {
+      throw new ResourceNotFoundError(`No resource found in collection: Library, with id: ${parsedParams.id}`);
     }
-    activeLibrary.url = parsedParams.url;
-    checkIsOwned(activeLibrary, 'Child artifacts cannot be directly cloned.');
+    library.url = parsedParams.url;
+    checkIsOwned(library, 'Child artifacts cannot be directly cloned.');
 
     // recursively get any child artifacts from the artifact if they exist
-    const children = activeLibrary.relatedArtifact ? await getChildren(activeLibrary.relatedArtifact) : [];
+    const children = library.relatedArtifact ? await getChildren(library.relatedArtifact) : [];
     children.forEach(child => {
       child.url = child.url + '-clone';
     });
 
-    const clonedArtifacts = await modifyResourcesForClone(
-      [activeLibrary, ...(await Promise.all(children))],
-      params.version
-    );
+    const clonedArtifacts = await modifyResourcesForClone([library, ...(await Promise.all(children))], params.version);
 
     // now we want to batch insert the cloned parent Library artifact and any of its children
     const newClones = await batchInsert(clonedArtifacts, 'clone');
 
     // we want to return a Bundle containing the created artifacts
     return createBatchResponseBundle(newClones);
+  }
+
+  /**
+   * result of sending a POST or GET request to:
+   * {BASE_URL}/4_0_1/Library/$approve or {BASE_URL}/4_0_1/Library/[id]/$approve
+   * applies an approval to an existing artifact, regardless of status, and sets the
+   * date and approvalDate elements of the approved artifact as well as for all resources
+   * it is composed of
+   */
+  async approve(args: RequestArgs, { req }: RequestCtx) {
+    logger.info(`${req.method} ${req.path}`);
+
+    // checks that the authoring environment variable is true
+    checkAuthoring();
+
+    if (req.method === 'POST') {
+      const contentType: string | undefined = req.headers['content-type'];
+      checkContentTypeHeader(contentType);
+    }
+
+    const params = gatherParams(req.query, args.resource);
+    validateParamIdSource(req.params.id, params.id);
+
+    const query = extractIdentificationForQuery(args, params);
+
+    const parsedParams = parseRequestSchema({ ...params, ...query }, ApproveArgs);
+
+    const library = await findResourceById<CRMIShareableLibrary>(parsedParams.id, 'Library');
+    if (!library) {
+      throw new ResourceNotFoundError(`No resource found in collection: Library, with id: ${parsedParams.id}`);
+    }
+    if (parsedParams.artifactAssessmentType && parsedParams.artifactAssessmentSummary) {
+      const approveExtension: fhir4.Extension[] = [];
+      approveExtension.push(
+        { url: 'type', valueCode: parsedParams.artifactAssessmentType },
+        { url: 'text', valueMarkdown: parsedParams.artifactAssessmentSummary }
+      );
+      if (library.extension) {
+        library.extension.push({
+          extension: approveExtension,
+          url: 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-artifactComment'
+        });
+      } else {
+        library.extension = [
+          {
+            extension: approveExtension,
+            url: 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-artifactComment'
+          }
+        ];
+      }
+    }
+    library.date = new Date().toISOString();
+    library.approvalDate = new Date().toISOString();
+    checkIsOwned(library, 'Child artifacts cannot be directly approved.');
+
+    // recursively get any child artifacts form the artifact if they exist
+    const children = library.relatedArtifact ? await getChildren(library.relatedArtifact) : [];
+    children.forEach(child => {
+      if (parsedParams.artifactAssessmentType && parsedParams.artifactAssessmentSummary) {
+        const approveExtension: fhir4.Extension[] = [];
+        approveExtension.push(
+          { url: 'type', valueCode: parsedParams.artifactAssessmentType },
+          { url: 'text', valueMarkdown: parsedParams.artifactAssessmentSummary }
+        );
+        if (child.extension) {
+          child.extension.push({
+            extension: approveExtension,
+            url: 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-artifactComment'
+          });
+        } else {
+          child.extension = [
+            {
+              extension: approveExtension,
+              url: 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-artifactComment'
+            }
+          ];
+        }
+      }
+      child.date = new Date().toISOString();
+      child.approvalDate = new Date().toISOString();
+    });
+
+    // now we want to batch update the approved parent Library and any of its children
+    const approvedArtifacts = await batchUpdate([library, ...(await Promise.all(children))]);
+
+    // we want to return a Bundle containing the updated artifacts
+    return createBatchResponseBundle(approvedArtifacts);
   }
 
   /**

--- a/service/src/services/LibraryService.ts
+++ b/service/src/services/LibraryService.ts
@@ -305,7 +305,7 @@ export class LibraryService implements Service<CRMIShareableLibrary> {
       }
     }
     library.date = new Date().toISOString();
-    library.approvalDate = new Date().toISOString();
+    library.approvalDate = parsedParams.approvalDate ?? new Date().toISOString();
     checkIsOwned(library, 'Child artifacts cannot be directly approved.');
 
     // recursively get any child artifacts form the artifact if they exist
@@ -332,7 +332,7 @@ export class LibraryService implements Service<CRMIShareableLibrary> {
         }
       }
       child.date = new Date().toISOString();
-      child.approvalDate = new Date().toISOString();
+      child.approvalDate = parsedParams.approvalDate ?? new Date().toISOString();
     });
 
     // now we want to batch update the approved parent Library and any of its children

--- a/service/src/services/MeasureService.ts
+++ b/service/src/services/MeasureService.ts
@@ -293,6 +293,17 @@ export class MeasureService implements Service<CRMIShareableMeasure> {
         { url: 'type', valueCode: parsedParams.artifactAssessmentType },
         { url: 'text', valueMarkdown: parsedParams.artifactAssessmentSummary }
       );
+
+      if (parsedParams.artifactAssessmentTarget) {
+        approveExtension.push({ url: 'target', valueUri: parsedParams.artifactAssessmentTarget });
+      }
+      if (parsedParams.artifactAssessmentRelatedArtifact) {
+        approveExtension.push({ url: 'reference', valueUri: parsedParams.artifactAssessmentRelatedArtifact });
+      }
+      if (parsedParams.artifactAssessmentAuthor) {
+        approveExtension.push({ url: 'user', valueString: parsedParams.artifactAssessmentAuthor.reference });
+      }
+
       if (measure.extension) {
         measure.extension.push({
           extension: approveExtension,
@@ -320,6 +331,17 @@ export class MeasureService implements Service<CRMIShareableMeasure> {
           { url: 'type', valueCode: parsedParams.artifactAssessmentType },
           { url: 'text', valueMarkdown: parsedParams.artifactAssessmentSummary }
         );
+
+        if (parsedParams.artifactAssessmentTarget) {
+          approveExtension.push({ url: 'target', valueUri: parsedParams.artifactAssessmentTarget });
+        }
+        if (parsedParams.artifactAssessmentRelatedArtifact) {
+          approveExtension.push({ url: 'reference', valueUri: parsedParams.artifactAssessmentRelatedArtifact });
+        }
+        if (parsedParams.artifactAssessmentAuthor) {
+          approveExtension.push({ url: 'user', valueString: parsedParams.artifactAssessmentAuthor.reference });
+        }
+
         if (child.extension) {
           child.extension.push({
             extension: approveExtension,

--- a/service/src/services/MeasureService.ts
+++ b/service/src/services/MeasureService.ts
@@ -262,7 +262,8 @@ export class MeasureService implements Service<CRMIShareableMeasure> {
    * {BASE_URL}/4_0_1/Measure/$approve or {BASE_URL}/4_0_1/Measure/[id]/$approve
    * applies an approval to an existing artifact, regardless of status, and sets the
    * date and approvalDate elements of the approved artifact as well as for all resources
-   * it is composed of
+   * it is composed of. The user can optionally provide an artifactAssessmentType and an
+   * artifactAssessmentSummary for an cqfm-artifactComment extension.
    */
   async approve(args: RequestArgs, { req }: RequestCtx) {
     logger.info(`${req.method} ${req.path}`);

--- a/service/src/services/MeasureService.ts
+++ b/service/src/services/MeasureService.ts
@@ -339,7 +339,7 @@ export class MeasureService implements Service<CRMIShareableMeasure> {
     });
 
     // now we want to batch update the approved parent Measure and any of its children
-    const approvedArtifacts = await batchUpdate([measure, ...(await Promise.all(children))]);
+    const approvedArtifacts = await batchUpdate([measure, ...(await Promise.all(children))], 'approve');
 
     // we want to return a Bundle containing the updated artifacts
     return createBatchResponseBundle(approvedArtifacts);

--- a/service/src/services/MeasureService.ts
+++ b/service/src/services/MeasureService.ts
@@ -1,6 +1,7 @@
 import { loggers, RequestArgs, RequestCtx } from '@projecttacoma/node-fhir-server-core';
 import {
   batchInsert,
+  batchUpdate,
   createResource,
   deleteResource,
   findDataRequirementsWithQuery,
@@ -38,7 +39,8 @@ import {
   PackageArgs,
   parseRequestSchema,
   DraftArgs,
-  CloneArgs
+  CloneArgs,
+  ApproveArgs
 } from '../requestSchemas';
 import { v4 as uuidv4 } from 'uuid';
 import { Filter } from 'mongodb';
@@ -233,26 +235,113 @@ export class MeasureService implements Service<CRMIShareableMeasure> {
 
     const parsedParams = parseRequestSchema({ ...params, ...query }, CloneArgs);
 
-    const activeMeasure = await findResourceById<CRMIShareableMeasure>(parsedParams.id, 'Measure');
-    if (!activeMeasure) {
+    const measure = await findResourceById<CRMIShareableMeasure>(parsedParams.id, 'Measure');
+    if (!measure) {
       throw new ResourceNotFoundError(`No resource found in collection: Measure, with id: ${args.id}`);
     }
-    activeMeasure.url = parsedParams.url;
-    checkIsOwned(activeMeasure, 'Child artifacts cannot be directly cloned.');
+    measure.url = parsedParams.url;
+    checkIsOwned(measure, 'Child artifacts cannot be directly cloned.');
 
     // recursively get any child artifacts from the artifact if they exist
-    const children = activeMeasure.relatedArtifact ? await getChildren(activeMeasure.relatedArtifact) : [];
+    const children = measure.relatedArtifact ? await getChildren(measure.relatedArtifact) : [];
     children.forEach(child => {
       child.url = child.url + '-clone';
     });
 
-    const clonedArtifacts = await modifyResourcesForClone([activeMeasure, ...children], parsedParams.version);
+    const clonedArtifacts = await modifyResourcesForClone([measure, ...children], parsedParams.version);
 
     // now we want to batch insert the cloned parent Measure artifact and any of its children
     const newClones = await batchInsert(clonedArtifacts, 'clone');
 
     // we want to return a Bundle containing the created artifacts
     return createBatchResponseBundle(newClones);
+  }
+
+  /**
+   * result of sending a POST or GET request to:
+   * {BASE_URL}/4_0_1/Measure/$approve or {BASE_URL}/4_0_1/Measure/[id]/$approve
+   * applies an approval to an existing artifact, regardless of status, and sets the
+   * date and approvalDate elements of the approved artifact as well as for all resources
+   * it is composed of
+   */
+  async approve(args: RequestArgs, { req }: RequestCtx) {
+    logger.info(`${req.method} ${req.path}`);
+
+    // checks that the authoring environment variable is true
+    checkAuthoring();
+
+    if (req.method === 'POST') {
+      const contentType: string | undefined = req.headers['content-type'];
+      checkContentTypeHeader(contentType);
+    }
+
+    const params = gatherParams(req.query, args.resource);
+    validateParamIdSource(req.params.id, params.id);
+
+    const query = extractIdentificationForQuery(args, params);
+
+    const parsedParams = parseRequestSchema({ ...params, ...query }, ApproveArgs);
+
+    const measure = await findResourceById<CRMIShareableMeasure>(parsedParams.id, 'Measure');
+    if (!measure) {
+      throw new ResourceNotFoundError(`No resource found in collection: Measure, with id: ${parsedParams.id}`);
+    }
+    if (parsedParams.artifactAssessmentType && parsedParams.artifactAssessmentSummary) {
+      const approveExtension: fhir4.Extension[] = [];
+      approveExtension.push(
+        { url: 'type', valueCode: parsedParams.artifactAssessmentType },
+        { url: 'text', valueMarkdown: parsedParams.artifactAssessmentSummary }
+      );
+      if (measure.extension) {
+        measure.extension.push({
+          extension: approveExtension,
+          url: 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-artifactComment'
+        });
+      } else {
+        measure.extension = [
+          {
+            extension: approveExtension,
+            url: 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-artifactComment'
+          }
+        ];
+      }
+    }
+    measure.date = new Date().toISOString();
+    measure.approvalDate = parsedParams.approvalDate ?? new Date().toISOString();
+    checkIsOwned(measure, 'Child artifacts cannot be directly approved.');
+
+    // recursively get any child artifacts from the artifact if they exist
+    const children = measure.relatedArtifact ? await getChildren(measure.relatedArtifact) : [];
+    children.forEach(child => {
+      if (parsedParams.artifactAssessmentType && parsedParams.artifactAssessmentSummary) {
+        const approveExtension: fhir4.Extension[] = [];
+        approveExtension.push(
+          { url: 'type', valueCode: parsedParams.artifactAssessmentType },
+          { url: 'text', valueMarkdown: parsedParams.artifactAssessmentSummary }
+        );
+        if (child.extension) {
+          child.extension.push({
+            extension: approveExtension,
+            url: 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-artifactComment'
+          });
+        } else {
+          child.extension = [
+            {
+              extension: approveExtension,
+              url: 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-artifactComment'
+            }
+          ];
+        }
+      }
+      child.date = new Date().toISOString();
+      child.approvalDate = parsedParams.approvalDate ?? new Date().toISOString();
+    });
+
+    // now we want to batch update the approved parent Measure and any of its children
+    const approvedArtifacts = await batchUpdate([measure, ...(await Promise.all(children))]);
+
+    // we want to return a Bundle containing the updated artifacts
+    return createBatchResponseBundle(approvedArtifacts);
   }
 
   /**

--- a/service/src/util/inputUtils.ts
+++ b/service/src/util/inputUtils.ts
@@ -21,6 +21,7 @@ export function gatherParams(query: RequestQuery, parameters?: fhir4.Parameters)
           bodyParam.valueCanonical ||
           bodyParam.valueDate ||
           bodyParam.valueCode ||
+          bodyParam.valueReference ||
           bodyParam.valueBoolean;
       }
       return params;

--- a/service/src/util/inputUtils.ts
+++ b/service/src/util/inputUtils.ts
@@ -20,6 +20,7 @@ export function gatherParams(query: RequestQuery, parameters?: fhir4.Parameters)
           bodyParam.valueInteger ||
           bodyParam.valueCanonical ||
           bodyParam.valueDate ||
+          bodyParam.valueCode ||
           bodyParam.valueBoolean;
       }
       return params;

--- a/service/src/util/serviceUtils.ts
+++ b/service/src/util/serviceUtils.ts
@@ -106,3 +106,29 @@ export async function modifyResourcesForClone(artifacts: FhirArtifact[], version
 
   return artifacts;
 }
+
+export function createArtifactComment(
+  type: string,
+  summary: string,
+  target: string | undefined,
+  relatedArtifact: string | undefined,
+  reference: string | undefined
+) {
+  const approveExtension: fhir4.Extension[] = [];
+  approveExtension.push({ url: 'type', valueCode: type }, { url: 'text', valueMarkdown: summary });
+
+  if (target) {
+    approveExtension.push({ url: 'target', valueUri: target });
+  }
+  if (relatedArtifact) {
+    approveExtension.push({ url: 'reference', valueUri: relatedArtifact });
+  }
+  if (reference) {
+    approveExtension.push({ url: 'user', valueString: reference });
+  }
+
+  return {
+    extension: approveExtension,
+    url: 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-artifactComment'
+  };
+}

--- a/service/src/util/serviceUtils.ts
+++ b/service/src/util/serviceUtils.ts
@@ -107,8 +107,12 @@ export async function modifyResourcesForClone(artifacts: FhirArtifact[], version
   return artifacts;
 }
 
+/**
+ * Helper function that takes any artifactAssessment input parameters and adds
+ * them to a cqfm-artifactComment extension
+ */
 export function createArtifactComment(
-  type: string,
+  type: 'guidance' | 'review' | 'documentation',
   summary: string,
   target: string | undefined,
   relatedArtifact: string | undefined,

--- a/service/test/services/LibraryService.test.ts
+++ b/service/test/services/LibraryService.test.ts
@@ -1085,13 +1085,20 @@ describe('LibraryService', () => {
     it('returns 200 status with a Bundle result containing the updated parent Library artifact and any children it has for GET /Library/$approve', async () => {
       await supertest(server.app)
         .get('/4_0_1/Library/$approve')
-        .query({ id: 'approve-child1' })
+        .query({
+          id: 'approve-child1',
+          artifactAssessmentType: 'guidance',
+          artifactAssessmentSummary: 'Sample summary',
+          artifactAssessmentAuthor: { reference: 'Sample Author' }
+        })
         .set('Accept', 'application/json+fhir')
         .expect(200)
         .then(response => {
           expect(response.body.total).toEqual(2);
           expect(response.body.entry[0].resource.date).toBeDefined();
+          expect(response.body.entry[0].resource.extension[0].extension[2].valueString).toEqual('Sample Author');
           expect(response.body.entry[1].resource.date).toBeDefined();
+          expect(response.body.entry[1].resource.extension[1].extension[2].valueString).toEqual('Sample Author');
         });
     });
 

--- a/service/test/services/LibraryService.test.ts
+++ b/service/test/services/LibraryService.test.ts
@@ -1115,7 +1115,8 @@ describe('LibraryService', () => {
           parameter: [
             { name: 'id', valueString: 'approve-child1' },
             { name: 'artifactAssessmentType', valueCode: 'documentation' },
-            { name: 'artifactAssessmentSummary', valueString: 'Hello' }
+            { name: 'artifactAssessmentSummary', valueString: 'Hello' },
+            { name: 'approvalDate', valueDate: '2024-08-14T17:29:34.344Z' }
           ]
         })
         .set('content-type', 'application/fhir+json')
@@ -1126,10 +1127,12 @@ describe('LibraryService', () => {
           expect(response.body.entry[0].resource.extension[0].url).toEqual(
             'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-artifactComment'
           );
+          expect(response.body.entry[0].resource.approvalDate).toEqual('2024-08-14T17:29:34.344Z');
           expect(response.body.entry[1].resource.date).toBeDefined();
           expect(response.body.entry[1].resource.extension[1].url).toEqual(
             'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-artifactComment'
           );
+          expect(response.body.entry[1].resource.approvalDate).toEqual('2024-08-14T17:29:34.344Z');
         });
     });
 

--- a/service/test/services/MeasureService.test.ts
+++ b/service/test/services/MeasureService.test.ts
@@ -1098,14 +1098,22 @@ describe('MeasureService', () => {
     it('returns 200 status with a Bundle result containing the updated parent Measure artifact and any children it has for GET /Measure/$approve', async () => {
       await supertest(server.app)
         .get('/4_0_1/Measure/$approve')
-        .query({ id: 'approve-parent' })
+        .query({
+          id: 'approve-parent',
+          artifactAssessmentType: 'guidance',
+          artifactAssessmentSummary: 'Sample summary',
+          artifactAssessmentAuthor: { reference: 'Sample Author' }
+        })
         .set('Accept', 'application/json+fhir')
         .expect(200)
         .then(response => {
           expect(response.body.total).toEqual(3);
           expect(response.body.entry[0].resource.date).toBeDefined();
+          expect(response.body.entry[0].resource.extension[0].extension[2].valueString).toEqual('Sample Author');
           expect(response.body.entry[1].resource.date).toBeDefined();
+          expect(response.body.entry[1].resource.extension[1].extension[2].valueString).toEqual('Sample Author');
           expect(response.body.entry[2].resource.date).toBeDefined();
+          expect(response.body.entry[2].resource.extension[1].extension[2].valueString).toEqual('Sample Author');
         });
     });
 

--- a/service/test/services/MeasureService.test.ts
+++ b/service/test/services/MeasureService.test.ts
@@ -1023,6 +1023,166 @@ describe('MeasureService', () => {
     });
   });
 
+  describe('$approve', () => {
+    beforeEach(() => {
+      createTestResource(
+        {
+          resourceType: 'Measure',
+          id: 'approve-parent',
+          url: 'http://example.com/approve-parent',
+          status: 'active',
+          relatedArtifact: [
+            {
+              type: 'composed-of',
+              resource: 'http://example.com/approve-child1|1',
+              extension: [
+                {
+                  url: 'http://hl7.org/fhir/StructureDefinition/artifact-isOwned',
+                  valueBoolean: true
+                }
+              ]
+            }
+          ],
+          version: '1',
+          description: 'Example description',
+          title: 'Parent Active Measure'
+        },
+        'Measure'
+      );
+      createTestResource(
+        {
+          resourceType: 'Library',
+          id: 'approve-child1',
+          url: 'http://example.com/approve-child1',
+          status: 'active',
+          extension: [
+            {
+              url: 'http://hl7.org/fhir/StructureDefinition/artifact-isOwned',
+              valueBoolean: true
+            }
+          ],
+          relatedArtifact: [
+            {
+              type: 'composed-of',
+              resource: 'http://example.com/approve-child2|1',
+              extension: [
+                {
+                  url: 'http://hl7.org/fhir/StructureDefinition/artifact-isOwned',
+                  valueBoolean: true
+                }
+              ]
+            }
+          ],
+          ...LIBRARY_BASE
+        },
+        'Library'
+      );
+      return createTestResource(
+        {
+          resourceType: 'Library',
+          id: 'approve-child2',
+          url: 'http://example.com/approve-child2',
+          status: 'active',
+          extension: [
+            {
+              url: 'http://hl7.org/fhir/StructureDefinition/artifact-isOwned',
+              valueBoolean: true
+            }
+          ],
+          ...LIBRARY_BASE
+        },
+        'Library'
+      );
+    });
+
+    it('returns 200 status with a Bundle result containing the updated parent Measure artifact and any children it has for GET /Measure/$approve', async () => {
+      await supertest(server.app)
+        .get('/4_0_1/Measure/$approve')
+        .query({ id: 'approve-parent' })
+        .set('Accept', 'application/json+fhir')
+        .expect(200)
+        .then(response => {
+          expect(response.body.total).toEqual(3);
+          expect(response.body.entry[0].resource.date).toBeDefined();
+          expect(response.body.entry[1].resource.date).toBeDefined();
+          expect(response.body.entry[2].resource.date).toBeDefined();
+        });
+    });
+
+    it('returns 200 status with a Bundle result containing the updated parent Measure artifact and any children it has for GET /Measure/[id]/$approve', async () => {
+      await supertest(server.app)
+        .get('/4_0_1/Measure/approve-parent/$approve')
+        .set('Accept', 'application/json+fhir')
+        .expect(200)
+        .then(response => {
+          expect(response.body.total).toEqual(3);
+          expect(response.body.entry[0].resource.date).toBeDefined();
+          expect(response.body.entry[1].resource.date).toBeDefined();
+          expect(response.body.entry[2].resource.date).toBeDefined();
+        });
+    });
+
+    it('returns 200 status with a Bundle result containing the updated parent Measure artifact and any children it has for POST /Measure/[id]/$approve', async () => {
+      await supertest(server.app)
+        .post('/4_0_1/Measure/$approve')
+        .send({
+          resourceType: 'Parameters',
+          parameter: [{ name: 'id', valueString: 'approve-parent' }]
+        })
+        .set('content-type', 'application/fhir+json')
+        .expect(200)
+        .then(response => {
+          expect(response.body.total).toEqual(3);
+          expect(response.body.entry[0].resource.date).toBeDefined();
+          expect(response.body.entry[1].resource.date).toBeDefined();
+          expect(response.body.entry[2].resource.date).toBeDefined();
+        });
+    });
+
+    it('returns 200 status with a Bundle result containing the updated parent Measure artifact and any children it has for POST /Measure/$approve with cqf-artifactComment extension', async () => {
+      await supertest(server.app)
+        .post('/4_0_1/Measure/$approve')
+        .send({
+          resourceType: 'Parameters',
+          parameter: [
+            { name: 'id', valueString: 'approve-parent' },
+            { name: 'artifactAssessmentType', valueCode: 'documentation' },
+            { name: 'artifactAssessmentSummary', valueString: 'Hello' }
+          ]
+        })
+        .set('content-type', 'application/fhir+json')
+        .expect(200)
+        .then(response => {
+          expect(response.body.total).toEqual(3);
+          expect(response.body.entry[0].resource.date).toBeDefined();
+          expect(response.body.entry[0].resource.extension[0].url).toEqual(
+            'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-artifactComment'
+          );
+          expect(response.body.entry[1].resource.date).toBeDefined();
+          expect(response.body.entry[1].resource.extension[1].url).toEqual(
+            'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-artifactComment'
+          );
+          expect(response.body.entry[2].resource.date).toBeDefined();
+          expect(response.body.entry[2].resource.extension[1].url).toEqual(
+            'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-artifactComment'
+          );
+        });
+    });
+
+    it('returns 200 status with a Bundle result containing the updated parent Measure artifact and any children it has for POST /Measure/[id]/$approve', async () => {
+      await supertest(server.app)
+        .post('/4_0_1/Measure/approve-parent/$approve')
+        .set('content-type', 'application/fhir+json')
+        .expect(200)
+        .then(response => {
+          expect(response.body.total).toEqual(3);
+          expect(response.body.entry[0].resource.date).toBeDefined();
+          expect(response.body.entry[1].resource.date).toBeDefined();
+          expect(response.body.entry[2].resource.date).toBeDefined();
+        });
+    });
+  });
+
   afterAll(() => {
     return cleanUpTestDatabase();
   });

--- a/service/test/services/MeasureService.test.ts
+++ b/service/test/services/MeasureService.test.ts
@@ -1147,7 +1147,8 @@ describe('MeasureService', () => {
           parameter: [
             { name: 'id', valueString: 'approve-parent' },
             { name: 'artifactAssessmentType', valueCode: 'documentation' },
-            { name: 'artifactAssessmentSummary', valueString: 'Hello' }
+            { name: 'artifactAssessmentSummary', valueString: 'Hello' },
+            { name: 'approvalDate', valueDate: '2024-08-14T17:29:34.344Z' }
           ]
         })
         .set('content-type', 'application/fhir+json')
@@ -1158,14 +1159,17 @@ describe('MeasureService', () => {
           expect(response.body.entry[0].resource.extension[0].url).toEqual(
             'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-artifactComment'
           );
+          expect(response.body.entry[0].resource.approvalDate).toEqual('2024-08-14T17:29:34.344Z');
           expect(response.body.entry[1].resource.date).toBeDefined();
           expect(response.body.entry[1].resource.extension[1].url).toEqual(
             'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-artifactComment'
           );
+          expect(response.body.entry[1].resource.approvalDate).toEqual('2024-08-14T17:29:34.344Z');
           expect(response.body.entry[2].resource.date).toBeDefined();
           expect(response.body.entry[2].resource.extension[1].url).toEqual(
             'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-artifactComment'
           );
+          expect(response.body.entry[2].resource.approvalDate).toEqual('2024-08-14T17:29:34.344Z');
         });
     });
 


### PR DESCRIPTION
# Summary
This PR exposes the $approve operation as an endpoint on the server. This functionality is defined in the CRMI IG [here](https://hl7.org/fhir/uv/crmi/OperationDefinition-crmi-approve.html).

## New behavior
The user can now approve a Measure or Library artifact and any resources it is composed of regardless of status by sending a GET or POST request to `Measure/$approve`, `Measure/:id/$approve`, `Library/$approve` and `Library/:id/$approve`. This operation takes three optional parameters: `approvalDate`, `artifactAssessmentType`, and `artifactAssessmentSummary`. If `artifactAssessmentType` and `artifactAssessmentSummary` are both provided, then a [cqf-artifactComment](https://hl7.org/fhir/extensions/5.1.0/StructureDefinition-cqf-artifactComment.html) extension will be added to the artifact and any of its children. If `approvalDate` is provided, the `approvalDate` is set, if not, it is set to the system. The `date` is also set to the system date. Since this is only an operation supported in an Authoring Artifact Repository, the `AUTHORING` environment variable must be set to true.

## Code changes
- `service/README.md` - add description of `$approve`
- `service/src/config/capabilityStatementResources.json` - add crmi-approve
- `service/src/config/serverConfig.ts` - add `approve` endpoints
- `service/src/db/dbOperations.ts` - add `batchUpdate` function
- `service/src/requestSchemas` - add id and type and summary checks and ApproveArgs for type checking
- `service/src/services/LibraryService.ts` / `service/src/services/MeasureService.ts` - add `approve` function
- `service/src/util/inputUtils.ts` - add `valueCode` to `gatherParams`
- `service/test/services/LibraryService.test.ts` / `service/test/services/MeasureService.test.ts` - added unit tests 

# Testing guidance
- `npm run build:all`
- `npm run check:all`
- In `service`, reset the database (`npm run db:reset`) and test with the nested child artifact bundle I made and may connectathon bundles (attached example Insomnia requests are for use with the created nested artifact bundle
- `npm run start:all`
- Go through example Insomnia requests. Make sure `date` and `approvalDate` are changed/added, `extension` is added if `artifactAssessmentSummary` AND `artifactAssessmentType` are included as input parameters, etc.

[approve-testing.json](https://github.com/user-attachments/files/16626948/approve-testing.json)
