### PR TITLE
Expose review

### DIFF
--- a/service/README.md
+++ b/service/README.md
@@ -202,6 +202,21 @@ And takes the following optional parameters:
 - artifactAssessmentRelatedArtifact
 - artifactAssessmentAuthor
 
+### Review
+
+The Measure Repository Service Authoring Repository Service server supports the `Measure` and `Library` `$review` operations as defined by the [Canonical Resource Management Infrastructure IG](https://hl7.org/fhir/uv/crmi/OperationDefinition-crmi-review.html). It requires the following parameters:
+
+- id
+
+And takes the following optional parameters:
+
+- reviewDate
+- artifactAssessmentType (must be included with any other artifactAssessment parameters, if provided)
+- artifactAssessmentSummary (must be included with any other artifactAssessment parameters, if provided)
+- artifactAssessmentTarget
+- artifactAssessmentRelatedArtifact
+- artifactAssessmentAuthor
+
 ## License
 
 Copyright 2022-2023 The MITRE Corporation

--- a/service/src/config/capabilityStatementResources.json
+++ b/service/src/config/capabilityStatementResources.json
@@ -192,6 +192,16 @@
           ],
           "name": "approve",
           "definition": "http://hl7.org/fhir/uv/crmi/OperationDefinition/crmi-approve"
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHALL"
+            }
+          ],
+          "name": "review",
+          "definition": "http://hl7.org/fhir/uv/crmi/OperationDefinition/crmi-review"
         }
       ]
     },
@@ -380,6 +390,16 @@
           ],
           "name": "approve",
           "definition": "http://hl7.org/fhir/uv/crmi/OperationDefinition/crmi-approve"
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHALL"
+            }
+          ],
+          "name": "review",
+          "definition": "http://hl7.org/fhir/uv/crmi/OperationDefinition/crmi-review"
         }
       ]
     }

--- a/service/src/config/serverConfig.ts
+++ b/service/src/config/serverConfig.ts
@@ -157,6 +157,30 @@ export const serverConfig: ServerConfig = {
           route: '/:id/$approve',
           method: 'POST',
           reference: 'https://hl7.org/fhir/uv/crmi/STU1/OperationDefinition-crmi-approve.html'
+        },
+        {
+          name: 'review',
+          route: '/$review',
+          method: 'GET',
+          reference: 'https://hl7.org/fhir/uv/crmi/STU1/OperationDefinition-crmi-review.html'
+        },
+        {
+          name: 'review',
+          route: '/$review',
+          method: 'POST',
+          reference: 'https://hl7.org/fhir/uv/crmi/STU1/OperationDefinition-crmi-review.html'
+        },
+        {
+          name: 'review',
+          route: '/:id/$review',
+          method: 'GET',
+          reference: 'https://hl7.org/fhir/uv/crmi/STU1/OperationDefinition-crmi-review.html'
+        },
+        {
+          name: 'review',
+          route: '/:id/$review',
+          method: 'POST',
+          reference: 'https://hl7.org/fhir/uv/crmi/STU1/OperationDefinition-crmi-review.html'
         }
       ]
     },
@@ -283,6 +307,30 @@ export const serverConfig: ServerConfig = {
           route: '/:id/$approve',
           method: 'POST',
           reference: 'https://hl7.org/fhir/uv/crmi/STU1/OperationDefinition-crmi-approve.html'
+        },
+        {
+          name: 'review',
+          route: '/$review',
+          method: 'GET',
+          reference: 'https://hl7.org/fhir/uv/crmi/STU1/OperationDefinition-crmi-review.html'
+        },
+        {
+          name: 'review',
+          route: '/$review',
+          method: 'POST',
+          reference: 'https://hl7.org/fhir/uv/crmi/STU1/OperationDefinition-crmi-review.html'
+        },
+        {
+          name: 'review',
+          route: '/:id/$review',
+          method: 'GET',
+          reference: 'https://hl7.org/fhir/uv/crmi/STU1/OperationDefinition-crmi-review.html'
+        },
+        {
+          name: 'review',
+          route: '/:id/$review',
+          method: 'POST',
+          reference: 'https://hl7.org/fhir/uv/crmi/STU1/OperationDefinition-crmi-review.html'
         }
       ]
     }

