### PR TITLE
Change service location in frontend, another upload script

### DIFF
--- a/app/src/pages/index.tsx
+++ b/app/src/pages/index.tsx
@@ -67,7 +67,7 @@ export default function Home({
       <Divider my="sm" variant="dotted" />
       <Title order={2}>Service Location:</Title>
       <div style={{ marginTop: '18px', marginBottom: '18px' }}>
-        <Anchor href={`${serviceUri}/metadata`}>{`${serviceUri}/metadata`}</Anchor>
+        <Anchor href={`${serviceUri}`}>{`${serviceUri}`}</Anchor>
       </div>
       <Divider my="sm" variant="dotted" />
       <Title order={2}>Service Capabilities:</Title>

--- a/service/README.md
+++ b/service/README.md
@@ -64,6 +64,18 @@ To load [ecqm-content-qicore-2024](https://github.com/cqframework/ecqm-content-q
 npm run db:loadEcqmContent <optional service url, default: http://localhost:3000/4_0_1>
 ```
 
+To load a measure bundle and related library artifacts, and coerce all of their statuses to `active`, run:
+
+```
+npm run db:loadPublishableContent <path to measure bundle>
+```
+
+To load multiple bundles from a directory, and coerce all of their statuses to `active`, run:
+
+```
+npm run db:loadPublishableContent <path to directory>
+```
+
 ### Bundle Upload Details
 
 Upon uploading a Measure resource, the Measure's main library is added to the `relatedArtifact` array with an [isOwned extension](https://build.fhir.org/ig/HL7/fhir-extensions/StructureDefinition-artifact-isOwned.html).

--- a/service/package.json
+++ b/service/package.json
@@ -15,6 +15,7 @@
     "db:loadBundle": "ts-node ./scripts/dbSetup.ts loadBundle",
     "db:postBundle": "ts-node ./scripts/dbSetup.ts postBundle",
     "db:loadEcqmContent": "ts-node ./scripts/dbSetup.ts loadEcqmContent",
+    "db:loadPublishableContent": "ts-node ./scripts/dbSetup.ts loadPublishableContent",
     "lint": "eslint \"./src/**/*.{js,ts}\"",
     "lint:fix": "eslint \"./src/**/*.{js,ts}\" --fix",
     "prettier": "prettier --check \"./src/**/*.{js,ts}\"",


### PR DESCRIPTION
# Summary
This PR changes the service location URL in the frontend app to no longer have the `/metadata` endpoint. It also adds a new db option: `loadPublishableContent`. This essentially does the same thing as `loadBundle` (takes a measure bundle or directory of measure bundles and uploads them to the measure repository service); however, the one difference is that if there are any `draft` artifacts in the measure, they will be coerced to `active` so they can be uploaded without error.

## New behavior
- `npm run db:loadPublishableContent` script

## Code changes
- `README.md` - additions regarding new db upload option
- `package.json` - `npm run db:loadPublishableContent`
- `app/src/pages/index.tsx` - remove `/metadata`
- `service/scripts/dbSetup.ts` - `loadPublishableContent` now allows measure bundle and measure bundle directory upload while coercing artifacts to `active`

# Testing guidance
- `cd service`
- `npm run db:reset`
- `npm run db:loadContentBundle <path to one of the bundles where Measure has status draft>`
- `cd ..`
- `npm run start:all`
- Make sure Measure has been uploaded with status `active`
- Check Service Location URL in frontend  