### PR TITLE
Handle duplicate key errors from mongo and return Bad Request errors

### DIFF
--- a/service/src/db/dbOperations.ts
+++ b/service/src/db/dbOperations.ts
@@ -182,7 +182,7 @@ export async function batchUpdate(artifacts: FhirArtifact[], action: string) {
     console.log(`Batch ${action} transaction committed.`);
   } catch (err) {
     console.log(`Batch ${action} transaction failed: ` + err);
-    error = err;
+    error = handlePossibleDuplicateKeyError(err);
   } finally {
     await updateSession?.endSession();
   }

--- a/service/src/db/dbOperations.ts
+++ b/service/src/db/dbOperations.ts
@@ -155,7 +155,7 @@ export async function batchInsert(artifacts: FhirArtifact[], action: string) {
     console.log(`Batch ${action} transaction committed.`);
   } catch (err) {
     console.log(`Batch ${action} transaction failed: ` + err);
-    error = err;
+    error = handlePossibleDuplicateKeyError(err);
   } finally {
     await insertSession?.endSession();
   }

--- a/service/test/services/BaseService.test.ts
+++ b/service/test/services/BaseService.test.ts
@@ -137,7 +137,7 @@ describe('BaseService', () => {
   beforeAll(async () => {
     server = initialize(serverConfig, app);
     process.env.AUTHORING = 'true';
-    return setupTestDatabase([]);
+    await setupTestDatabase([]);
   });
 
   describe('uploadTransactionBundle', () => {
@@ -260,7 +260,5 @@ describe('BaseService', () => {
         });
     });
   });
-  afterAll(() => {
-    return cleanUpTestDatabase();
-  });
+  afterAll(cleanUpTestDatabase);
 });

--- a/service/test/services/BaseService.test.ts
+++ b/service/test/services/BaseService.test.ts
@@ -316,7 +316,7 @@ describe('BaseService', () => {
         .then(response => {
           expect(response.body.issue[0].code).toEqual('invalid');
           expect(response.body.issue[0].details.text).toEqual(
-            'Resource with identifiers (url,version) already exists in the repository.'
+            'Library Resource with identifiers (url: http://example.com/testActiveLibrary, version: 1) already exists in the repository.'
           );
         });
     });
@@ -359,7 +359,7 @@ describe('BaseService', () => {
         .then(response => {
           expect(response.body.issue[0].code).toEqual('invalid');
           expect(response.body.issue[0].details.text).toEqual(
-            'Resource with identifiers (url,version) already exists in the repository.'
+            'Library Resource with identifiers (url: http://example.com/testActiveLibrary2, version: 1) already exists in the repository.'
           );
         });
     });

--- a/service/test/services/BaseService.test.ts
+++ b/service/test/services/BaseService.test.ts
@@ -2,7 +2,7 @@ import { initialize, Server } from '@projecttacoma/node-fhir-server-core';
 import supertest from 'supertest';
 import { app } from '../../src/app';
 import { serverConfig } from '../../src/config/serverConfig';
-import { cleanUpTestDatabase, setupTestDatabase } from '../utils';
+import { cleanUpTestDatabase, createTestResource, setupTestDatabase } from '../utils';
 
 let server: Server;
 
@@ -133,6 +133,13 @@ const VALID_POST_REQ = {
   ]
 };
 