--- a/service/src/requestSchemas.ts
+++ b/service/src/requestSchemas.ts
@@ -210,6 +210,18 @@ export const ApproveArgs = z
   .strict()
   .superRefine(catchInvalidParams([catchMissingId, catchMissingTypeAndSummary]));
 
+export const ReviewArgs = z
+  .object({
+    id: z.string(),
+    reviewDate: checkDate.optional(),
+    artifactAssessmentType: z
+      .union([z.literal('documentation'), z.literal('guidance'), z.literal('review')])
+      .optional(),
+    artifactAssessmentSummary: z.string().optional()
+  })
+  .strict()
+  .superRefine(catchInvalidParams([catchMissingId, catchMissingTypeAndSummary]));
+
 export const IdentifyingParameters = z
   .object({
     id: z.string(),

--- a/service/src/requestSchemas.ts
+++ b/service/src/requestSchemas.ts
@@ -217,7 +217,10 @@ export const ReviewArgs = z
     artifactAssessmentType: z
       .union([z.literal('documentation'), z.literal('guidance'), z.literal('review')])
       .optional(),
-    artifactAssessmentSummary: z.string().optional()
+    artifactAssessmentSummary: z.string().optional(),
+    artifactAssessmentTarget: checkUri.optional(),
+    artifactAssessmentRelatedArtifact: checkUri.optional(),
+    artifactAssessmentAuthor: z.object({ reference: z.string() }).optional()
   })
   .strict()
   .superRefine(catchInvalidParams([catchMissingId, catchMissingTypeAndSummary]));

--- a/service/src/services/LibraryService.ts
+++ b/service/src/services/LibraryService.ts
@@ -337,7 +337,7 @@ export class LibraryService implements Service<CRMIShareableLibrary> {
     return createBatchResponseBundle(approvedArtifacts);
   }
 
-    /**
+  /**
    * result of sending a POST or GET request to:
    * {BASE_URL}/4_0_1/Library/$review or {BASE_URL}/4_0_1/Library/[id]/$review
    * applies a review to an existing artifact, regardless of status, and sets the
@@ -345,85 +345,73 @@ export class LibraryService implements Service<CRMIShareableLibrary> {
    * it is composed of. The user can optionally provide an artifactAssessmentType and an
    * artifactAssessmentSummary for an cqfm-artifactComment extension.
    */
