### PR TITLE
release implementation

### DIFF
--- a/service/README.md
+++ b/service/README.md
@@ -217,6 +217,14 @@ And takes the following optional parameters:
 - artifactAssessmentRelatedArtifact
 - artifactAssessmentAuthor
 
+### Release
+
+The Measure Repository Service Authoring Repository Service server supports the `Measure` and `Library` `$release` operations as defined by the [Canonical Resource Management Infrastructure IG](https://hl7.org/fhir/uv/crmi/OperationDefinition-crmi-release.html). It requires the following parameters:
+
+- id
+- version
+- [versionBehavior](https://hl7.org/fhir/uv/crmi/ValueSet-crmi-release-version-behavior.html)
+
 ## License
 
 Copyright 2022-2023 The MITRE Corporation

--- a/service/scripts/dbSetup.ts
+++ b/service/scripts/dbSetup.ts
@@ -217,10 +217,10 @@ function modifyEntriesForUpload(entries: fhir4.BundleEntry<fhir4.FhirResource>[]
       if (!updatedEntry.resource.id) {
         updatedEntry.resource.id = uuidv4();
       }
-      if (updatedEntry.resource.status != 'active') {
+      if (updatedEntry.resource.status != 'active' && process.env.AUTHORING === 'false') {
         updatedEntry.resource.status = 'active';
         console.warn(
-          `Resource ${updatedEntry.resource.resourceType}/${updatedEntry.resource.id} status has been coerced to 'active'.`
+          `Resource ${updatedEntry.resource.resourceType}/${updatedEntry.resource.id} status has been coerced to 'active' for Publishable environment.`
         );
       }
     }

--- a/service/src/config/capabilityStatementResources.json
+++ b/service/src/config/capabilityStatementResources.json
@@ -202,6 +202,16 @@
           ],
           "name": "review",
           "definition": "http://hl7.org/fhir/uv/crmi/OperationDefinition/crmi-review"
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHALL"
+            }
+          ],
+          "name": "release",
+          "definition": "http://hl7.org/fhir/uv/crmi/OperationDefinition/crmi-release"
         }
       ]
     },
@@ -400,6 +410,16 @@
           ],
           "name": "review",
           "definition": "http://hl7.org/fhir/uv/crmi/OperationDefinition/crmi-review"
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHALL"
+            }
+          ],
+          "name": "release",
+          "definition": "http://hl7.org/fhir/uv/crmi/OperationDefinition/crmi-release"
         }
       ]
     }

--- a/service/src/config/serverConfig.ts
+++ b/service/src/config/serverConfig.ts
@@ -181,6 +181,30 @@ export const serverConfig: ServerConfig = {
           route: '/:id/$review',
           method: 'POST',
           reference: 'https://hl7.org/fhir/uv/crmi/STU1/OperationDefinition-crmi-review.html'
+        },
+        {
+          name: 'release',
+          route: '/$release',
+          method: 'GET',
+          reference: 'https://hl7.org/fhir/uv/crmi/STU1/OperationDefinition-crmi-release.html'
+        },
+        {
+          name: 'release',
+          route: '/$release',
+          method: 'POST',
+          reference: 'https://hl7.org/fhir/uv/crmi/STU1/OperationDefinition-crmi-release.html'
+        },
+        {
+          name: 'release',
+          route: '/:id/$release',
+          method: 'GET',
+          reference: 'https://hl7.org/fhir/uv/crmi/STU1/OperationDefinition-crmi-release.html'
+        },
+        {
+          name: 'release',
+          route: '/:id/$release',
+          method: 'POST',
+          reference: 'https://hl7.org/fhir/uv/crmi/STU1/OperationDefinition-crmi-release.html'
         }
       ]
     },
@@ -331,6 +355,30 @@ export const serverConfig: ServerConfig = {
           route: '/:id/$review',
           method: 'POST',
           reference: 'https://hl7.org/fhir/uv/crmi/STU1/OperationDefinition-crmi-review.html'
+        },
+        {
+          name: 'release',
+          route: '/$release',
+          method: 'GET',
+          reference: 'https://hl7.org/fhir/uv/crmi/STU1/OperationDefinition-crmi-release.html'
+        },
+        {
+          name: 'release',
+          route: '/$release',
+          method: 'POST',
+          reference: 'https://hl7.org/fhir/uv/crmi/STU1/OperationDefinition-crmi-release.html'
+        },
+        {
+          name: 'release',
+          route: '/:id/$release',
+          method: 'GET',
+          reference: 'https://hl7.org/fhir/uv/crmi/STU1/OperationDefinition-crmi-release.html'
+        },
+        {
+          name: 'release',
+          route: '/:id/$release',
+          method: 'POST',
+          reference: 'https://hl7.org/fhir/uv/crmi/STU1/OperationDefinition-crmi-release.html'
         }
       ]
     }