+const LIBRARY_BASE = {
+  type: { coding: [{ code: 'logic-library' }] },
+  version: '1',
+  title: 'Sample title',
+  description: 'Sample description'
+};
+
 describe('BaseService', () => {
   beforeAll(async () => {
     server = initialize(serverConfig, app);
@@ -256,6 +263,103 @@ describe('BaseService', () => {
         .then(response => {
           expect(response.body.issue[0].details.text).toEqual(
             `Requests of type PUT must have an id associated with the resource.`
+          );
+        });
+    });
+
+    it('returns 400 when transaction bundle has a PUT request that conflicts with an existing url,version pair.', async () => {
+      await createTestResource(
+        {
+          resourceType: 'Library',
+          id: 'testActiveLibrary',
+          url: 'http://example.com/testActiveLibrary',
+          status: 'active',
+          ...LIBRARY_BASE
+        },
+        'Library'
+      );
+
+      await createTestResource(
+        {
+          resourceType: 'Library',
+          id: 'changeTest',
+          url: 'http://example.com/changeTest',
+          status: 'draft',
+          ...LIBRARY_BASE
+        },
+        'Library'
+      );
+
+      await supertest(server.app)
+        .post('/4_0_1/')
+        .send({
+          resourceType: 'Bundle',
+          type: 'transaction',
+          entry: [
+            {
+              resource: {
+                resourceType: 'Library',
+                id: 'changeTest',
+                url: 'http://example.com/testActiveLibrary',
+                status: 'draft',
+                ...LIBRARY_BASE
+              },
+              request: {
+                method: 'PUT',
+                url: 'Library/changeTest'
+              }
+            }
+          ]
+        })
+        .set('content-type', 'application/json+fhir')
+        .expect(400)
+        .then(response => {
+          expect(response.body.issue[0].code).toEqual('invalid');
+          expect(response.body.issue[0].details.text).toEqual(
+            'Resource with identifiers (url,version) already exists in the repository.'
+          );
+        });
+    });
+
+    it('returns 400 when transaction bundle has a POST request that conflicts with an existing url,version pair.', async () => {
+      await createTestResource(
+        {
+          resourceType: 'Library',
+          id: 'testActiveLibrary2',
+          url: 'http://example.com/testActiveLibrary2',
+          status: 'active',
+          ...LIBRARY_BASE
+        },
+        'Library'
+      );
+
+      await supertest(server.app)
+        .post('/4_0_1/')
+        .send({
+          resourceType: 'Bundle',
+          type: 'transaction',
+          entry: [
+            {
+              resource: {
+                resourceType: 'Library',
+                id: 'changeTest',
+                url: 'http://example.com/testActiveLibrary2',
+                status: 'draft',
+                ...LIBRARY_BASE
+              },
+              request: {
+                method: 'POST',
+                url: 'Library/changeTest'
+              }
+            }
+          ]
+        })
+        .set('content-type', 'application/json+fhir')
+        .expect(400)
+        .then(response => {
+          expect(response.body.issue[0].code).toEqual('invalid');
+          expect(response.body.issue[0].details.text).toEqual(
+            'Resource with identifiers (url,version) already exists in the repository.'
           );
         });
     });

--- a/service/test/services/LibraryService.test.ts
+++ b/service/test/services/LibraryService.test.ts
@@ -1120,8 +1120,8 @@ describe('LibraryService', () => {
   });
 
   describe('$approve', () => {
-    beforeEach(() => {
-      createTestResource(
+    beforeAll(async () => {
+      await createTestResource(
         {
           resourceType: 'Library',
           id: 'approve-child1',
@@ -1143,7 +1143,7 @@ describe('LibraryService', () => {
         },
         'Library'
       );
-      return createTestResource(
+      await createTestResource(
         {
           resourceType: 'Library',
           id: 'approve-child2',
@@ -1236,8 +1236,8 @@ describe('LibraryService', () => {
   });
 
   describe('$review', () => {
-    beforeEach(() => {
-      createTestResource(
+    beforeAll(async () => {
+      await createTestResource(
         {
           resourceType: 'Library',
           id: 'review-child1',
@@ -1259,7 +1259,7 @@ describe('LibraryService', () => {
         },
         'Library'
       );
-      return createTestResource(
+      await createTestResource(
         {
           resourceType: 'Library',
           id: 'review-child2',
@@ -1351,7 +1351,5 @@ describe('LibraryService', () => {
     });
   });
 
-  afterAll(() => {
-    return cleanUpTestDatabase();
-  });
+  afterAll(cleanUpTestDatabase);
 });

--- a/service/test/services/LibraryService.test.ts
+++ b/service/test/services/LibraryService.test.ts
@@ -677,6 +677,20 @@ describe('LibraryService', () => {
         .set('content-type', 'application/fhir+json')
         .expect(200);
     });
+
+    it('returns 400 status for a url and version pairing that already exists for POST /Library/:id/$draft', async () => {
+      await supertest(server.app)
+        .post('/4_0_1/Library/parentLibrary/$draft')
+        .send({ resourceType: 'Parameters', parameter: [{ name: 'version', valueString: '1.0.0.4' }] })
+        .set('content-type', 'application/fhir+json')
+        .expect(400)
+        .then(response => {
+          expect(response.body.issue[0].code).toEqual('invalid');
+          expect(response.body.issue[0].details.text).toEqual(
+            'Resource with identifiers (url,version) already exists in the repository.'
+          );
+        });
+    });
   });
 
   describe('$clone', () => {
@@ -723,6 +737,26 @@ describe('LibraryService', () => {
         })
         .set('content-type', 'application/fhir+json')
         .expect(200);
+    });
+
+    it('returns 400 status for a url and version pairing that already exists for POST /Library/:id/$clone', async () => {
+      await supertest(server.app)
+        .post('/4_0_1/Library/parentLibrary/$clone')
+        .send({
+          resourceType: 'Parameters',
+          parameter: [
+            { name: 'version', valueString: '1.0.0.8' },
+            { name: 'url', valueString: 'http://clone-example.com' }
+          ]
+        })
+        .set('content-type', 'application/fhir+json')
+        .expect(400)
+        .then(response => {
+          expect(response.body.issue[0].code).toEqual('invalid');
+          expect(response.body.issue[0].details.text).toEqual(
+            'Resource with identifiers (url,version) already exists in the repository.'
+          );
+        });
     });
   });
 

--- a/service/test/services/LibraryService.test.ts
+++ b/service/test/services/LibraryService.test.ts
@@ -441,7 +441,7 @@ describe('LibraryService', () => {
         .then(response => {
           expect(response.body.issue[0].code).toEqual('invalid');
           expect(response.body.issue[0].details.text).toEqual(
-            'Resource with identifiers (url,version) already exists in the repository.'
+            'Library Resource with identifiers (url: http://example.com/testActiveLibrary, version: 1) already exists in the repository.'
           );
         });
     });
@@ -577,7 +577,7 @@ describe('LibraryService', () => {
         .then(response => {
           expect(response.body.issue[0].code).toEqual('invalid');
           expect(response.body.issue[0].details.text).toEqual(
-            'Resource with identifiers (url,version) already exists in the repository.'
+            'Library Resource with identifiers (url: http://example.com/testActiveLibrary, version: 1) already exists in the repository.'
           );
         });
     });
@@ -687,7 +687,7 @@ describe('LibraryService', () => {
         .then(response => {
           expect(response.body.issue[0].code).toEqual('invalid');
           expect(response.body.issue[0].details.text).toEqual(
-            'Resource with identifiers (url,version) already exists in the repository.'
+            'Library Resource with identifiers (url: http://parent-library.com, version: 1.0.0.4) already exists in the repository.'
           );
         });
     });
@@ -754,7 +754,7 @@ describe('LibraryService', () => {
         .then(response => {
           expect(response.body.issue[0].code).toEqual('invalid');
           expect(response.body.issue[0].details.text).toEqual(
-            'Resource with identifiers (url,version) already exists in the repository.'
+            'Library Resource with identifiers (url: http://clone-example.com, version: 1.0.0.8) already exists in the repository.'
           );
         });
     });

--- a/service/test/services/LibraryService.test.ts
+++ b/service/test/services/LibraryService.test.ts
@@ -550,6 +550,37 @@ describe('LibraryService', () => {
           expect(response.body.issue[0].details.text).toEqual('Argument id must match request body id for PUT request');
         });
     });
+
+    it('returns 400 when the url and version pair already exists in the database', async () => {
+      await createTestResource(
+        {
+          resourceType: 'Library',
+          id: 'changeTest',
+          url: 'http://example.com/changeTest',
+          status: 'draft',
+          ...LIBRARY_BASE
+        },
+        'Library'
+      );
+
+      await supertest(server.app)
+        .put('/4_0_1/Library/changeTest')
+        .send({
+          resourceType: 'Library',
+          id: 'changeTest',
+          url: 'http://example.com/testActiveLibrary',
+          status: 'draft',
+          ...LIBRARY_BASE
+        })
+        .set('content-type', 'application/json+fhir')
+        .expect(400)
+        .then(response => {
+          expect(response.body.issue[0].code).toEqual('invalid');
+          expect(response.body.issue[0].details.text).toEqual(
+            'Resource with identifiers (url,version) already exists in the repository.'
+          );
+        });
+    });
   });
 
   describe('delete', () => {

--- a/service/test/services/LibraryService.test.ts
+++ b/service/test/services/LibraryService.test.ts
@@ -185,10 +185,10 @@ const CHILD_ACTIVE_LIBRARY: CRMIShareableLibrary = {
 };
 
 describe('LibraryService', () => {
-  beforeAll(() => {
+  beforeAll(async () => {
     server = initialize(serverConfig);
     process.env.AUTHORING = 'true';
-    return setupTestDatabase([
+    await setupTestDatabase([
       ACTIVE_LIBRARY,
       ACTIVE_LIBRARY_2,
       LIBRARY_WITH_NESTED_DEPS,
@@ -430,6 +430,14 @@ describe('LibraryService', () => {
         .then(response => {
           expect(response.headers.location).toBeDefined();
         });
+    });
+
+    it('publish: returns 400 status when Library with same url and version pair already exists', async () => {
+      await supertest(server.app)
+        .post('/4_0_1/Library')
+        .send(ACTIVE_LIBRARY)
+        .set('content-type', 'application/json+fhir')
+        .expect(400);
     });
   });
 

--- a/service/test/services/LibraryService.test.ts
+++ b/service/test/services/LibraryService.test.ts
@@ -331,9 +331,9 @@ describe('LibraryService', () => {
 
   describe('publishable repository validation', () => {
     const ORIGINAL_AUTHORING = process.env.AUTHORING;
-    beforeAll(() => {
+    beforeAll(async () => {
       process.env.AUTHORING = 'false';
-      createTestResource(
+      await createTestResource(
         {
           resourceType: 'Library',
           id: 'publishable-retired',
@@ -343,7 +343,7 @@ describe('LibraryService', () => {
         },
         'Library'
       );
-      return createTestResource(
+      await createTestResource(
         {
           resourceType: 'Library',
           id: 'publishable-active',
@@ -437,13 +437,19 @@ describe('LibraryService', () => {
         .post('/4_0_1/Library')
         .send(ACTIVE_LIBRARY)
         .set('content-type', 'application/json+fhir')
-        .expect(400);
+        .expect(400)
+        .then(response => {
+          expect(response.body.issue[0].code).toEqual('invalid');
+          expect(response.body.issue[0].details.text).toEqual(
+            'Resource with identifiers (url,version) already exists in the repository.'
+          );
+        });
     });
   });
 
   describe('update', () => {
-    beforeAll(() => {
-      createTestResource(
+    beforeAll(async () => {
+      await createTestResource(
         {
           resourceType: 'Library',
           id: 'exampleId-active',
@@ -453,7 +459,7 @@ describe('LibraryService', () => {
         },
         'Library'
       );
-      return createTestResource(
+      await createTestResource(
         {
           resourceType: 'Library',
           id: 'exampleId',
@@ -547,8 +553,8 @@ describe('LibraryService', () => {
   });
 
   describe('delete', () => {
-    beforeAll(() => {
-      createTestResource(
+    beforeAll(async () => {
+      await createTestResource(
         {
           resourceType: 'Library',
           id: 'delete-active',
@@ -558,7 +564,7 @@ describe('LibraryService', () => {
         },
         'Library'
       );
-      createTestResource(
+      await createTestResource(
         {
           resourceType: 'Library',
           id: 'delete-retired',
@@ -568,7 +574,7 @@ describe('LibraryService', () => {
         },
         'Library'
       );
-      return createTestResource(
+      await createTestResource(
         {
           resourceType: 'Library',
           id: 'delete-draft',

--- a/service/test/services/MeasureService.test.ts
+++ b/service/test/services/MeasureService.test.ts
@@ -552,6 +552,37 @@ describe('MeasureService', () => {
           expect(response.body.issue[0].details.text).toEqual('Argument id must match request body id for PUT request');
         });
     });
+
+    it('returns 400 when the url and version pair already exists in the database', async () => {
+      await createTestResource(
+        {
+          resourceType: 'Measure',
+          id: 'changeTest',
+          url: 'http://example.com/changeTest',
+          status: 'draft',
+          ...MEASURE_BASE
+        },
+        'Measure'
+      );
+
+      await supertest(server.app)
+        .put('/4_0_1/Measure/changeTest')
+        .send({
+          resourceType: 'Measure',
+          id: 'changeTest',
+          url: 'http://example.com/testActiveMeasure',
+          status: 'draft',
+          ...MEASURE_BASE
+        })
+        .set('content-type', 'application/json+fhir')
+        .expect(400)
+        .then(response => {
+          expect(response.body.issue[0].code).toEqual('invalid');
+          expect(response.body.issue[0].details.text).toEqual(
+            'Resource with identifiers (url,version) already exists in the repository.'
+          );
+        });
+    });
   });
 
   describe('delete', () => {

--- a/service/test/services/MeasureService.test.ts
+++ b/service/test/services/MeasureService.test.ts
@@ -444,7 +444,7 @@ describe('MeasureService', () => {
         .then(response => {
           expect(response.body.issue[0].code).toEqual('invalid');
           expect(response.body.issue[0].details.text).toEqual(
-            'Resource with identifiers (url,version) already exists in the repository.'
+            'Measure Resource with identifiers (url: http://example.com/testActiveMeasure, version: 1) already exists in the repository.'
           );
         });
     });
@@ -579,7 +579,7 @@ describe('MeasureService', () => {
         .then(response => {
           expect(response.body.issue[0].code).toEqual('invalid');
           expect(response.body.issue[0].details.text).toEqual(
-            'Resource with identifiers (url,version) already exists in the repository.'
+            'Measure Resource with identifiers (url: http://example.com/testActiveMeasure, version: 1) already exists in the repository.'
           );
         });
     });
@@ -692,7 +692,7 @@ describe('MeasureService', () => {
         .then(response => {
           expect(response.body.issue[0].code).toEqual('invalid');
           expect(response.body.issue[0].details.text).toEqual(
-            'Resource with identifiers (url,version) already exists in the repository.'
+            'Measure Resource with identifiers (url: http://parent-measure.com, version: 1.0.0.4) already exists in the repository.'
           );
         });
     });
@@ -759,7 +759,7 @@ describe('MeasureService', () => {
         .then(response => {
           expect(response.body.issue[0].code).toEqual('invalid');
           expect(response.body.issue[0].details.text).toEqual(
-            'Resource with identifiers (url,version) already exists in the repository.'
+            'Measure Resource with identifiers (url: http://clone-example.com, version: 1.0.0.8) already exists in the repository.'
           );
         });
     });

--- a/service/test/services/MeasureService.test.ts
+++ b/service/test/services/MeasureService.test.ts
@@ -440,13 +440,19 @@ describe('MeasureService', () => {
         .post('/4_0_1/Measure')
         .send(ACTIVE_MEASURE)
         .set('content-type', 'application/json+fhir')
-        .expect(400);
+        .expect(400)
+        .then(response => {
+          expect(response.body.issue[0].code).toEqual('invalid');
+          expect(response.body.issue[0].details.text).toEqual(
+            'Resource with identifiers (url,version) already exists in the repository.'
+          );
+        });
     });
   });
 
   describe('update', () => {
-    beforeAll(() => {
-      createTestResource(
+    beforeAll(async () => {
+      await createTestResource(
         {
           resourceType: 'Measure',
           id: 'exampleId-active',
@@ -456,7 +462,7 @@ describe('MeasureService', () => {
         },
         'Measure'
       );
-      return createTestResource(
+      await createTestResource(
         {
           resourceType: 'Measure',
           id: 'exampleId',
@@ -549,8 +555,8 @@ describe('MeasureService', () => {
   });
 
   describe('delete', () => {
-    beforeAll(() => {
-      createTestResource(
+    beforeAll(async () => {
+      await createTestResource(
         {
           resourceType: 'Measure',
           id: 'delete-active',
@@ -560,7 +566,7 @@ describe('MeasureService', () => {
         },
         'Measure'
       );
-      createTestResource(
+      await createTestResource(
         {
           resourceType: 'Measure',
           id: 'delete-retired',
@@ -570,7 +576,7 @@ describe('MeasureService', () => {
         },
         'Measure'
       );
-      return createTestResource(
+      await createTestResource(
         {
           resourceType: 'Measure',
           id: 'delete-draft',

--- a/service/test/services/MeasureService.test.ts
+++ b/service/test/services/MeasureService.test.ts
@@ -28,6 +28,14 @@ const ACTIVE_MEASURE: CRMIShareableMeasure = {
   ...MEASURE_BASE
 };
 
+const EXTRA_ACTIVE_MEASURE: CRMIShareableMeasure = {
+  resourceType: 'Measure',
+  id: 'testExtraActiveMeasure',
+  url: 'http://example.com/testExtraActiveMeasure',
+  status: 'active',
+  ...MEASURE_BASE
+};
+
 const ACTIVE_MEASURE_2: CRMIShareableMeasure = {
   resourceType: 'Measure',
   id: 'testActiveMeasure2',
@@ -183,10 +191,10 @@ const CHILD_ACTIVE_LIBRARY: CRMIShareableLibrary = {
 };
 
 describe('MeasureService', () => {
-  beforeAll(() => {
+  beforeAll(async () => {
     server = initialize(serverConfig);
     process.env.AUTHORING = 'true';
-    return setupTestDatabase([
+    await setupTestDatabase([
       ACTIVE_MEASURE,
       ACTIVE_MEASURE_2,
       MEASURE_WITH_ROOT_LIB,
@@ -419,12 +427,20 @@ describe('MeasureService', () => {
     it('publish: returns 201 status with populated location when provided correct headers and a FHIR Measure', async () => {
       await supertest(server.app)
         .post('/4_0_1/Measure')
-        .send(ACTIVE_MEASURE)
+        .send(EXTRA_ACTIVE_MEASURE)
         .set('content-type', 'application/json+fhir')
         .expect(201)
         .then(response => {
           expect(response.headers.location).toBeDefined();
         });
+    });
+
+    it('publish: returns 400 status for Measure with same url and version pair already in repository', async () => {
+      await supertest(server.app)
+        .post('/4_0_1/Measure')
+        .send(ACTIVE_MEASURE)
+        .set('content-type', 'application/json+fhir')
+        .expect(400);
     });
   });
 

--- a/service/test/services/MeasureService.test.ts
+++ b/service/test/services/MeasureService.test.ts
@@ -682,6 +682,20 @@ describe('MeasureService', () => {
         .set('content-type', 'application/fhir+json')
         .expect(200);
     });
+
+    it('returns 400 status for a url and version pairing that already exists for POST /Measure/:id/$draft', async () => {
+      await supertest(server.app)
+        .post('/4_0_1/Measure/parentMeasure/$draft')
+        .send({ resourceType: 'Parameters', parameter: [{ name: 'version', valueString: '1.0.0.4' }] })
+        .set('content-type', 'application/fhir+json')
+        .expect(400)
+        .then(response => {
+          expect(response.body.issue[0].code).toEqual('invalid');
+          expect(response.body.issue[0].details.text).toEqual(
+            'Resource with identifiers (url,version) already exists in the repository.'
+          );
+        });
+    });
   });
 
   describe('$clone', () => {
@@ -728,6 +742,26 @@ describe('MeasureService', () => {
         })
         .set('content-type', 'application/fhir+json')
         .expect(200);
+    });
+
+    it('returns 400 status for a url and version pairing that already exists for POST /Measure/:id/$clone', async () => {
+      await supertest(server.app)
+        .post('/4_0_1/Measure/parentMeasure/$clone')
+        .send({
+          resourceType: 'Parameters',
+          parameter: [
+            { name: 'version', valueString: '1.0.0.8' },
+            { name: 'url', valueString: 'http://clone-example.com' }
+          ]
+        })
+        .set('content-type', 'application/fhir+json')
+        .expect(400)
+        .then(response => {
+          expect(response.body.issue[0].code).toEqual('invalid');
+          expect(response.body.issue[0].details.text).toEqual(
+            'Resource with identifiers (url,version) already exists in the repository.'
+          );
+        });
     });
   });
 

--- a/service/test/services/MeasureService.test.ts
+++ b/service/test/services/MeasureService.test.ts
@@ -1111,8 +1111,8 @@ describe('MeasureService', () => {
   });
 
   describe('$approve', () => {
-    beforeEach(() => {
-      createTestResource(
+    beforeAll(async () => {
+      await createTestResource(
         {
           resourceType: 'Measure',
           id: 'approve-parent',
@@ -1136,7 +1136,7 @@ describe('MeasureService', () => {
         },
         'Measure'
       );
-      createTestResource(
+      await createTestResource(
         {
           resourceType: 'Library',
           id: 'approve-child1',
@@ -1164,7 +1164,7 @@ describe('MeasureService', () => {
         },
         'Library'
       );
-      return createTestResource(
+      await createTestResource(
         {
           resourceType: 'Library',
           id: 'approve-child2',
@@ -1283,8 +1283,8 @@ describe('MeasureService', () => {
   });
 
   describe('$review', () => {
-    beforeEach(() => {
-      createTestResource(
+    beforeAll(async () => {
+      await createTestResource(
         {
           resourceType: 'Measure',
           id: 'review-parent',
@@ -1308,7 +1308,7 @@ describe('MeasureService', () => {
         },
         'Measure'
       );
-      createTestResource(
+      await createTestResource(
         {
           resourceType: 'Library',
           id: 'review-child1',
@@ -1336,7 +1336,7 @@ describe('MeasureService', () => {
         },
         'Library'
       );
-      return createTestResource(
+      await createTestResource(
         {
           resourceType: 'Library',
           id: 'review-child2',
@@ -1454,7 +1454,5 @@ describe('MeasureService', () => {
     });
   });
 
-  afterAll(() => {
-    return cleanUpTestDatabase();
-  });
+  afterAll(cleanUpTestDatabase);
 });

--- a/service/test/util/bundleUtils.test.ts
+++ b/service/test/util/bundleUtils.test.ts
@@ -145,15 +145,15 @@ const MEASURE_WITH_NO_LIBRARY: CRMIShareableMeasure = {
 const MEASURE_WITH_LIBRARY: CRMIShareableMeasure = {
   resourceType: 'Measure',
   id: 'MeasureWithLib',
-  url: 'http://example.com/MeasureNoLib',
+  url: 'http://example.com/MeasureWithLib',
   status: 'draft',
   library: ['http://example.com/LibraryWithDeps'],
   ...MEASURE_BASE
 };
 
 describe('bundleUtils', () => {
-  beforeAll(() => {
-    return setupTestDatabase([
+  beforeAll(async () => {
+    await setupTestDatabase([
       LIB_WITH_DEPS,
       LIB_WITH_NO_DEPS,
       LIB_WITH_MISSING_DEPS,

--- a/service/test/util/serviceUtils.test.ts
+++ b/service/test/util/serviceUtils.test.ts
@@ -62,8 +62,8 @@ const CHILD_LIBRARY_2: CRMIShareableLibrary = {
 };
 
 describe('serviceUtils', () => {
-  beforeAll(() => {
-    return setupTestDatabase([CHILD_LIBRARY_1, CHILD_LIBRARY_2]);
+  beforeAll(async () => {
+    await setupTestDatabase([CHILD_LIBRARY_1, CHILD_LIBRARY_2]);
   });
 
   describe('getChildren', () => {

--- a/service/test/utils.ts
+++ b/service/test/utils.ts
@@ -15,7 +15,6 @@ export async function setupTestDatabase(testFixtureList: FhirArtifact[]) {
   await Connection.connect((global as any).__MONGO_URI__);
 
   for (const cn of ['Library', 'Measure']) {
-    console.log(`Creating collection ${cn}`);
     const collection = await Connection.db.createCollection(cn);
     await collection.createIndex({ id: 1 }, { unique: true });
     await collection.createIndex({ url: 1, version: 1 }, { unique: true });

--- a/service/test/utils.ts
+++ b/service/test/utils.ts
@@ -14,6 +14,13 @@ export async function cleanUpTestDatabase() {
 export async function setupTestDatabase(testFixtureList: FhirArtifact[]) {
   await Connection.connect((global as any).__MONGO_URI__);
 
+  for (const cn of ['Library', 'Measure']) {
+    console.log(`Creating collection ${cn}`);
+    const collection = await Connection.db.createCollection(cn);
+    await collection.createIndex({ id: 1 }, { unique: true });
+    await collection.createIndex({ url: 1, version: 1 }, { unique: true });
+  }
+
   for (const resource of testFixtureList) {
     await createTestResource(resource, resource.resourceType);
   }


### PR DESCRIPTION
# Summary

Currently when a database change is made that would cause a duplicate `url` and `id` to occur, the response from the server is 500 from mongo enforcing the restraint. This work catches the specific mongo errors responds with a 400 Bad Request `invalid` response explaining the issue. 

## New behavior

All DB operations that make changes will catch the duplicate key errors from mongo and throw a BadRequestError that will result in a 400 response.

Adds collection index creation to the test db setup functions and fixes many async issues with the unit tests.

## Code changes

`dbOperations.ts` - Added a helper function to convert a caught error to a BadRequestError if it happens to be the mongo duplicate key error.
`tests/utils.ts` - Added index creation to `setupTestDatabase`.
Unit Tests - Fixes to many of the test database setup and tear down to ensure the database is actually ready before tests. Added to test to operations that change/insert resources to check for 400 error on duplicate key situations.

# Testing guidance

Run unit tests.

Attempt to insert a resource that has the same url and version as one that is already in your database.
