### PR TITLE
Child artifact deletion and retire

### DIFF
--- a/service/README.md
+++ b/service/README.md
@@ -113,6 +113,7 @@ This server currently supports the following CRUD operations:
   - Publishable:
     - Supports the _Publishable_ minimum write capability _retire_
     - Artifact must be in active status and may only change the status to retired and update the date (and other metadata appropriate to indicate retired status)
+    - Note: While it is not yet mentioned in the specification, _retire_ supports the update of an artifact as well as any resources it is composed of, recursively
   - Authoring:
     - Supports the additional _Authoring_ capability _revise_
     - Artifact must be in (and remain in) draft status
@@ -121,9 +122,11 @@ This server currently supports the following CRUD operations:
   - Publishable:
     - Supports the _Publishable_ minimum write capability _archive_
     - Artifact must be in retired status
+    - Note: While it is not yet mentioned in the specification, _archive_ supports the deletion of an artifact in retired status as well as any resources it is composed of, recursively
   - Authoring:
     - Supports the additional _Authoring_ capability _withdraw_
     - Artifact must be in draft status
+    - Note: While it is not yet mentioned in the specification, _withdraw_ supports the deletion of an artifact in draft status as well as any resources it is composed of, recursively
 
 ### Search
 

--- a/service/src/services/LibraryService.ts
+++ b/service/src/services/LibraryService.ts
@@ -1,9 +1,9 @@
 import { loggers, RequestArgs, RequestCtx } from '@projecttacoma/node-fhir-server-core';
 import {
+  batchDelete,
   batchInsert,
   batchUpdate,
   createResource,
-  deleteResource,
   findDataRequirementsWithQuery,
   findResourceById,
   findResourceCountWithQuery,
@@ -186,16 +186,33 @@ export class LibraryService implements Service<CRMIShareableLibrary> {
   }
 
   /**
+   * archive: deletes a library and any resources it is composed of with 'retried' status
+   * withdraw: deletes a library and any resources it is composed of with 'draft' status
    * result of sending a DELETE request to {BASE_URL}/4_0_1/Library/{id}
    * deletes the library with the passed in id if it exists in the database
+   * as well as all resources it is composed of
+   * requires id parameter
    */
   async remove(args: RequestArgs) {
-    const resource = (await findResourceById(args.id, 'Library')) as CRMIShareableLibrary | null;
-    if (!resource) {
-      throw new ResourceNotFoundError(`Existing resource not found with id ${args.id}`);
+    const library = await findResourceById<CRMIShareableLibrary>(args.id, 'Library');
+    if (!library) {
+      throw new ResourceNotFoundError(`No resource found in collection: Library, with id: ${args.id}`);
     }
-    checkFieldsForDelete(resource);
-    return deleteResource(args.id, 'Library');
+    checkFieldsForDelete(library);
+    const archiveOrWithdraw = library.status === 'retired' ? 'archive' : 'withdraw';
+    checkIsOwned(
+      library,
+      `Child artifacts cannot be directly ${archiveOrWithdraw === 'archive' ? 'archived' : 'withdrawn'}`
+    );
+
+    // recursively get any child artifacts from the artifact if they exist
+    const children = library.relatedArtifact ? await getChildren(library.relatedArtifact) : [];
+
+    // now we want to batch delete (archive/withdraw) the Library artifact and any of its children
+    const newDeletes = await batchDelete([library, ...children], archiveOrWithdraw);
+
+    // we want to return a Bundle containing the deleted artifacts
+    return createBatchResponseBundle(newDeletes);
   }
 
   /**

--- a/service/src/services/MeasureService.ts
+++ b/service/src/services/MeasureService.ts
@@ -166,32 +166,6 @@ export class MeasureService implements Service<CRMIShareableMeasure> {
   }
 
   /**
-   * result of sending a PUT request to {BASE_URL}/4_0_1/Measure/{id}
-   * updates the measure with the passed in id using the passed in data
-   * or creates a measure with passed in id if it does not exist in the database
-   */
-  // async update(args: RequestArgs, { req }: RequestCtx) {
-  //   logger.info(`PUT /Measure/${args.id}`);
-  //   const contentType: string | undefined = req.headers['content-type'];
-  //   checkContentTypeHeader(contentType);
-  //   const resource = req.body;
-  //   checkExpectedResourceType(resource.resourceType, 'Measure');
-  //   // Throw error if the id arg in the url does not match the id in the request body
-  //   if (resource.id !== args.id) {
-  //     throw new BadRequestError('Argument id must match request body id for PUT request');
-  //   }
-  //   const oldResource = (await findResourceById(resource.id, resource.resourceType)) as CRMIShareableMeasure | null;
-  //   // note: the distance between this database call and the update resource call, could cause a race condition
-  //   if (oldResource) {
-  //     checkFieldsForUpdate(resource, oldResource);
-  //   } else {
-  //     checkFieldsForCreate(resource);
-  //   }
-
-  //   return updateResource(args.id, resource, 'Measure');
-  // }
-
-  /**
    * retire: only updates a measure with status 'active' to have status 'retired'
    * and any resource it is composed of
    *
@@ -223,7 +197,7 @@ export class MeasureService implements Service<CRMIShareableMeasure> {
         });
 
         // now we want to batch update the retired parent Measure and any of its children
-        await batchUpdate([resource, ...(await Promise.all(children))], 'review');
+        await batchUpdate([resource, ...(await Promise.all(children))], 'retire');
 
         return { id: args.id, created: false };
       }


### PR DESCRIPTION
# Summary
This PR ensures that the Publishable Measure Repository `archive` DELETE and the Authoring Measure Repository `withdraw` DELETE interactions include handling of child artifacts. Additionally, it includes handling of child artifacts for the Publishable Measure Repository `retire` UPDATE interaction.

## New behavior
- When sending a DELETE request (withdraw) to an artifact with status `draft`, it now also deletes any resources it is composed of, recursively.
- When sending a DELETE request (archive) to an artifact with status `retired`, it now also deletes any resources it is composed of, recursively.
- When sending an UPDATE request (retire) to an artifact with status `active` where the only update is the date changing and the status changing to `retired`, it now also updates any resources it is composed of, recursively.

## Code changes
- `README.md` - Readme updates. Let me know if anything else should be included but the README is looking good!
- `service/src/db/dbOperations.ts` - remove `deleteResource` function (no longer used) and add `batchDelete` function that deletes resources in a batch transaction.
- `service/src/services/LibraryService.ts` / `service/src/services/MeasureService.ts` - update `update` to include check for `retire` interaction so that child artifacts can be included in the update, update `remove` to include handling of child artifacts in a batch delete transaction

# Testing guidance
- `cd service`
- `npm run db:reset`
- `npm run db:loadBundle <path to nested child artifact bundle>`
- `cd ..`
- `npm run build:all`
- `npm run check:all`
- `npm run start:all`
- Attached is an Insomnia collection of some example requests, but please test the following scenarios: 

Update:
-  An artifact with children with status `draft` - cannot update status, any other updates can only be made to individual draft artifacts (i.e., an update made to a parent artifact cannot update any of its children until further guidance is provided)
- An artifact with children with status `retired` - error
- An artifact with children with status `active` - can only update status to specifically `retired` and `date`, all children should also be updated

Delete:
- An artifact with children with status `draft` - delete all
- An artifact with children with status `retired` - delete all
- An artifact with children with status `active` - error

[WriteCapabilities.json](https://github.com/user-attachments/files/17213644/WriteCapabilities.json)

