### PR TITLE
Pub auth frontend

### DIFF
--- a/app/src/components/ResourceInfoCard.tsx
+++ b/app/src/components/ResourceInfoCard.tsx
@@ -39,6 +39,7 @@ export default function ResourceInfoCard({ resourceInfo, authoring }: ResourceIn
   const utils = trpc.useUtils();
   const [isDeleteConfirmationModalOpen, setIsDeleteConfirmationModalOpen] = useState(false);
   const [isCloneConfirmationModalOpen, setIsCloneConfirmationModalOpen] = useState(false);
+  const authoringEnvironment = trpc.service.getAuthoring.useQuery();
 
   const successNotification = (resourceType: string, childArtifact: boolean, action: string, idOrUrl?: string) => {
     let message;
@@ -180,19 +181,24 @@ export default function ResourceInfoCard({ resourceInfo, authoring }: ResourceIn
                 </ActionIcon>
               </Tooltip>
             </Link>
-            <Link
-              href={{
-                pathname: `/review/${resourceInfo.resourceType}/${resourceInfo.id}`,
-                query: { authoring: `${authoring}` }
-              }}
-            >
-              <Tooltip label={authoring ? 'Review Draft Resource' : 'Review Resource'} openDelay={1000}>
-                <ActionIcon radius="md" size="md" variant="subtle" color="blue">
-                  <Report size="24" />
-                </ActionIcon>
-              </Tooltip>
-            </Link>
+            {authoringEnvironment.data ? (
+              <Link
+                href={{
+                  pathname: `/review/${resourceInfo.resourceType}/${resourceInfo.id}`,
+                  query: { authoring: `${authoring}` }
+                }}
+              >
+                <Tooltip label={authoring ? 'Review Draft Resource' : 'Review Resource'} openDelay={1000}>
+                  <ActionIcon radius="md" size="md" variant="subtle" color="blue">
+                    <Report size="24" />
+                  </ActionIcon>
+                </Tooltip>
+              </Link>
+            ) : (
+              <></>
+            )}
             {authoring &&
+              authoringEnvironment &&
               (resourceInfo.isChild ? (
                 <Group>
                   <Tooltip label={'Child artifacts cannot be directly cloned'}>

--- a/app/src/components/SearchComponent.tsx
+++ b/app/src/components/SearchComponent.tsx
@@ -115,7 +115,7 @@ export default function SearchComponent({ resourceType }: SearchComponentProps) 
       requestParams.push({ name: 'version', value: version });
     }
     const query = requestParams.filter(si => si.value !== '').map(si => si.name + '=' + si.value);
-    return query.length !== 0 ? `?${query.join('&')}` : '';
+    return query.length !== 0 ? `?status=active&${query.join('&')}` : '?status=active';
   };
 
   return (

--- a/app/src/pages/[resourceType]/[id].tsx
+++ b/app/src/pages/[resourceType]/[id].tsx
@@ -50,6 +50,7 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
 
   const ctx = trpc.useContext();
   const router = useRouter();
+  const authoring = trpc.service.getAuthoring.useQuery();
 
   // Overwrite Prism with our custom Prism that includes CQL as a language
   useEffect(() => {
@@ -150,31 +151,36 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
     <div>
       <Stack spacing="xs">
         <div>
-          <Group position="apart">
-            <Text size="xl" color="gray">
-              {jsonData.resourceType}/{jsonData.id}
-            </Text>
-            {!!jsonData?.extension?.find(
-              ext => ext.url === 'http://hl7.org/fhir/StructureDefinition/artifact-isOwned' && ext.valueBoolean === true
-            ) ? (
-              <Tooltip label="Child artifacts cannot be directly drafted">
-                <span>
-                  <Button w={240} loading={draftFromArtifactMutation.isLoading} disabled={true}>
-                    Create Draft of {jsonData.resourceType}
-                  </Button>
-                </span>
-              </Tooltip>
-            ) : (
-              <Button
-                w={240}
-                loading={draftFromArtifactMutation.isLoading}
-                onClick={createDraftOfArtifact}
-                disabled={false}
-              >
-                Create Draft of {jsonData.resourceType}
-              </Button>
-            )}
-          </Group>
+          {authoring.data ? (
+            <Group position="apart">
+              <Text size="xl" color="gray">
+                {jsonData.resourceType}/{jsonData.id}
+              </Text>
+              {!!jsonData?.extension?.find(
+                ext =>
+                  ext.url === 'http://hl7.org/fhir/StructureDefinition/artifact-isOwned' && ext.valueBoolean === true
+              ) ? (
+                <Tooltip label="Child artifacts cannot be directly drafted">
+                  <span>
+                    <Button w={240} loading={draftFromArtifactMutation.isLoading} disabled={true}>
+                      Create Draft of {jsonData.resourceType}
+                    </Button>
+                  </span>
+                </Tooltip>
+              ) : (
+                <Button
+                  w={240}
+                  loading={draftFromArtifactMutation.isLoading}
+                  onClick={createDraftOfArtifact}
+                  disabled={false}
+                >
+                  Create Draft of {jsonData.resourceType}
+                </Button>
+              )}
+            </Group>
+          ) : (
+            <></>
+          )}
         </div>
         <Divider my="sm" pb={6} />
         <Tabs variant="outline" defaultValue="json" value={activeTab} onTabChange={setActiveTab}>

--- a/app/src/pages/_app.tsx
+++ b/app/src/pages/_app.tsx
@@ -41,6 +41,7 @@ const useStyles = createStyles(theme => ({
 function App({ Component, pageProps }: AppProps) {
   const router = useRouter();
   const { classes } = useStyles();
+  const authoring = trpc.service.getAuthoring.useQuery();
 
   return (
     <>
@@ -139,17 +140,21 @@ function App({ Component, pageProps }: AppProps) {
                     Repository
                   </Text>
                 </Link>
-                <Link href="/authoring">
-                  <Text
-                    c={
-                      router.asPath.endsWith(`authoring=true`) || router.pathname.startsWith('/authoring')
-                        ? 'orange.3'
-                        : 'gray.4'
-                    }
-                  >
-                    Authoring
-                  </Text>
-                </Link>
+                {authoring.data ? (
+                  <Link href="/authoring">
+                    <Text
+                      c={
+                        router.asPath.endsWith(`authoring=true`) || router.pathname.startsWith('/authoring')
+                          ? 'orange.3'
+                          : 'gray.4'
+                      }
+                    >
+                      Authoring
+                    </Text>
+                  </Link>
+                ) : (
+                  <> </>
+                )}
               </Group>
             </Header>
           }

--- a/app/src/pages/authoring/[resourceType]/[id].tsx
+++ b/app/src/pages/authoring/[resourceType]/[id].tsx
@@ -1,5 +1,5 @@
 import { trpc } from '@/util/trpc';
-import { Button, Center, Divider, Grid, Group, Paper, Select, Stack, Text, Tooltip } from '@mantine/core';
+import { Button, Center, Divider, Grid, Group, Paper, Select, Stack, Text, Title, Tooltip } from '@mantine/core';
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/router';
 import { Prism } from '@mantine/prism';
@@ -99,6 +99,15 @@ export default function ResourceAuthoringPage() {
       setLibrary(resource.library[0]);
     }
   }, [resource]);
+
+  const authoring = trpc.service.getAuthoring.useQuery();
+  if (!authoring.data) {
+    return (
+      <Center>
+        <Title> Authoring Unavailable </Title>
+      </Center>
+    );
+  }
 
   const resourceUpdate = trpc.draft.updateDraft.useMutation({
     onSuccess: () => {

--- a/app/src/pages/authoring/[resourceType]/index.tsx
+++ b/app/src/pages/authoring/[resourceType]/index.tsx
@@ -1,5 +1,5 @@
 import { trpc } from '@/util/trpc';
-import { Center, Text, Divider } from '@mantine/core';
+import { Center, Text, Divider, Title } from '@mantine/core';
 import { useRouter } from 'next/router';
 import { ArtifactResourceType, ResourceInfo } from '@/util/types/fhir';
 import ResourceCards from '@/components/ResourceCards';
@@ -15,6 +15,15 @@ export default function ResourceAuthoringPage() {
   const resourceCardContent: ResourceInfo[] = useMemo(() => {
     return (artifacts ?? []).map(a => extractResourceInfo(a));
   }, [artifacts]);
+
+  const authoring = trpc.service.getAuthoring.useQuery();
+  if (!authoring.data) {
+    return (
+      <Center>
+        <Title> Authoring Unavailable </Title>
+      </Center>
+    );
+  }
 
   return (
     <div>

--- a/app/src/pages/authoring/index.tsx
+++ b/app/src/pages/authoring/index.tsx
@@ -38,6 +38,15 @@ export default function AuthoringPage() {
   const { classes } = useStyles();
   const router = useRouter();
 
+  const authoring = trpc.service.getAuthoring.useQuery();
+  if (!authoring.data) {
+    return (
+      <Center>
+        <Title> Authoring Unavailable </Title>
+      </Center>
+    );
+  }
+
   const successNotification = (
     resourceType: string,
     createdFromArtifact: boolean,

--- a/app/src/pages/index.tsx
+++ b/app/src/pages/index.tsx
@@ -58,7 +58,7 @@ export default function Home({
         <Anchor href="http://hl7.org/fhir/us/cqfmeasures/measure-repository-service.html">
           FHIR Measure Repository Service
         </Anchor>{' '}
-        with Measure and Library authoring capabilities. See the{' '}
+        with Measure and Library management capabilities. See the{' '}
         <Anchor href="https://github.com/projecttacoma/measure-repository/blob/main/README.md">
           Measure Repository README
         </Anchor>{' '}
@@ -70,7 +70,16 @@ export default function Home({
         <Anchor href={`${serviceUri}/metadata`}>{`${serviceUri}/metadata`}</Anchor>
       </div>
       <Divider my="sm" variant="dotted" />
-      <Title order={2}>Service Capabilities:</Title>
+      <Title order={2}>
+        {!capabilityStatement
+          ? ''
+          : capabilityStatement.instantiates?.includes(
+              'http://hl7.org/fhir/us/cqfmeasures/CapabilityStatement/authoring-measure-repository'
+            )
+          ? 'Authoring '
+          : 'Publishable '}
+        Service Capabilities:
+      </Title>
       <div style={{ marginTop: '18px', marginBottom: '18px' }}>{renderCapabilityTable()}</div>
       <Center>
         <Group>

--- a/app/src/server/trpc/routers/service.ts
+++ b/app/src/server/trpc/routers/service.ts
@@ -13,6 +13,16 @@ export const serviceRouter = router({
     return process.env.PUBLIC_MRS_SERVER;
   }),
 
+  getAuthoring: publicProcedure.query(async () => {
+    // get authoring environment based on capability statement
+    const res = await fetch(`${process.env.MRS_SERVER}/metadata`);
+    const capabilityStatement = res.status === 200 ? ((await res.json()) as fhir4.CapabilityStatement) : null;
+    //defaults to publishable if capability statement cannot be resolved
+    return !!capabilityStatement?.instantiates?.includes(
+      'http://hl7.org/fhir/us/cqfmeasures/CapabilityStatement/authoring-measure-repository'
+    );
+  }),
+
   getArtifactCounts: publicProcedure.query(async () => {
     const [measureBundle, libraryBundle] = await Promise.all([
       fetch(`${process.env.MRS_SERVER}/Measure?_summary=count&status=active`),

--- a/service/src/config/publishableCapabilityStatementResources.json
+++ b/service/src/config/publishableCapabilityStatementResources.json
@@ -1,0 +1,327 @@
+{
+  "mode": "server",
+  "resource": [
+    {
+      "type": "Library",
+      "profile": "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-shareablelibrary",
+      "supportedProfile": [
+        "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablelibrary",
+        "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-publishablelibrary",
+        "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-executablelibrary",
+        "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-moduledefinitionlibrary",
+        "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-manifestlibrary"
+      ],
+      "interaction": [
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHALL"
+            }
+          ],
+          "code": "read",
+          "documentation": "Read allows clients to get the definitions and details of repository libraries"
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHALL"
+            }
+          ],
+          "code": "search-type",
+          "documentation": "Search allows clients to search for repository libraries"
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHALL"
+            }
+          ],
+          "code": "create",
+          "documentation": "Create allows authoring workflows to post new libraries in _draft_ (**submit**) or _active_ (**publish**) status."
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHALL"
+            }
+          ],
+          "code": "update",
+          "documentation": "Update allows authoring workflows to update existing libraries in _draft_ (**revise**) status, add comments to existing libraries (**review** and **approve**), and **release** or **retire** a library."
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHALL"
+            }
+          ],
+          "code": "delete",
+          "documentation": "Delete allows authoring workflows to **withdraw** _draft_ libraries or **archive** _retired_ libraries."
+        }
+      ],
+      "searchParam": [
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHALL"
+            }
+          ],
+          "name": "url",
+          "definition": "http://hl7.org/fhir/SearchParameter/Library-url",
+          "type": "uri"
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHALL"
+            }
+          ],
+          "name": "version",
+          "definition": "http://hl7.org/fhir/SearchParameter/Library-version",
+          "type": "string"
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHALL"
+            }
+          ],
+          "name": "identifier",
+          "definition": "http://hl7.org/fhir/SearchParameter/Library-identifier",
+          "type": "token"
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHALL"
+            }
+          ],
+          "name": "name",
+          "definition": "http://hl7.org/fhir/SearchParameter/Library-name",
+          "type": "string"
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHALL"
+            }
+          ],
+          "name": "title",
+          "definition": "http://hl7.org/fhir/SearchParameter/Library-title",
+          "type": "string"
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHALL"
+            }
+          ],
+          "name": "description",
+          "definition": "http://hl7.org/fhir/SearchParameter/Library-description",
+          "type": "string"
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHALL"
+            }
+          ],
+          "name": "status",
+          "definition": "http://hl7.org/fhir/SearchParameter/Library-status",
+          "type": "token"
+        }
+      ],
+      "operation": [
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHALL"
+            }
+          ],
+          "name": "cqfm-package",
+          "definition": "http://hl7.org/fhir/us/cqfmeasures/OperationDefinition/cqfm-package"
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHALL"
+            }
+          ],
+          "name": "data-requirements",
+          "definition": "https://hl7.org/fhir/us/cqfmeasures/OperationDefinition/Library-data-requirements"
+        }
+      ]
+    }, 
+    {
+      "type": "Measure",
+      "profile": "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-shareablemeasure",
+      "supportedProfile": ["http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-publishablemeasure"],
+      "interaction": [
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHALL"
+            }
+          ],
+          "code": "read",
+          "documentation": "Read allows clients to get the definitions and details of repository measures"
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHALL"
+            }
+          ],
+          "code": "search-type",
+          "documentation": "Search allows clients to search for repository measures"
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHALL"
+            }
+          ],
+          "code": "create",
+          "documentation": "Create allows authoring workflows to post new measures in _draft_ (**submit**) or _active_ (**publish**) status."
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHALL"
+            }
+          ],
+          "code": "update",
+          "documentation": "Update allows authoring workflows to update existing measures in _draft_ (**revise**) status, add comments to existing measures (**review** and **approve**), and **release** or **retire** a measure."
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHALL"
+            }
+          ],
+          "code": "delete",
+          "documentation": "Delete allows authoring workflows to **withdraw** _draft_ measures or **archive** _retired_ measures."
+        }
+      ],
+      "searchParam": [
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHALL"
+            }
+          ],
+          "name": "url",
+          "definition": "http://hl7.org/fhir/SearchParameter/Measure-url",
+          "type": "uri"
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHALL"
+            }
+          ],
+          "name": "version",
+          "definition": "http://hl7.org/fhir/SearchParameter/Measure-version",
+          "type": "string"
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHALL"
+            }
+          ],
+          "name": "identifier",
+          "definition": "http://hl7.org/fhir/SearchParameter/Measure-identifier",
+          "type": "token"
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHALL"
+            }
+          ],
+          "name": "name",
+          "definition": "http://hl7.org/fhir/SearchParameter/Measure-name",
+          "type": "string"
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHALL"
+            }
+          ],
+          "name": "title",
+          "definition": "http://hl7.org/fhir/SearchParameter/Measure-title",
+          "type": "string"
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHALL"
+            }
+          ],
+          "name": "description",
+          "definition": "http://hl7.org/fhir/SearchParameter/Measure-description",
+          "type": "string"
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHALL"
+            }
+          ],
+          "name": "status",
+          "definition": "http://hl7.org/fhir/SearchParameter/Measure-status",
+          "type": "token"
+        }
+      ],
+      "operation": [
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHALL"
+            }
+          ],
+          "name": "cqfm-package",
+          "definition": "http://hl7.org/fhir/us/cqfmeasures/OperationDefinition/cqfm-package"
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHALL"
+            }
+          ],
+          "name": "data-requirements",
+          "definition": "http://hl7.org/fhir/us/cqfmeasures/OperationDefinition/Measure-data-requirements"
+        }
+      ]
+    }
+  ]
+}