--- a/service/src/requestSchemas.ts
+++ b/service/src/requestSchemas.ts
@@ -225,6 +225,14 @@ export const ReviewArgs = z
   .strict()
   .superRefine(catchInvalidParams([catchMissingId, catchMissingTypeAndSummary]));
 
+export const ReleaseArgs = z
+  .object({
+    id: z.string(),
+    releaseVersion: z.string(),
+    versionBehavior: z.union([z.literal('default'), z.literal('check'), z.literal('force')])
+  })
+  .strict();
+
 export const IdentifyingParameters = z
   .object({
     id: z.string(),

--- a/service/src/services/MeasureService.ts
+++ b/service/src/services/MeasureService.ts
@@ -41,7 +41,8 @@ import {
   DraftArgs,
   CloneArgs,
   ApproveArgs,
-  ReviewArgs
+  ReviewArgs,
+  ReleaseArgs
 } from '../requestSchemas';
 import { v4 as uuidv4 } from 'uuid';
 import { Filter } from 'mongodb';
@@ -413,6 +414,86 @@ export class MeasureService implements Service<CRMIShareableMeasure> {
 
     // we want to return a Bundle containing the updated artifacts
     return createBatchResponseBundle(reviewedArtifacts);
+  }
+
+  /**
+   * result of sending a POST or GET request to:
+   * {BASE_URL}/4_0_1/Measure/$release or {BASE_URL}/4_0_1/Measure/[id]/$release
+   * releases an artifact, updating the status of an existing draft artifact to active and
+   * setting the date element of the resource. Also sets the version and recursively releases
+   * child artifacts according to the versionBehavior parameter.
+   */
+  async release(args: RequestArgs, { req }: RequestCtx) {
+    logger.info(`${req.method} ${req.path}`);
+
+    // checks that the authoring environment variable is true
+    checkAuthoring();
+
+    if (req.method === 'POST') {
+      const contentType: string | undefined = req.headers['content-type'];
+      checkContentTypeHeader(contentType);
+    }
+
+    const params = gatherParams(req.query, args.resource);
+    validateParamIdSource(req.params.id, params.id);
+    const query = extractIdentificationForQuery(args, params);
+    const parsedParams = parseRequestSchema({ ...params, ...query }, ReleaseArgs);
+
+    const measure = await findResourceById<CRMIShareableMeasure>(parsedParams.id, 'Measure');
+    if (!measure) {
+      throw new ResourceNotFoundError(`No resource found in collection: Measure, with id: ${parsedParams.id}`);
+    }
+    if (measure.status !== 'draft') {
+      throw new BadRequestError(
+        `Measure with id: ${measure.id} has status ${measure.status}. $release may only be used on draft artifacts.`
+      );
+    }
+    checkIsOwned(measure, 'Child artifacts cannot be directly released.');
+
+    measure.status = 'active';
+    measure.date = new Date().toISOString();
+
+    // Version behavior source: https://hl7.org/fhir/uv/crmi/1.0.0-snapshot/CodeSystem-crmi-release-version-behavior-codes.html
+    if (parsedParams.versionBehavior === 'check') {
+      logger.info('Applying check version behavior');
+      // check: if the root artifact has a specified version different from the version passed in, an error will be returned
+      // Developer note: this is assumed to be the behavior for child artifacts as well
+      if (parsedParams.releaseVersion !== measure.version) {
+        throw new BadRequestError(
+          `Measure with id: ${measure.id} has version ${measure.version}, which does not match the passed release version ${parsedParams.releaseVersion}`
+        );
+      }
+    } else if (parsedParams.versionBehavior === 'force') {
+      logger.info('Applying force version behavior');
+      // force: version provided will be applied to the root and all children, regardless of whether a version was already specified
+      measure.version = parsedParams.releaseVersion;
+    } else {
+      logger.info('Applying default version behavior');
+      // default: version provided will be applied to the root artifact and all children if a version is not specified.
+      // Developer note: this is currently a null operation because version is a required field
+    }
+
+    // recursively get any child artifacts from the artifact if they exist
+    const children = measure.relatedArtifact ? await getChildren(measure.relatedArtifact) : [];
+    children.forEach(child => {
+      child.status = 'active';
+      child.date = new Date().toISOString();
+      if (parsedParams.versionBehavior === 'check') {
+        if (parsedParams.releaseVersion !== child.version) {
+          throw new BadRequestError(
+            `Child artifact with id: ${child.id} has version ${child.version}, which does not match the passed release version ${parsedParams.releaseVersion}`
+          );
+        }
+      } else if (parsedParams.versionBehavior === 'force') {
+        child.version = parsedParams.releaseVersion;
+      }
+    });
+
+    // batch update the released parent Measure and any of its children
+    const releasedArtifacts = await batchUpdate([measure, ...(await Promise.all(children))], 'release');
+
+    // return a Bundle containing the updated artifacts
+    return createBatchResponseBundle(releasedArtifacts);
   }
 
   /**

--- a/service/test/services/LibraryService.test.ts
+++ b/service/test/services/LibraryService.test.ts
@@ -1527,6 +1527,34 @@ describe('LibraryService', () => {
         .set('content-type', 'application/fhir+json')
         .expect(400)
     });
+
+    it('returns 400 status with force release version behavior with force into a url/version collision', async () => {
+      await createTestResource(
+        {
+          resourceType: 'Library',
+          id: 'collision-test',
+          url: 'http://example.com/release-child1', //same as existing
+          status: 'draft',
+          type: { coding: [{ code: 'logic-library' }] },
+          version: 'collision', //collision version
+          title: 'Sample title',
+          description: 'Sample description'
+        },
+        'Library'
+      );
+
+      await supertest(server.app)
+        .post('/4_0_1/Library/release-child1/$release')
+        .send({
+          resourceType: 'Parameters',
+          parameter: [
+            { name: 'releaseVersion', valueCode: 'collision' },
+            { name: 'versionBehavior', valueString: 'force' }
+          ]
+        })
+        .set('content-type', 'application/fhir+json')
+        .expect(400);
+    });
   });
 
   afterAll(cleanUpTestDatabase);

--- a/service/test/services/LibraryService.test.ts
+++ b/service/test/services/LibraryService.test.ts
@@ -1,6 +1,6 @@
 import { initialize, Server } from '@projecttacoma/node-fhir-server-core';
 import { serverConfig } from '../../src/config/serverConfig';
-import { cleanUpTestDatabase, setupTestDatabase, createTestResource } from '../utils';
+import { cleanUpTestDatabase, setupTestDatabase, createTestResource, removeTestResource } from '../utils';
 import supertest from 'supertest';
 import { Calculator } from 'fqm-execution';
 import { CRMIShareableLibrary } from '../../src/types/service-types';
@@ -1348,6 +1348,184 @@ describe('LibraryService', () => {
           expect(response.body.entry[0].resource.date).toBeDefined();
           expect(response.body.entry[1].resource.date).toBeDefined();
         });
+    });
+  });
+
+  describe('$release', () => {
+    beforeEach(async () => {
+      await createTestResource(
+        {
+          resourceType: 'Library',
+          id: 'release-child1',
+          url: 'http://example.com/release-child1',
+          status: 'draft',
+          relatedArtifact: [
+            {
+              type: 'composed-of',
+              resource: 'http://example.com/release-child2|1',
+              extension: [
+                {
+                  url: 'http://hl7.org/fhir/StructureDefinition/artifact-isOwned',
+                  valueBoolean: true
+                }
+              ]
+            }
+          ],
+          ...LIBRARY_BASE
+        },
+        'Library'
+      );
+      await createTestResource(
+        {
+          resourceType: 'Library',
+          id: 'release-child2',
+          url: 'http://example.com/release-child2',
+          status: 'draft',
+          extension: [
+            {
+              url: 'http://hl7.org/fhir/StructureDefinition/artifact-isOwned',
+              valueBoolean: true
+            }
+          ],
+          ...LIBRARY_BASE
+        },
+        'Library'
+      );
+    });
+
+    afterEach(async () => {
+      await removeTestResource('release-child1', 'Library');
+      await removeTestResource('release-child2', 'Library');
+    });
+
+    it('returns 200 status with a Bundle result containing the updated parent Library artifact and any children it has for GET /Library/$release', async () => {
+      await supertest(server.app)
+        .get('/4_0_1/Library/$release')
+        .query({
+          id: 'release-child1',
+          releaseVersion: '2',
+          versionBehavior: 'force'
+        })
+        .set('Accept', 'application/json+fhir')
+        .expect(200)
+        .then(response => {
+          expect(response.body.total).toEqual(2);
+          expect(response.body.entry[0].resource.date).toBeDefined();
+          expect(response.body.entry[0].resource.status).toEqual('active');
+          expect(response.body.entry[0].resource.version).toEqual('2');
+          expect(response.body.entry[1].resource.date).toBeDefined();
+          expect(response.body.entry[1].resource.status).toEqual('active');
+          expect(response.body.entry[1].resource.version).toEqual('2');
+        });
+    });
+
+    it('returns 200 status with a Bundle result containing the updated parent Library artifact and any children it has for GET /Library/[id]/$release', async () => {
+      await supertest(server.app)
+        .get('/4_0_1/Library/release-child1/$release')
+        .query({
+          releaseVersion: '2',
+          versionBehavior: 'force'
+        })
+        .set('Accept', 'application/json+fhir')
+        .expect(200)
+        .then(response => {
+          expect(response.body.total).toEqual(2);
+        });
+    });
+
+    it('returns 200 status with a Bundle result containing the updated parent Library artifact and any children it has for POST /Library/$release', async () => {
+      await supertest(server.app)
+        .post('/4_0_1/Library/$release')
+        .send({
+          resourceType: 'Parameters',
+          parameter: [
+            { name: 'id', valueString: 'release-child1' },
+            { name: 'releaseVersion', valueCode: '2' },
+            { name: 'versionBehavior', valueString: 'force' }
+          ]
+        })
+        .set('content-type', 'application/fhir+json')
+        .expect(200)
+        .then(response => {
+          expect(response.body.total).toEqual(2);
+          expect(response.body.entry[0].resource.date).toBeDefined();
+          expect(response.body.entry[0].resource.status).toEqual('active');
+          expect(response.body.entry[0].resource.version).toEqual('2');
+          expect(response.body.entry[1].resource.date).toBeDefined();
+          expect(response.body.entry[1].resource.status).toEqual('active');
+          expect(response.body.entry[1].resource.version).toEqual('2');
+        });
+    });
+
+    it('returns 200 status with a Bundle result containing the updated parent Library artifact and any children it has for POST /Library/[id]/$release', async () => {
+      await supertest(server.app)
+        .post('/4_0_1/Library/release-child1/$release')
+        .send({
+          resourceType: 'Parameters',
+          parameter: [
+            { name: 'releaseVersion', valueCode: '2' },
+            { name: 'versionBehavior', valueString: 'force' }
+          ]
+        })
+        .set('content-type', 'application/fhir+json')
+        .expect(200)
+        .then(response => {
+          expect(response.body.total).toEqual(2);
+          expect(response.body.entry[0].resource.date).toBeDefined();
+          expect(response.body.entry[1].resource.date).toBeDefined();
+        });
+    });
+
+    it('returns 200 status and does not update the version with default release version behavior', async () => {
+      await supertest(server.app)
+        .post('/4_0_1/Library/release-child1/$release')
+        .send({
+          resourceType: 'Parameters',
+          parameter: [
+            { name: 'releaseVersion', valueCode: '2' },
+            { name: 'versionBehavior', valueString: 'default' }
+          ]
+        })
+        .set('content-type', 'application/fhir+json')
+        .expect(200)
+        .then(response => {
+          expect(response.body.total).toEqual(2);
+          expect(response.body.entry[0].resource.version).toEqual('1');
+          expect(response.body.entry[0].resource.status).toEqual('active');
+          expect(response.body.entry[1].resource.version).toEqual('1');
+          expect(response.body.entry[1].resource.status).toEqual('active');
+        });
+    });
+
+    it('returns 200 status with check release version behavior with matching versions', async () => {
+      await supertest(server.app)
+        .post('/4_0_1/Library/release-child1/$release')
+        .send({
+          resourceType: 'Parameters',
+          parameter: [
+            { name: 'releaseVersion', valueCode: '1' },
+            { name: 'versionBehavior', valueString: 'check' }
+          ]
+        })
+        .set('content-type', 'application/fhir+json')
+        .expect(200)
+        .then(response => {
+          expect(response.body.total).toEqual(2);
+        });
+    });
+
+    it('returns 400 status with check release version behavior with mismatched versions', async () => {
+      await supertest(server.app)
+        .post('/4_0_1/Library/release-child1/$release')
+        .send({
+          resourceType: 'Parameters',
+          parameter: [
+            { name: 'releaseVersion', valueCode: '2' },
+            { name: 'versionBehavior', valueString: 'check' }
+          ]
+        })
+        .set('content-type', 'application/fhir+json')
+        .expect(400)
     });
   });
 

--- a/service/test/services/MeasureService.test.ts
+++ b/service/test/services/MeasureService.test.ts
@@ -1630,6 +1630,33 @@ describe('MeasureService', () => {
         .set('content-type', 'application/fhir+json')
         .expect(400)
     });
+    
+    it('returns 400 status with force release version behavior with force into a url/version collision', async () => {
+      await createTestResource(
+        {
+          resourceType: 'Measure',
+          id: 'collision-test',
+          url: 'http://example.com/release-measure', //same as existing
+          status: 'draft',
+          version: 'collision', //collision version
+          title: 'Sample title',
+          description: 'Sample description'
+        },
+        'Measure'
+      );
+
+      await supertest(server.app)
+        .post('/4_0_1/Measure/release-measure/$release')
+        .send({
+          resourceType: 'Parameters',
+          parameter: [
+            { name: 'releaseVersion', valueCode: 'collision' },
+            { name: 'versionBehavior', valueString: 'force' }
+          ]
+        })
+        .set('content-type', 'application/fhir+json')
+        .expect(400);
+    });
   });
 
   afterAll(cleanUpTestDatabase);

--- a/service/test/utils.ts
+++ b/service/test/utils.ts
@@ -6,6 +6,11 @@ export async function createTestResource(data: FhirArtifact, resourceType: Artif
   await collection.insertOne({ ...data });
 }
 
+export async function removeTestResource(id: string, resourceType: ArtifactResourceType) {
+  const collection = Connection.db.collection(resourceType);
+  await collection.deleteOne({ id });
+}
+
 export async function cleanUpTestDatabase() {
   await Connection.db.dropDatabase();
   await Connection.connection?.close();


### PR DESCRIPTION
# Summary
Implements the `$release` endpoint in the server according to the [CRMI IG definition](https://hl7.org/fhir/uv/crmi/OperationDefinition-crmi-release.html).

## New behavior
The user can now release a Measure or Library draft artifact and any resources it is composed of by sending a GET or POST request to `Measure/$release`, `Measure/:id/$release`, `Library/$release` and `Library/:id/$release`. This operation takes three required parameters: `id`, `releaseVersion`, and `versionBehavior`. It updates the artifact and children artifact `date` and `version`. For pieces of the spec that are a unclear, questions have been added to the connectathon document.

## Code changes
- `service/README.md` - add description of `$release`
- `service/scripts/dbSetup.ts` - add check for publishable environment before coercing to active
- `service/src/config/capabilityStatementResources.json` - add crmi-release
- `service/src/config/serverConfig.ts` - add `release` endpoints
- `service/src/requestSchemas` - add ReleaseArgs for type checking
- `service/src/services/LibraryService.ts` / `service/src/services/MeasureService.ts` - add `release` function
- `service/test/services/LibraryService.test.ts` / `service/test/services/MeasureService.test.ts` - added unit tests 
- `service/test/utils.ts` - add utility for removing test resources

Note: I believe all instances of `catchMissingId` in RequestSchemas are unnecessary because id is a strict required parameter already in zod args definition. Any problem with removing them?

# Testing guidance
Ensure env has `AUTHORING=true` to allow for draft artifacts to exist
In service folder...
- `npm run check`
- `npm run build`
- `npm run db:reset`
- `npm run db:loadBundle {pathToNestedChild-draft.json}` (change an existing nested child bundle to make root artifact and all children status `draft` or ask me for a sample bundle)
- `npm run start`

Run through the attached Insomnia tests (and fiddle with to test any other edge cases)
You can repeat the 
- `npm run db:reset`
- `npm run db:loadBundle {pathToNestedChild-draft.json}`

steps between Insomnia tests to ensure the correct draft artifact exists

Insomnia requests:
[release-requests.json](https://github.com/user-attachments/files/16784583/release-requests.json)