-    async review(args: RequestArgs, { req }: RequestCtx) {
-      logger.info(`${req.method} ${req.path}`);
-  
-      // checks that the authoring environment variable is true
-      checkAuthoring();
-  
-      if (req.method === 'POST') {
-        const contentType: string | undefined = req.headers['content-type'];
-        checkContentTypeHeader(contentType);
-      }
-  
-      const params = gatherParams(req.query, args.resource);
-      validateParamIdSource(req.params.id, params.id);
-  
-      const query = extractIdentificationForQuery(args, params);
-  
-      const parsedParams = parseRequestSchema({ ...params, ...query }, ReviewArgs);
-  
-      const library = await findResourceById<CRMIShareableLibrary>(parsedParams.id, 'Library');
-      if (!library) {
-        throw new ResourceNotFoundError(`No resource found in collection: Library, with id: ${parsedParams.id}`);
-      }
-      if (parsedParams.artifactAssessmentType && parsedParams.artifactAssessmentSummary) {
-        const reviewExtension: fhir4.Extension[] = [];
-        reviewExtension.push(
-          { url: 'type', valueCode: parsedParams.artifactAssessmentType },
-          { url: 'text', valueMarkdown: parsedParams.artifactAssessmentSummary }
-        );
-        if (library.extension) {
-          library.extension.push({
-            extension: reviewExtension,
-            url: 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-artifactComment'
-          });
-        } else {
-          library.extension = [
-            {
-              extension: reviewExtension,
-              url: 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-artifactComment'
-            }
-          ];
-        }
-      }
-      library.date = new Date().toISOString();
-      library.lastReviewDate = parsedParams.reviewDate ?? new Date().toISOString();
-      checkIsOwned(library, 'Child artifacts cannot be directly reviewed.');
-  
-      // recursively get any child artifacts form the artifact if they exist
-      const children = library.relatedArtifact ? await getChildren(library.relatedArtifact) : [];
-      children.forEach(child => {
-        if (parsedParams.artifactAssessmentType && parsedParams.artifactAssessmentSummary) {
-          const reviewExtension: fhir4.Extension[] = [];
-          reviewExtension.push(
-            { url: 'type', valueCode: parsedParams.artifactAssessmentType },
-            { url: 'text', valueMarkdown: parsedParams.artifactAssessmentSummary }
-          );
-          if (child.extension) {
-            child.extension.push({
-              extension: reviewExtension,
-              url: 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-artifactComment'
-            });
-          } else {
-            child.extension = [
-              {
-                extension: reviewExtension,
-                url: 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-artifactComment'
-              }
-            ];
-          }
-        }
-        child.date = new Date().toISOString();
-        child.lastReviewDate = parsedParams.reviewDate ?? new Date().toISOString();
-      });
-  
-      // now we want to batch update the reviewed parent Library and any of its children
-      const reviewedArtifacts = await batchUpdate([library, ...(await Promise.all(children))], 'review');
-  
-      // we want to return a Bundle containing the updated artifacts
-      return createBatchResponseBundle(reviewedArtifacts);
+  async review(args: RequestArgs, { req }: RequestCtx) {
+    logger.info(`${req.method} ${req.path}`);
+
+    // checks that the authoring environment variable is true
+    checkAuthoring();
+
+    if (req.method === 'POST') {
+      const contentType: string | undefined = req.headers['content-type'];
+      checkContentTypeHeader(contentType);
     }
+
+    const params = gatherParams(req.query, args.resource);
+    validateParamIdSource(req.params.id, params.id);
+
+    const query = extractIdentificationForQuery(args, params);
+
+    const parsedParams = parseRequestSchema({ ...params, ...query }, ReviewArgs);
+
+    const library = await findResourceById<CRMIShareableLibrary>(parsedParams.id, 'Library');
+    if (!library) {
+      throw new ResourceNotFoundError(`No resource found in collection: Library, with id: ${parsedParams.id}`);
+    }
+    if (parsedParams.artifactAssessmentType && parsedParams.artifactAssessmentSummary) {
+      const comment = createArtifactComment(
+        parsedParams.artifactAssessmentType,
+        parsedParams.artifactAssessmentSummary,
+        parsedParams.artifactAssessmentTarget,
+        parsedParams.artifactAssessmentRelatedArtifact,
+        parsedParams.artifactAssessmentAuthor?.reference
+      );
+      if (library.extension) {
+        library.extension.push(comment);
+      } else {
+        library.extension = [comment];
+      }
+    }
+    library.date = new Date().toISOString();
+    library.lastReviewDate = parsedParams.reviewDate ?? new Date().toISOString();
+    checkIsOwned(library, 'Child artifacts cannot be directly reviewed.');
+
+    // recursively get any child artifacts form the artifact if they exist
+    const children = library.relatedArtifact ? await getChildren(library.relatedArtifact) : [];
+    children.forEach(child => {
+      if (parsedParams.artifactAssessmentType && parsedParams.artifactAssessmentSummary) {
+        const comment = createArtifactComment(
+          parsedParams.artifactAssessmentType,
+          parsedParams.artifactAssessmentSummary,
+          parsedParams.artifactAssessmentTarget,
+          parsedParams.artifactAssessmentRelatedArtifact,
+          parsedParams.artifactAssessmentAuthor?.reference
+        );
+        if (child.extension) {
+          child.extension.push(comment);
+        } else {
+          child.extension = [comment];
+        }
+      }
+      child.date = new Date().toISOString();
+      child.lastReviewDate = parsedParams.reviewDate ?? new Date().toISOString();
+    });
+
+    // now we want to batch update the reviewed parent Library and any of its children
+    const reviewedArtifacts = await batchUpdate([library, ...(await Promise.all(children))], 'review');
+
+    // we want to return a Bundle containing the updated artifacts
+    return createBatchResponseBundle(reviewedArtifacts);
+  }
 
   /**
    * result of sending a POST or GET request to:

--- a/service/src/services/LibraryService.ts
+++ b/service/src/services/LibraryService.ts
@@ -18,7 +18,8 @@ import {
   parseRequestSchema,
   DraftArgs,
   CloneArgs,
-  ApproveArgs
+  ApproveArgs,
+  ReviewArgs
 } from '../requestSchemas';
 import { Service } from '../types/service';
 import {
@@ -335,6 +336,94 @@ export class LibraryService implements Service<CRMIShareableLibrary> {
     // we want to return a Bundle containing the updated artifacts
     return createBatchResponseBundle(approvedArtifacts);
   }
+
+    /**
+   * result of sending a POST or GET request to:
+   * {BASE_URL}/4_0_1/Library/$review or {BASE_URL}/4_0_1/Library/[id]/$review
+   * applies a review to an existing artifact, regardless of status, and sets the
+   * date and lastReviewedDate elements of the reviewed artifact as well as for all resources
+   * it is composed of. The user can optionally provide an artifactAssessmentType and an
+   * artifactAssessmentSummary for an cqfm-artifactComment extension.
+   */
+    async review(args: RequestArgs, { req }: RequestCtx) {
+      logger.info(`${req.method} ${req.path}`);
+  
+      // checks that the authoring environment variable is true
+      checkAuthoring();
+  
+      if (req.method === 'POST') {
+        const contentType: string | undefined = req.headers['content-type'];
+        checkContentTypeHeader(contentType);
+      }
+  
+      const params = gatherParams(req.query, args.resource);
+      validateParamIdSource(req.params.id, params.id);
+  
+      const query = extractIdentificationForQuery(args, params);
+  
+      const parsedParams = parseRequestSchema({ ...params, ...query }, ReviewArgs);
+  
+      const library = await findResourceById<CRMIShareableLibrary>(parsedParams.id, 'Library');
+      if (!library) {
+        throw new ResourceNotFoundError(`No resource found in collection: Library, with id: ${parsedParams.id}`);
+      }
+      if (parsedParams.artifactAssessmentType && parsedParams.artifactAssessmentSummary) {
+        const reviewExtension: fhir4.Extension[] = [];
+        reviewExtension.push(
+          { url: 'type', valueCode: parsedParams.artifactAssessmentType },
+          { url: 'text', valueMarkdown: parsedParams.artifactAssessmentSummary }
+        );
+        if (library.extension) {
+          library.extension.push({
+            extension: reviewExtension,
+            url: 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-artifactComment'
+          });
+        } else {
+          library.extension = [
+            {
+              extension: reviewExtension,
+              url: 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-artifactComment'
+            }
+          ];
+        }
+      }
+      library.date = new Date().toISOString();
+      library.lastReviewDate = parsedParams.reviewDate ?? new Date().toISOString();
+      checkIsOwned(library, 'Child artifacts cannot be directly reviewed.');
+  
+      // recursively get any child artifacts form the artifact if they exist
+      const children = library.relatedArtifact ? await getChildren(library.relatedArtifact) : [];
+      children.forEach(child => {
+        if (parsedParams.artifactAssessmentType && parsedParams.artifactAssessmentSummary) {
+          const reviewExtension: fhir4.Extension[] = [];
+          reviewExtension.push(
+            { url: 'type', valueCode: parsedParams.artifactAssessmentType },
+            { url: 'text', valueMarkdown: parsedParams.artifactAssessmentSummary }
+          );
+          if (child.extension) {
+            child.extension.push({
+              extension: reviewExtension,
+              url: 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-artifactComment'
+            });
+          } else {
+            child.extension = [
+              {
+                extension: reviewExtension,
+                url: 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-artifactComment'
+              }
+            ];
+          }
+        }
+        child.date = new Date().toISOString();
+        child.lastReviewDate = parsedParams.reviewDate ?? new Date().toISOString();
+      });
+  
+      // now we want to batch update the reviewed parent Library and any of its children
+      const reviewedArtifacts = await batchUpdate([library, ...(await Promise.all(children))], 'review');
+  
+      // we want to return a Bundle containing the updated artifacts
+      return createBatchResponseBundle(reviewedArtifacts);
+    }
 
   /**
    * result of sending a POST or GET request to:

--- a/service/src/services/LibraryService.ts
+++ b/service/src/services/LibraryService.ts
@@ -309,7 +309,7 @@ export class LibraryService implements Service<CRMIShareableLibrary> {
     library.approvalDate = parsedParams.approvalDate ?? new Date().toISOString();
     checkIsOwned(library, 'Child artifacts cannot be directly approved.');
 
-    // recursively get any child artifacts form the artifact if they exist
+    // recursively get any child artifacts from the artifact if they exist
     const children = library.relatedArtifact ? await getChildren(library.relatedArtifact) : [];
     children.forEach(child => {
       if (parsedParams.artifactAssessmentType && parsedParams.artifactAssessmentSummary) {
@@ -341,7 +341,7 @@ export class LibraryService implements Service<CRMIShareableLibrary> {
    * result of sending a POST or GET request to:
    * {BASE_URL}/4_0_1/Library/$review or {BASE_URL}/4_0_1/Library/[id]/$review
    * applies a review to an existing artifact, regardless of status, and sets the
-   * date and lastReviewedDate elements of the reviewed artifact as well as for all resources
+   * date and lastReviewDate elements of the reviewed artifact as well as for all resources
    * it is composed of. The user can optionally provide an artifactAssessmentType and an
    * artifactAssessmentSummary for an cqfm-artifactComment extension.
    */
@@ -385,7 +385,7 @@ export class LibraryService implements Service<CRMIShareableLibrary> {
     library.lastReviewDate = parsedParams.reviewDate ?? new Date().toISOString();
     checkIsOwned(library, 'Child artifacts cannot be directly reviewed.');
 
-    // recursively get any child artifacts form the artifact if they exist
+    // recursively get any child artifacts from the artifact if they exist
     const children = library.relatedArtifact ? await getChildren(library.relatedArtifact) : [];
     children.forEach(child => {
       if (parsedParams.artifactAssessmentType && parsedParams.artifactAssessmentSummary) {

--- a/service/src/services/MeasureService.ts
+++ b/service/src/services/MeasureService.ts
@@ -40,7 +40,8 @@ import {
   parseRequestSchema,
   DraftArgs,
   CloneArgs,
-  ApproveArgs
+  ApproveArgs,
+  ReviewArgs
 } from '../requestSchemas';
 import { v4 as uuidv4 } from 'uuid';
 import { Filter } from 'mongodb';
@@ -336,6 +337,94 @@ export class MeasureService implements Service<CRMIShareableMeasure> {
 
     // we want to return a Bundle containing the updated artifacts
     return createBatchResponseBundle(approvedArtifacts);
+  }
+
+   /**
+   * result of sending a POST or GET request to:
+   * {BASE_URL}/4_0_1/Measure/$review or {BASE_URL}/4_0_1/Measure/[id]/$review
+   * applies a review to an existing artifact, regardless of status, and sets the
+   * date and lastReviewedDate elements of the reviewed artifact as well as for all resources
+   * it is composed of. The user can optionally provide an artifactAssessmentType and an
+   * artifactAssessmentSummary for an cqfm-artifactComment extension.
+   */
+   async review(args: RequestArgs, { req }: RequestCtx) {
+    logger.info(`${req.method} ${req.path}`);
+
+    // checks that the authoring environment variable is true
+    checkAuthoring();
+
+    if (req.method === 'POST') {
+      const contentType: string | undefined = req.headers['content-type'];
+      checkContentTypeHeader(contentType);
+    }
+
+    const params = gatherParams(req.query, args.resource);
+    validateParamIdSource(req.params.id, params.id);
+
+    const query = extractIdentificationForQuery(args, params);
+
+    const parsedParams = parseRequestSchema({ ...params, ...query }, ReviewArgs);
+
+    const measure = await findResourceById<CRMIShareableMeasure>(parsedParams.id, 'Measure');
+    if (!measure) {
+      throw new ResourceNotFoundError(`No resource found in collection: Measure, with id: ${parsedParams.id}`);
+    }
+    if (parsedParams.artifactAssessmentType && parsedParams.artifactAssessmentSummary) {
+      const reviewExtension: fhir4.Extension[] = [];
+      reviewExtension.push(
+        { url: 'type', valueCode: parsedParams.artifactAssessmentType },
+        { url: 'text', valueMarkdown: parsedParams.artifactAssessmentSummary }
+      );
+      if (measure.extension) {
+        measure.extension.push({
+          extension: reviewExtension,
+          url: 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-artifactComment'
+        });
+      } else {
+        measure.extension = [
+          {
+            extension: reviewExtension,
+            url: 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-artifactComment'
+          }
+        ];
+      }
+    }
+    measure.date = new Date().toISOString();
+    measure.lastReviewDate = parsedParams.reviewDate ?? new Date().toISOString();
+    checkIsOwned(measure, 'Child artifacts cannot be directly reviewed.');
+
+    // recursively get any child artifacts from the artifact if they exist
+    const children = measure.relatedArtifact ? await getChildren(measure.relatedArtifact) : [];
+    children.forEach(child => {
+      if (parsedParams.artifactAssessmentType && parsedParams.artifactAssessmentSummary) {
+        const reviewExtension: fhir4.Extension[] = [];
+        reviewExtension.push(
+          { url: 'type', valueCode: parsedParams.artifactAssessmentType },
+          { url: 'text', valueMarkdown: parsedParams.artifactAssessmentSummary }
+        );
+        if (child.extension) {
+          child.extension.push({
+            extension: reviewExtension,
+            url: 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-artifactComment'
+          });
+        } else {
+          child.extension = [
+            {
+              extension: reviewExtension,
+              url: 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-artifactComment'
+            }
+          ];
+        }
+      }
+      child.date = new Date().toISOString();
+      child.lastReviewDate = parsedParams.reviewDate ?? new Date().toISOString();
+    });
+
+    // now we want to batch update the reviewed parent Measure and any of its children
+    const reviewedArtifacts = await batchUpdate([measure, ...(await Promise.all(children))], 'review');
+
+    // we want to return a Bundle containing the updated artifacts
+    return createBatchResponseBundle(reviewedArtifacts);
   }
 
   /**

--- a/service/src/services/MeasureService.ts
+++ b/service/src/services/MeasureService.ts
@@ -343,7 +343,7 @@ export class MeasureService implements Service<CRMIShareableMeasure> {
    * result of sending a POST or GET request to:
    * {BASE_URL}/4_0_1/Measure/$review or {BASE_URL}/4_0_1/Measure/[id]/$review
    * applies a review to an existing artifact, regardless of status, and sets the
-   * date and lastReviewedDate elements of the reviewed artifact as well as for all resources
+   * date and lastReviewDate elements of the reviewed artifact as well as for all resources
    * it is composed of. The user can optionally provide an artifactAssessmentType and an
    * artifactAssessmentSummary for an cqfm-artifactComment extension.
    */

--- a/service/test/services/MeasureService.test.ts
+++ b/service/test/services/MeasureService.test.ts
@@ -1195,6 +1195,178 @@ describe('MeasureService', () => {
     });
   });
 
+  describe('$review', () => {
+    beforeEach(() => {
+      createTestResource(
+        {
+          resourceType: 'Measure',
+          id: 'review-parent',
+          url: 'http://example.com/review-parent',
+          status: 'active',
+          relatedArtifact: [
+            {
+              type: 'composed-of',
+              resource: 'http://example.com/review-child1|1',
+              extension: [
+                {
+                  url: 'http://hl7.org/fhir/StructureDefinition/artifact-isOwned',
+                  valueBoolean: true
+                }
+              ]
+            }
+          ],
+          version: '1',
+          description: 'Example description',
+          title: 'Parent Active Measure'
+        },
+        'Measure'
+      );
+      createTestResource(
+        {
+          resourceType: 'Library',
+          id: 'review-child1',
+          url: 'http://example.com/review-child1',
+          status: 'active',
+          extension: [
+            {
+              url: 'http://hl7.org/fhir/StructureDefinition/artifact-isOwned',
+              valueBoolean: true
+            }
+          ],
+          relatedArtifact: [
+            {
+              type: 'composed-of',
+              resource: 'http://example.com/review-child2|1',
+              extension: [
+                {
+                  url: 'http://hl7.org/fhir/StructureDefinition/artifact-isOwned',
+                  valueBoolean: true
+                }
+              ]
+            }
+          ],
+          ...LIBRARY_BASE
+        },
+        'Library'
+      );
+      return createTestResource(
+        {
+          resourceType: 'Library',
+          id: 'review-child2',
+          url: 'http://example.com/review-child2',
+          status: 'active',
+          extension: [
+            {
+              url: 'http://hl7.org/fhir/StructureDefinition/artifact-isOwned',
+              valueBoolean: true
+            }
+          ],
+          ...LIBRARY_BASE
+        },
+        'Library'
+      );
+    });
+
+    it('returns 200 status with a Bundle result containing the updated parent Measure artifact and any children it has for GET /Measure/$review', async () => {
+      await supertest(server.app)
+        .get('/4_0_1/Measure/$review')
+        .query({
+          id: 'review-parent',
+          artifactAssessmentType: 'guidance',
+          artifactAssessmentSummary: 'Sample summary',
+          artifactAssessmentAuthor: { reference: 'Sample Author' }
+        })
+        .set('Accept', 'application/json+fhir')
+        .expect(200)
+        .then(response => {
+          expect(response.body.total).toEqual(3);
+          expect(response.body.entry[0].resource.date).toBeDefined();
+          expect(response.body.entry[0].resource.extension[0].extension[2].valueString).toEqual('Sample Author');
+          expect(response.body.entry[1].resource.date).toBeDefined();
+          expect(response.body.entry[1].resource.extension[1].extension[2].valueString).toEqual('Sample Author');
+          expect(response.body.entry[2].resource.date).toBeDefined();
+          expect(response.body.entry[2].resource.extension[1].extension[2].valueString).toEqual('Sample Author');
+        });
+    });
+
+    it('returns 200 status with a Bundle result containing the updated parent Measure artifact and any children it has for GET /Measure/[id]/$review', async () => {
+      await supertest(server.app)
+        .get('/4_0_1/Measure/review-parent/$review')
+        .set('Accept', 'application/json+fhir')
+        .expect(200)
+        .then(response => {
+          expect(response.body.total).toEqual(3);
+          expect(response.body.entry[0].resource.date).toBeDefined();
+          expect(response.body.entry[1].resource.date).toBeDefined();
+          expect(response.body.entry[2].resource.date).toBeDefined();
+        });
+    });
+
+    it('returns 200 status with a Bundle result containing the updated parent Measure artifact and any children it has for POST /Measure/[id]/$review', async () => {
+      await supertest(server.app)
+        .post('/4_0_1/Measure/$review')
+        .send({
+          resourceType: 'Parameters',
+          parameter: [{ name: 'id', valueString: 'review-parent' }]
+        })
+        .set('content-type', 'application/fhir+json')
+        .expect(200)
+        .then(response => {
+          expect(response.body.total).toEqual(3);
+          expect(response.body.entry[0].resource.date).toBeDefined();
+          expect(response.body.entry[1].resource.date).toBeDefined();
+          expect(response.body.entry[2].resource.date).toBeDefined();
+        });
+    });
+
+    it('returns 200 status with a Bundle result containing the updated parent Measure artifact and any children it has for POST /Measure/$review with cqf-artifactComment extension', async () => {
+      await supertest(server.app)
+        .post('/4_0_1/Measure/$review')
+        .send({
+          resourceType: 'Parameters',
+          parameter: [
+            { name: 'id', valueString: 'review-parent' },
+            { name: 'artifactAssessmentType', valueCode: 'documentation' },
+            { name: 'artifactAssessmentSummary', valueString: 'Hello' },
+            { name: 'reviewDate', valueDate: '2024-08-14T17:29:34.344Z' }
+          ]
+        })
+        .set('content-type', 'application/fhir+json')
+        .expect(200)
+        .then(response => {
+          expect(response.body.total).toEqual(3);
+          expect(response.body.entry[0].resource.date).toBeDefined();
+          expect(response.body.entry[0].resource.extension[0].url).toEqual(
+            'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-artifactComment'
+          );
+          expect(response.body.entry[0].resource.lastReviewDate).toEqual('2024-08-14T17:29:34.344Z');
+          expect(response.body.entry[1].resource.date).toBeDefined();
+          expect(response.body.entry[1].resource.extension[1].url).toEqual(
+            'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-artifactComment'
+          );
+          expect(response.body.entry[1].resource.lastReviewDate).toEqual('2024-08-14T17:29:34.344Z');
+          expect(response.body.entry[2].resource.date).toBeDefined();
+          expect(response.body.entry[2].resource.extension[1].url).toEqual(
+            'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-artifactComment'
+          );
+          expect(response.body.entry[2].resource.lastReviewDate).toEqual('2024-08-14T17:29:34.344Z');
+        });
+    });
+
+    it('returns 200 status with a Bundle result containing the updated parent Measure artifact and any children it has for POST /Measure/[id]/$review', async () => {
+      await supertest(server.app)
+        .post('/4_0_1/Measure/review-parent/$review')
+        .set('content-type', 'application/fhir+json')
+        .expect(200)
+        .then(response => {
+          expect(response.body.total).toEqual(3);
+          expect(response.body.entry[0].resource.date).toBeDefined();
+          expect(response.body.entry[1].resource.date).toBeDefined();
+          expect(response.body.entry[2].resource.date).toBeDefined();
+        });
+    });
+  });
+
   afterAll(() => {
     return cleanUpTestDatabase();
   });


### PR DESCRIPTION
# Summary
Implements the `$review` endpoint in the server according to the [CRMI IG definition](https://hl7.org/fhir/uv/crmi/OperationDefinition-crmi-review.html).

## New behavior

For all details, this functionality is essentially the same as `$approve` with the exception of the `approvalDate` parameter, which becomes the `reviewDate`, and instead of setting the `approvalDate` field on the artifact, it sets the `lastReviewDate` field.

## Code changes

See https://github.com/projecttacoma/measure-repository/pull/106

# Testing guidance

Use the testing guidance in https://github.com/projecttacoma/measure-repository/pull/106, including Insomnia requests, but change all `$approve` to `$review` and all `approvalDate` parameters to `reviewDate`.