--- a/service/src/config/serverConfig.ts
+++ b/service/src/config/serverConfig.ts
@@ -1,6 +1,7 @@
 import { constants, ServerConfig, resolveSchema } from '@projecttacoma/node-fhir-server-core';
 import { MeasureService, LibraryService } from '../services';
 import capabilityStatementResources from './capabilityStatementResources.json';
+import publishableCapabilityStatementResources from './publishableCapabilityStatementResources.json';
 
 const customCapabilityStatement = (): fhir4.CapabilityStatement => {
   const base_version = constants.VERSIONS['4_0_1'];
@@ -12,12 +13,13 @@ const customCapabilityStatement = (): fhir4.CapabilityStatement => {
     title: 'FHIR Measure Repository Service Capability Statement',
     status: 'active',
     // date last modified
-    date: new Date(2023, 0, 31),
+    date: new Date(2024, 10, 25),
     publisher: 'The MITRE Corporation',
     instantiates: [
       'http://hl7.org/fhir/us/cqfmeasures/CapabilityStatement/shareable-measure-repository',
-      'http://hl7.org/fhir/us/cqfmeasures/CapabilityStatement/publishable-measure-repository',
-      'http://hl7.org/fhir/us/cqfmeasures/CapabilityStatement/authoring-measure-repository'
+      process.env.AUTHORING === 'true'
+        ? 'http://hl7.org/fhir/us/cqfmeasures/CapabilityStatement/authoring-measure-repository'
+        : 'http://hl7.org/fhir/us/cqfmeasures/CapabilityStatement/publishable-measure-repository'
     ],
     kind: 'instance',
     implementation: {
@@ -28,7 +30,7 @@ const customCapabilityStatement = (): fhir4.CapabilityStatement => {
     // NOTE: the definitions for authoring measure repository operations
     // are not FHIR OperationDefinitions, and we should update the JSON
     // when FHIR OperationDefinitions are available
-    rest: [capabilityStatementResources]
+    rest: [process.env.AUTHORING === 'true' ? capabilityStatementResources : publishableCapabilityStatementResources]
   });
 };
 


### PR DESCRIPTION
# Summary
Updates capability statement from server to reflect publishable/authoring environment. Updates frontend application to use capability statement to hide authoring capabilities if the server is in publishable mode.

## New behavior
Server provides publishable capability statement at `/metadata` endpoint if the server is in publishable mode (i.e. AUTHORING env variable is false). If the server is in publishable mode, the frontend with show a different capability statement on the main page, and authoring operations and draft measure interactions will be disabled.

## Code changes

- Server: adds `publishableCapabilityStatementResources.json` and updates `serverConfig.ts` to share publishable capability statement according to environment variable.
- Update search to show only status active (This seems to be the intention of our current organization of functionality. If we want to be able to search draft measures, recommend we add search functionality under the authoring tab)
- If publishable or authoring, show updated capability statement on top index page
- Add `getAuthoring` procedure to `service.ts` trpc router
- If publishable, disable review button (`ResourceInfoCard` update), "Create Draft" button (`resourceType/[id]` update), and authoring tab (`_app` update).
- If publishable, disables all /authoring pages with an `Authoring Unavailable` message. (The drafts counts will still show in the left menu if you manually navigate to /authoring, but for an exclusively publishable server, these counts should be 0.)

# Testing guidance

- `npm run check:all`
- `npm run start:all` with service `.env` file containing `AUTHORING=true` and confirm the same functionality is available (slight changes expected on main page and on search page)
- `npm run start:all` with service `.env` file containing `AUTHORING=false` and confirm authoring functionality is disabled
