### PR TITLE
create transaction response bundle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2791,18 +2791,20 @@
       }
     },
     "node_modules/@projecttacoma/fhir-response-util": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@projecttacoma/fhir-response-util/-/fhir-response-util-1.2.5.tgz",
-      "integrity": "sha512-Vvz3DcXZ2YRWwPbKeqAzeheykiWYcRO5WdXEz6iQKlPgFQHFB3rml7g3NcEkTrxlwwDb0C86Yg682PJDW1Q0GA=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@projecttacoma/fhir-response-util/-/fhir-response-util-1.3.0.tgz",
+      "integrity": "sha512-isPMoLabjZEwlc5pQid/XBCDyTAB0NQlzI+NH/xAChYx68ooVDB9tq0yRbmFBAdJ/cLhq5QbLP9ImVhRiViBeA==",
+      "license": "MIT"
     },
     "node_modules/@projecttacoma/node-fhir-server-core": {
-      "version": "2.2.8",
-      "resolved": "https://registry.npmjs.org/@projecttacoma/node-fhir-server-core/-/node-fhir-server-core-2.2.8.tgz",
-      "integrity": "sha512-tGyc/VFQI474JXMxbpfjQfS2zaJVO+tBcx146n0rHWy5LvvGZ4DKV7t1qKKq9co/UVFwQXat0d7loPAKNitzPg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@projecttacoma/node-fhir-server-core/-/node-fhir-server-core-2.3.0.tgz",
+      "integrity": "sha512-GQoHU92Q3vEAdTH49RK7NTHdFl70moGHy5URW9+YX7Cy9ofEZDZI8aeWakqGnplSFnOxnNp/0IRIaEa+fn1DQA==",
+      "license": "MIT",
       "dependencies": {
         "@asymmetrik/sof-scope-checker": "^1.0.7",
         "@hapi/bourne": "^1.3.2",
-        "@projecttacoma/fhir-response-util": "^1.2.5",
+        "@projecttacoma/fhir-response-util": "^1.3.0",
         "body-parser": "^1.18.2",
         "compression": "^1.7.1",
         "cors": "^2.8.4",
@@ -13739,7 +13741,7 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@projecttacoma/node-fhir-server-core": "^2.2.8",
+        "@projecttacoma/node-fhir-server-core": "^2.3.0",
         "cors": "^2.8.5",
         "dotenv": "^16.0.3",
         "express": "^4.19.2",

--- a/service/package.json
+++ b/service/package.json
@@ -49,7 +49,7 @@
     "typescript": "^4.9.3"
   },
   "dependencies": {
-    "@projecttacoma/node-fhir-server-core": "^2.2.8",
+    "@projecttacoma/node-fhir-server-core": "^2.3.0",
     "cors": "^2.8.5",
     "dotenv": "^16.0.3",
     "express": "^4.19.2",

--- a/service/src/services/LibraryService.ts
+++ b/service/src/services/LibraryService.ts
@@ -28,7 +28,8 @@ import {
   createLibraryPackageBundle,
   createPaginationLinks,
   createSearchsetBundle,
-  createSummarySearchsetBundle
+  createSummarySearchsetBundle,
+  createTransactionResponseBundle
 } from '../util/bundleUtils';
 import { BadRequestError, ResourceNotFoundError } from '../util/errorUtils';
 import { getMongoQueryFromRequest } from '../util/queryUtils';
@@ -231,7 +232,7 @@ export class LibraryService implements Service<CRMIShareableLibrary> {
     const newDeletes = await batchDelete([library, ...children], archiveOrWithdraw);
 
     // we want to return a Bundle containing the deleted artifacts
-    return createBatchResponseBundle(newDeletes);
+    return createTransactionResponseBundle(newDeletes);
   }
 
   /**

--- a/service/src/services/MeasureService.ts
+++ b/service/src/services/MeasureService.ts
@@ -17,7 +17,8 @@ import {
   createPaginationLinks,
   createMeasurePackageBundle,
   createSearchsetBundle,
-  createSummarySearchsetBundle
+  createSummarySearchsetBundle,
+  createTransactionResponseBundle
 } from '../util/bundleUtils';
 import { BadRequestError, ResourceNotFoundError } from '../util/errorUtils';
 import { getMongoQueryFromRequest } from '../util/queryUtils';
@@ -235,7 +236,7 @@ export class MeasureService implements Service<CRMIShareableMeasure> {
     const newDeletes = await batchDelete([measure, ...children], archiveOrWithdraw);
 
     // we want to return a Bundle containing the deleted artifacts
-    return createBatchResponseBundle(newDeletes);
+    return createTransactionResponseBundle(newDeletes);
   }
 
   /**

--- a/service/src/util/bundleUtils.ts
+++ b/service/src/util/bundleUtils.ts
@@ -45,6 +45,17 @@ export function createBatchResponseBundle<T extends FhirArtifact>(entries: T[]):
   };
 }
 
+export function createTransactionResponseBundle<T extends FhirArtifact>(entries: T[]): fhir4.Bundle<T> {
+  return {
+    resourceType: 'Bundle',
+    meta: { lastUpdated: new Date().toISOString() },
+    id: v4(),
+    type: 'transaction-response',
+    total: entries.length,
+    entry: entries.map(e => ({ resource: e }))
+  };
+}
+
 /**
  *
  * Takes in a number of FHIR resources and creates a FHIR searchset Bundle without entries

--- a/service/test/services/LibraryService.test.ts
+++ b/service/test/services/LibraryService.test.ts
@@ -642,19 +642,25 @@ describe('LibraryService', () => {
         'Library'
       );
     });
-    it('withdraw: returns 204 status when deleting a draft artifact', async () => {
+    it('withdraw: returns 200 status when deleting a draft artifact', async () => {
       await supertest(server.app)
         .delete('/4_0_1/Library/delete-draft')
         .send()
         .set('content-type', 'application/json+fhir')
-        .expect(204);
+        .expect(200)
+        .then(response => {
+          expect(response.body.entry[0].resource.id).toEqual('delete-draft');
+        });
     });
-    it('archive: returns 204 status when deleting a retired artifact', async () => {
+    it('archive: returns 200 status when deleting a retired artifact', async () => {
       await supertest(server.app)
         .delete('/4_0_1/Library/delete-retired')
         .send()
         .set('content-type', 'application/json+fhir')
-        .expect(204);
+        .expect(200)
+        .then(response => {
+          expect(response.body.entry[0].resource.id).toEqual('delete-retired');
+        });
     });
     it('archive: returns 400 status when deleting an active artifact', async () => {
       await supertest(server.app)

--- a/service/test/services/MeasureService.test.ts
+++ b/service/test/services/MeasureService.test.ts
@@ -645,20 +645,26 @@ describe('MeasureService', () => {
       );
     });
 
-    it('withdraw: returns 204 status when deleting a draft artifact', async () => {
+    it('withdraw: returns 200 status when deleting a draft artifact', async () => {
       await supertest(server.app)
         .delete('/4_0_1/Measure/delete-draft')
         .send()
         .set('content-type', 'application/json+fhir')
-        .expect(204);
+        .expect(200)
+        .then(response => {
+          expect(response.body.entry[0].resource.id).toEqual('delete-draft');
+        });
     });
 
-    it('archive: returns 204 status when deleting a retired artifact', async () => {
+    it('archive: returns 200 status when deleting a retired artifact', async () => {
       await supertest(server.app)
         .delete('/4_0_1/Measure/delete-retired')
         .send()
         .set('content-type', 'application/json+fhir')
-        .expect(204);
+        .expect(200)
+        .then(response => {
+          expect(response.body.entry[0].resource.id).toEqual('delete-retired');
+        });
     });
 
     it('archive: returns 400 status when deleting an active artifact', async () => {


### PR DESCRIPTION
# Summary
Change delete response to respond with a `transaction-response` bundle as described further in PR here:
https://github.com/projecttacoma/node-fhir-server-core/pull/49

## New behavior

## Code changes

# Testing guidance
