### PR TITLE
Align ig

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -13,6 +13,8 @@
     "prettier:fix": "prettier --write \"**/*.{js,ts,jsx,tsx,css}\""
   },
   "dependencies": {
+    "@codemirror/lang-json": "0.20.0",
+    "@codemirror/lint": "0.20.3",
     "@emotion/react": "^11.10.8",
     "@emotion/server": "^11.10.0",
     "@mantine/core": "^6.0.9",
@@ -29,6 +31,7 @@
     "@trpc/react-query": "^10.26.0",
     "@trpc/server": "^10.26.0",
     "@types/fhir": "^0.0.36",
+    "@uiw/react-codemirror": "4.7.0",
     "dayjs": "^1.11.7",
     "html-react-parser": "^3.0.15",
     "luxon": "^3.3.0",

--- a/app/package.json
+++ b/app/package.json
@@ -22,6 +22,7 @@
     "@mantine/next": "^6.0.9",
     "@mantine/notifications": "^6.0.11",
     "@mantine/prism": "^6.0.9",
+    "@tabler/icons-react": "^3.26.0",
     "@tanstack/react-query": "^4.29.7",
     "@trpc/client": "^10.26.0",
     "@trpc/next": "^10.26.0",
@@ -36,7 +37,6 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "semver": "^7.5.4",
-    "tabler-icons-react": "^1.56.0",
     "zod": "^3.21.4"
   },
   "devDependencies": {

--- a/app/src/components/ArtifactFieldInput.tsx
+++ b/app/src/components/ArtifactFieldInput.tsx
@@ -1,5 +1,5 @@
 import { ActionIcon, TextInput } from '@mantine/core';
-import { X } from 'tabler-icons-react';
+import { IconX } from '@tabler/icons-react';
 
 export interface ArtifactFieldInputProps {
   label: string;
@@ -22,7 +22,7 @@ export default function ArtifactFieldInput({ label, value, disabled, setField }:
               setField('');
             }}
           >
-            <X size={16} />
+            <IconX size={16} />
           </ActionIcon>
         }
       />

--- a/app/src/components/ArtifactTimeline.tsx
+++ b/app/src/components/ArtifactTimeline.tsx
@@ -1,5 +1,5 @@
 import { Center, ScrollArea, Space, Text, Timeline } from '@mantine/core';
-import { Message } from 'tabler-icons-react';
+import { IconMessage } from '@tabler/icons-react';
 import { useEffect, useState } from 'react';
 import ArtifactComments, { ArtifactCommentProps } from './ArtifactComments';
 
@@ -77,7 +77,7 @@ export default function ArtifactTimeline({ extensions }: ArtifactTimelineProps) 
             <ScrollArea.Autosize mah={height * 0.8} type="scroll">
               <Timeline active={0} bulletSize={35} lineWidth={6}>
                 {commentArray?.reverse().map((e, index) => (
-                  <Timeline.Item lineVariant="dotted" bullet={<Message size={25} />} title={e.type} key={index}>
+                  <Timeline.Item lineVariant="dotted" bullet={<IconMessage size={25} />} title={e.type} key={index}>
                     {addArtifactComment({
                       date: e?.date,
                       body: e?.body,

--- a/app/src/components/CodeEditorModal.tsx
+++ b/app/src/components/CodeEditorModal.tsx
@@ -1,0 +1,89 @@
+import { Modal, Button, Center, Group, Text, Grid } from '@mantine/core';
+import CodeMirror from '@uiw/react-codemirror';
+import { json, jsonParseLinter } from '@codemirror/lang-json';
+import { linter } from '@codemirror/lint';
+import { useState } from 'react';
+
+const jsonLinter = jsonParseLinter();
+
+export interface CodeEditorModalProps {
+  open: boolean;
+  onClose: () => void;
+  onSave: (value: string) => void;
+  title?: string;
+  initialValue?: string;
+}
+
+export default function CodeEditorModal({
+  open = true,
+  onClose,
+  title,
+  onSave,
+  initialValue = ''
+}: CodeEditorModalProps) {
+  const [currentValue, setCurrentValue] = useState(initialValue);
+  const [linterError, setLinterError] = useState<string | null>(null);
+
+  return (
+    <Modal
+      centered
+      size={1000}
+      withCloseButton={false}
+      opened={open}
+      onClose={onClose}
+      styles={{
+        body: {
+          height: '700px'
+        }
+      }}
+      title={title}
+    >
+      <div style={{ overflow: 'scroll' }}>
+        {open && (
+          <CodeMirror
+            data-testid="codemirror"
+            height="600px"
+            value={initialValue}
+            extensions={[json(), linter(jsonLinter)]}
+            theme="light"
+            onUpdate={v => {
+              const diagnosticMessages = jsonLinter(v.view).map(d => d.message);
+
+              if (diagnosticMessages.length === 0) {
+                setLinterError(null);
+              } else {
+                setLinterError(diagnosticMessages.join('\n'));
+              }
+
+              // Grabbing updates from the readonly editor state to avoid codemirror weirdness
+              setCurrentValue(v.state.toJSON().doc);
+            }}
+          />
+        )}
+      </div>
+      <Grid>
+        <Grid.Col span={12}>
+          <Text color="red">{linterError}&nbsp;</Text>
+        </Grid.Col>
+        <Grid.Col span={12}>
+          <Center>
+            <Group>
+              <Button
+                data-testid="codemirror-save-button"
+                onClick={() => {
+                  onSave(currentValue);
+                }}
+                disabled={linterError != null}
+              >
+                Save
+              </Button>
+              <Button data-testid="codemirror-cancel-button" variant="default" onClick={onClose}>
+                Cancel
+              </Button>
+            </Group>
+          </Center>
+        </Grid.Col>
+      </Grid>
+    </Modal>
+  );
+}

--- a/app/src/components/ConfirmationModal.tsx
+++ b/app/src/components/ConfirmationModal.tsx
@@ -19,7 +19,7 @@ export default function ConfirmationModal({
   return (
     <Modal opened={open} onClose={onClose} withCloseButton={false} size="lg">
       <Center>
-        <IconAlertTriangle color={action === 'delete' ? 'red' : 'green'} size={40} />
+        <IconAlertTriangle color={action === 'clone' ? 'green' : 'red'} size={40} />
       </Center>
       <Center>
         <Text weight={700} align="center" lineClamp={2} p={'sm'}>
@@ -32,7 +32,7 @@ export default function ConfirmationModal({
             Cancel
           </Button>
           <Button onClick={onConfirm} color={action === 'clone' ? 'green' : 'red'}>
-            {action === 'clone' ? 'Clone' : 'Delete'}
+            {String(action).charAt(0).toUpperCase() + String(action).slice(1)}
           </Button>
         </Group>
       </Center>

--- a/app/src/components/ConfirmationModal.tsx
+++ b/app/src/components/ConfirmationModal.tsx
@@ -1,5 +1,5 @@
 import { Modal, Button, Center, Group, Text } from '@mantine/core';
-import { AlertTriangle } from 'tabler-icons-react';
+import { IconAlertTriangle } from '@tabler/icons-react';
 
 export interface ConfirmationModalProps {
   open: boolean;
@@ -19,7 +19,7 @@ export default function ConfirmationModal({
   return (
     <Modal opened={open} onClose={onClose} withCloseButton={false} size="lg">
       <Center>
-        <AlertTriangle color={action === 'delete' ? 'red' : 'green'} size={40} />
+        <IconAlertTriangle color={action === 'delete' ? 'red' : 'green'} size={40} />
       </Center>
       <Center>
         <Text weight={700} align="center" lineClamp={2} p={'sm'}>

--- a/app/src/components/DependencyCards.tsx
+++ b/app/src/components/DependencyCards.tsx
@@ -12,7 +12,7 @@ import {
 } from '@mantine/core';
 import Link from 'next/link';
 import React from 'react';
-import { SquareArrowRight } from 'tabler-icons-react';
+import { IconSquareArrowRight } from '@tabler/icons-react';
 
 interface DependencyInformation {
   type?: string;
@@ -82,7 +82,7 @@ function Dependencies(props: myComponentProps) {
               <Link href={`/${dependencyInfo.link}`}>
                 <Tooltip label={'Open Dependency Resource'} openDelay={1000}>
                   <ActionIcon radius="md" size="md" variant="subtle" color="gray">
-                    {<SquareArrowRight size="24" />}
+                    {<IconSquareArrowRight size="24" />}
                   </ActionIcon>
                 </Tooltip>
               </Link>

--- a/app/src/components/ReleaseModal.tsx
+++ b/app/src/components/ReleaseModal.tsx
@@ -2,7 +2,7 @@ import { trpc } from '@/util/trpc';
 import { ArtifactResourceType } from '@/util/types/fhir';
 import { Button, Center, Group, Modal, Stack, Text, Tooltip } from '@mantine/core';
 import { useRouter } from 'next/router';
-import { AlertCircle, CircleCheck, InfoCircle } from 'tabler-icons-react';
+import { IconAlertCircle, IconCircleCheck, IconInfoCircle } from '@tabler/icons-react';
 import { notifications } from '@mantine/notifications';
 
 export interface ReleaseModalProps {
@@ -28,7 +28,7 @@ export default function ReleaseModal({ open = true, onClose, id, resourceType }:
         notifications.show({
           title: `Release Failed!`,
           message: `Server unable to process request. ${data.error ?? ''}`,
-          icon: <AlertCircle />,
+          icon: <IconAlertCircle />,
           color: 'red'
         });
       } else if (!data.location) {
@@ -36,7 +36,7 @@ export default function ReleaseModal({ open = true, onClose, id, resourceType }:
         notifications.show({
           title: `Release Failed!`,
           message: `No resource location exists for draft artifact`,
-          icon: <AlertCircle />,
+          icon: <IconAlertCircle />,
           color: 'red'
         });
       } else {
@@ -44,7 +44,7 @@ export default function ReleaseModal({ open = true, onClose, id, resourceType }:
           notifications.show({
             title: `Draft ${r.resourceType} released!`,
             message: `Draft ${r.resourceType}/${r.id} successfully released!`,
-            icon: <CircleCheck />,
+            icon: <IconCircleCheck />,
             color: 'green'
           });
         });
@@ -79,7 +79,7 @@ export default function ReleaseModal({ open = true, onClose, id, resourceType }:
               label="Releasing a draft artifact changes the artifact's status from 'draft' to 'active' and sends the artifact to the Publishable Measure Repository. This action also deletes this draft artifact from the Authoring Measure Repository."
             >
               <div>
-                <InfoCircle size="1rem" style={{ display: 'block', opacity: 0.5 }} />
+                <IconInfoCircle size="1rem" style={{ display: 'block', opacity: 0.5 }} />
               </div>
             </Tooltip>
           </Group>

--- a/app/src/components/ResourceInfoCard.tsx
+++ b/app/src/components/ResourceInfoCard.tsx
@@ -60,13 +60,13 @@ export default function ResourceInfoCard({ resourceInfo, authoring }: ResourceIn
     let message;
     if (childArtifact) {
       message = `Child ${resourceType} artifact of url ${idOrUrl} successfully ${
-        action === 'delete' ? 'deleted' : 'cloned'
+        action === 'withdraw' ? 'withdrawn' : 'cloned'
       }`;
     } else {
-      message = `${resourceType}/${idOrUrl} successfully ${action === 'delete' ? 'deleted' : 'cloned'}`;
+      message = `${resourceType}/${idOrUrl} successfully ${action === 'withdraw' ? 'withdrawn' : 'cloned'}`;
     }
     notifications.show({
-      title: `${resourceType} ${action === 'delete' ? 'Deleted' : 'Cloned'}!`,
+      title: `${resourceType} ${action === 'withdraw' ? 'Withdrawn' : 'Cloned'}!`,
       message: message,
       icon: <IconCircleCheck />,
       color: 'green'
@@ -88,7 +88,7 @@ export default function ResourceInfoCard({ resourceInfo, authoring }: ResourceIn
       message = `Attempt to ${action} ${resourceType}/${idOrUrl} failed with message: ${errorMessage}`;
     }
     notifications.show({
-      title: `${resourceType} ${action === 'delete' ? 'Deletion' : 'Clone'} Failed!`,
+      title: `${resourceType} ${action === 'withdraw' ? 'Withdrawal' : 'Clone'} Failed!`,
       message: message,
       icon: <IconAlertCircle />,
       color: 'red'
@@ -111,11 +111,11 @@ export default function ResourceInfoCard({ resourceInfo, authoring }: ResourceIn
     }
   });
 
-  const deleteMutation = trpc.draft.deleteDraft.useMutation({
+  const withdrawMutation = trpc.draft.deleteDraft.useMutation({
     onSuccess: (data, variables) => {
-      successNotification(variables.resourceType, false, 'delete', variables.id);
+      successNotification(variables.resourceType, false, 'withdraw', variables.id);
       data.children.forEach(c => {
-        successNotification(c.resourceType, true, 'delete', c.url);
+        successNotification(c.resourceType, true, 'withdraw', c.url);
       });
       utils.draft.getDrafts.invalidate();
       router.replace(router.asPath);
@@ -123,7 +123,7 @@ export default function ResourceInfoCard({ resourceInfo, authoring }: ResourceIn
       setIsDeleteConfirmationModalOpen(false);
     },
     onError: (e, variables) => {
-      errorNotification(variables.resourceType, e.message, false, 'delete', variables.id);
+      errorNotification(variables.resourceType, e.message, false, 'withdraw', variables.id);
     }
   });
 
@@ -197,13 +197,13 @@ export default function ResourceInfoCard({ resourceInfo, authoring }: ResourceIn
         open={isDeleteConfirmationModalOpen}
         onClose={() => setIsDeleteConfirmationModalOpen(false)}
         onConfirm={() => {
-          deleteMutation.mutate({
+          withdrawMutation.mutate({
             resourceType: resourceInfo.resourceType,
             id: resourceInfo.id
           });
         }}
-        action="delete"
-        modalText={`This will delete draft ${resourceInfo.resourceType} "${
+        action="withdraw"
+        modalText={`This will withdraw draft ${resourceInfo.resourceType} "${
           resourceInfo.name ? resourceInfo.name : `${resourceInfo.resourceType}/${resourceInfo.id}`
         }" and any child artifacts permanently.`}
       />
@@ -318,7 +318,7 @@ export default function ResourceInfoCard({ resourceInfo, authoring }: ResourceIn
             {authoring ? (
               authoringEnvironment.data &&
               (resourceInfo.isChild ? (
-                <Tooltip label={'Child artifacts cannot be directly deleted'} openDelay={1000}>
+                <Tooltip label={'Child artifacts cannot be directly withdrawn'} openDelay={1000}>
                   <span>
                     <ActionIcon radius="md" size="md" disabled={true}>
                       <IconTrash size="24" />

--- a/app/src/components/ResourceInfoCard.tsx
+++ b/app/src/components/ResourceInfoCard.tsx
@@ -128,7 +128,7 @@ export default function ResourceInfoCard({ resourceInfo, authoring }: ResourceIn
           });
         }}
         action="clone"
-        modalText={`This will clone draft ${resourceInfo.resourceType} "${
+        modalText={`This will clone ${resourceInfo.resourceType} "${
           resourceInfo.name ? resourceInfo.name : `${resourceInfo.resourceType}/${resourceInfo.id}`
         }" and any child artifacts.`}
       />
@@ -189,26 +189,21 @@ export default function ResourceInfoCard({ resourceInfo, authoring }: ResourceIn
                 </ActionIcon>
               </Tooltip>
             </Link>
-            {authoringEnvironment.data ? (
-              <Link
-                href={{
-                  pathname: `/review/${resourceInfo.resourceType}/${resourceInfo.id}`,
-                  query: { authoring: `${authoring}` }
-                }}
-              >
-                <Tooltip label={authoring ? 'Review Draft Resource' : 'Review Resource'} openDelay={1000}>
-                  <ActionIcon radius="md" size="md" variant="subtle" color="blue">
-                    <IconMessage size="24" />
-                  </ActionIcon>
-                </Tooltip>
-              </Link>
-            ) : (
-              <></>
-            )}
-            {authoring &&
-              authoringEnvironment &&
-              (resourceInfo.isChild ? (
-                <Group>
+            {authoringEnvironment.data && (
+              <Group>
+                <Link
+                  href={{
+                    pathname: `/review/${resourceInfo.resourceType}/${resourceInfo.id}`,
+                    query: { authoring: `${authoring}` }
+                  }}
+                >
+                  <Tooltip label={authoring ? 'Review Draft Resource' : 'Review Resource'} openDelay={1000}>
+                    <ActionIcon radius="md" size="md" variant="subtle" color="blue">
+                      <IconMessage size="24" />
+                    </ActionIcon>
+                  </Tooltip>
+                </Link>
+                {resourceInfo.isChild ? (
                   <Tooltip label={'Child artifacts cannot be directly cloned'}>
                     <span>
                       <ActionIcon radius="md" size="md" disabled={true}>
@@ -216,16 +211,7 @@ export default function ResourceInfoCard({ resourceInfo, authoring }: ResourceIn
                       </ActionIcon>
                     </span>
                   </Tooltip>
-                  <Tooltip label={'Child artifacts cannot be directly deleted'} openDelay={1000}>
-                    <span>
-                      <ActionIcon radius="md" size="md" disabled={true}>
-                        <IconTrash size="24" />
-                      </ActionIcon>
-                    </span>
-                  </Tooltip>
-                </Group>
-              ) : (
-                <Group>
+                ) : (
                   <Tooltip label={'Clone Draft Resource'} openDelay={1000}>
                     <ActionIcon
                       radius="md"
@@ -237,6 +223,21 @@ export default function ResourceInfoCard({ resourceInfo, authoring }: ResourceIn
                       <IconCopy size="24" />
                     </ActionIcon>
                   </Tooltip>
+                )}
+              </Group>
+            )}
+            {authoring &&
+              authoringEnvironment.data &&
+              (resourceInfo.isChild ? (
+                <Tooltip label={'Child artifacts cannot be directly deleted'} openDelay={1000}>
+                  <span>
+                    <ActionIcon radius="md" size="md" disabled={true}>
+                      <IconTrash size="24" />
+                    </ActionIcon>
+                  </span>
+                </Tooltip>
+              ) : (
+                <Group>
                   <Tooltip label={'Delete Draft Resource'} openDelay={1000}>
                     <ActionIcon
                       radius="md"

--- a/app/src/components/ResourceInfoCard.tsx
+++ b/app/src/components/ResourceInfoCard.tsx
@@ -83,9 +83,9 @@ export default function ResourceInfoCard({ resourceInfo, authoring }: ResourceIn
   ) => {
     let message;
     if (childArtifact) {
-      message = `Attempt to ${action} draft of child ${resourceType} artifact of url ${idOrUrl} failed with message: ${errorMessage}`;
+      message = `Attempt to ${action} child ${resourceType} artifact of url ${idOrUrl} failed with message: ${errorMessage}`;
     } else {
-      message = `Attempt to ${action} draft of ${resourceType}/${idOrUrl} failed with message: ${errorMessage}`;
+      message = `Attempt to ${action} ${resourceType}/${idOrUrl} failed with message: ${errorMessage}`;
     }
     notifications.show({
       title: `${resourceType} ${action === 'delete' ? 'Deletion' : 'Clone'} Failed!`,

--- a/app/src/components/ResourceInfoCard.tsx
+++ b/app/src/components/ResourceInfoCard.tsx
@@ -13,7 +13,7 @@ import {
 import Link from 'next/link';
 import React, { useState } from 'react';
 import { ResourceInfo } from '@/util/types/fhir';
-import { Edit, SquareArrowRight, Trash, AlertCircle, CircleCheck, Report, Copy } from 'tabler-icons-react';
+import { IconEdit, IconSquareArrowRight, IconTrash, IconAlertCircle, IconCircleCheck, IconMessage, IconCopy, IconMessageCheck } from '@tabler/icons-react';
 import { trpc } from '@/util/trpc';
 import { notifications } from '@mantine/notifications';
 import ConfirmationModal from './ConfirmationModal';
@@ -53,7 +53,7 @@ export default function ResourceInfoCard({ resourceInfo, authoring }: ResourceIn
     notifications.show({
       title: `${resourceType} ${action === 'delete' ? 'Deleted' : 'Cloned'}!`,
       message: message,
-      icon: <CircleCheck />,
+      icon: <IconCircleCheck />,
       color: 'green'
     });
     utils.draft.getDraftCounts.invalidate();
@@ -75,7 +75,7 @@ export default function ResourceInfoCard({ resourceInfo, authoring }: ResourceIn
     notifications.show({
       title: `${resourceType} ${action === 'delete' ? 'Deletion' : 'Clone'} Failed!`,
       message: message,
-      icon: <AlertCircle />,
+      icon: <IconAlertCircle />,
       color: 'red'
     });
   };
@@ -177,11 +177,12 @@ export default function ResourceInfoCard({ resourceInfo, authoring }: ResourceIn
             >
               <Tooltip label={authoring ? 'Edit Draft Resource' : 'View Resource Contents'} openDelay={1000}>
                 <ActionIcon radius="md" size="md" variant="subtle" color="gray">
-                  {authoring ? <Edit size="24" /> : <SquareArrowRight size="24" />}
+                  {authoring ? <IconEdit size="24" /> : <IconSquareArrowRight size="24" />}
                 </ActionIcon>
               </Tooltip>
             </Link>
             {authoringEnvironment.data ? (
+              <Group>
               <Link
                 href={{
                   pathname: `/review/${resourceInfo.resourceType}/${resourceInfo.id}`,
@@ -190,10 +191,24 @@ export default function ResourceInfoCard({ resourceInfo, authoring }: ResourceIn
               >
                 <Tooltip label={authoring ? 'Review Draft Resource' : 'Review Resource'} openDelay={1000}>
                   <ActionIcon radius="md" size="md" variant="subtle" color="blue">
-                    <Report size="24" />
+                    <IconMessage size="24" />
                   </ActionIcon>
                 </Tooltip>
               </Link>
+              <Link
+                href={{
+                  pathname: `/approve/${resourceInfo.resourceType}/${resourceInfo.id}`,
+                  query: { authoring: `${authoring}` }
+                }}
+              >
+                <Tooltip label={authoring ? 'Approve Draft Resource' : 'Approve Resource'} openDelay={1000}>
+                  <ActionIcon radius="md" size="md" variant="subtle" color="green">
+                    <IconMessageCheck size="24" />
+                  </ActionIcon>
+                </Tooltip>
+              </Link>
+              </Group>
+              
             ) : (
               <></>
             )}
@@ -204,14 +219,14 @@ export default function ResourceInfoCard({ resourceInfo, authoring }: ResourceIn
                   <Tooltip label={'Child artifacts cannot be directly cloned'}>
                     <span>
                       <ActionIcon radius="md" size="md" disabled={true}>
-                        <Copy size="24" />
+                        <IconCopy size="24" />
                       </ActionIcon>
                     </span>
                   </Tooltip>
                   <Tooltip label={'Child artifacts cannot be directly deleted'} openDelay={1000}>
                     <span>
                       <ActionIcon radius="md" size="md" disabled={true}>
-                        <Trash size="24" />
+                        <IconTrash size="24" />
                       </ActionIcon>
                     </span>
                   </Tooltip>
@@ -223,10 +238,10 @@ export default function ResourceInfoCard({ resourceInfo, authoring }: ResourceIn
                       radius="md"
                       size="md"
                       variant="subtle"
-                      color="green"
+                      color="yellow"
                       onClick={() => setIsCloneConfirmationModalOpen(true)}
                     >
-                      <Copy size="24" />
+                      <IconCopy size="24" />
                     </ActionIcon>
                   </Tooltip>
                   <Tooltip label={'Delete Draft Resource'} openDelay={1000}>
@@ -237,7 +252,7 @@ export default function ResourceInfoCard({ resourceInfo, authoring }: ResourceIn
                       color="red"
                       onClick={() => setIsDeleteConfirmationModalOpen(true)}
                     >
-                      <Trash size="24" />
+                      <IconTrash size="24" />
                     </ActionIcon>
                   </Tooltip>
                 </Group>

--- a/app/src/components/ResourceInfoCard.tsx
+++ b/app/src/components/ResourceInfoCard.tsx
@@ -231,7 +231,7 @@ export default function ResourceInfoCard({ resourceInfo, authoring }: ResourceIn
           });
         }}
         action="archive"
-        modalText={`This will archive draft ${resourceInfo.resourceType} "${
+        modalText={`This will archive ${resourceInfo.resourceType} "${
           resourceInfo.name ? resourceInfo.name : `${resourceInfo.resourceType}/${resourceInfo.id}`
         }" and any child artifacts permanently.`}
       />
@@ -301,7 +301,7 @@ export default function ResourceInfoCard({ resourceInfo, authoring }: ResourceIn
                     </span>
                   </Tooltip>
                 ) : (
-                  <Tooltip label={'Clone Resource'} openDelay={1000}>
+                  <Tooltip label={authoring ? 'Clone Draft Resource' : 'Clone Resource'} openDelay={1000}>
                     <ActionIcon
                       radius="md"
                       size="md"
@@ -327,7 +327,7 @@ export default function ResourceInfoCard({ resourceInfo, authoring }: ResourceIn
                 </Tooltip>
               ) : (
                 <Group>
-                  <Tooltip label={'Delete Draft Resource'} openDelay={1000}>
+                  <Tooltip label={'Withdraw Draft Resource'} openDelay={1000}>
                     <ActionIcon
                       radius="md"
                       size="md"

--- a/app/src/components/ResourceInfoCard.tsx
+++ b/app/src/components/ResourceInfoCard.tsx
@@ -13,7 +13,7 @@ import {
 import Link from 'next/link';
 import React, { useState } from 'react';
 import { ResourceInfo } from '@/util/types/fhir';
-import { IconEdit, IconSquareArrowRight, IconTrash, IconAlertCircle, IconCircleCheck, IconMessage, IconCopy, IconMessageCheck } from '@tabler/icons-react';
+import { IconEdit, IconSquareArrowRight, IconTrash, IconAlertCircle, IconCircleCheck, IconMessage, IconCopy } from '@tabler/icons-react';
 import { trpc } from '@/util/trpc';
 import { notifications } from '@mantine/notifications';
 import ConfirmationModal from './ConfirmationModal';
@@ -182,32 +182,18 @@ export default function ResourceInfoCard({ resourceInfo, authoring }: ResourceIn
               </Tooltip>
             </Link>
             {authoringEnvironment.data ? (
-              <Group>
               <Link
-                href={{
-                  pathname: `/review/${resourceInfo.resourceType}/${resourceInfo.id}`,
-                  query: { authoring: `${authoring}` }
-                }}
-              >
-                <Tooltip label={authoring ? 'Review Draft Resource' : 'Review Resource'} openDelay={1000}>
-                  <ActionIcon radius="md" size="md" variant="subtle" color="blue">
-                    <IconMessage size="24" />
-                  </ActionIcon>
-                </Tooltip>
-              </Link>
-              <Link
-                href={{
-                  pathname: `/approve/${resourceInfo.resourceType}/${resourceInfo.id}`,
-                  query: { authoring: `${authoring}` }
-                }}
-              >
-                <Tooltip label={authoring ? 'Approve Draft Resource' : 'Approve Resource'} openDelay={1000}>
-                  <ActionIcon radius="md" size="md" variant="subtle" color="green">
-                    <IconMessageCheck size="24" />
-                  </ActionIcon>
-                </Tooltip>
-              </Link>
-              </Group>
+              href={{
+                pathname: `/review/${resourceInfo.resourceType}/${resourceInfo.id}`,
+                query: { authoring: `${authoring}` }
+              }}
+            >
+              <Tooltip label={authoring ? 'Review Draft Resource' : 'Review Resource'} openDelay={1000}>
+                <ActionIcon radius="md" size="md" variant="subtle" color="blue">
+                  <IconMessage size="24" />
+                </ActionIcon>
+              </Tooltip>
+            </Link>
               
             ) : (
               <></>

--- a/app/src/components/ResourceInfoCard.tsx
+++ b/app/src/components/ResourceInfoCard.tsx
@@ -13,7 +13,15 @@ import {
 import Link from 'next/link';
 import React, { useState } from 'react';
 import { ResourceInfo } from '@/util/types/fhir';
-import { IconEdit, IconSquareArrowRight, IconTrash, IconAlertCircle, IconCircleCheck, IconMessage, IconCopy } from '@tabler/icons-react';
+import {
+  IconEdit,
+  IconSquareArrowRight,
+  IconTrash,
+  IconAlertCircle,
+  IconCircleCheck,
+  IconMessage,
+  IconCopy
+} from '@tabler/icons-react';
 import { trpc } from '@/util/trpc';
 import { notifications } from '@mantine/notifications';
 import ConfirmationModal from './ConfirmationModal';
@@ -183,18 +191,17 @@ export default function ResourceInfoCard({ resourceInfo, authoring }: ResourceIn
             </Link>
             {authoringEnvironment.data ? (
               <Link
-              href={{
-                pathname: `/review/${resourceInfo.resourceType}/${resourceInfo.id}`,
-                query: { authoring: `${authoring}` }
-              }}
-            >
-              <Tooltip label={authoring ? 'Review Draft Resource' : 'Review Resource'} openDelay={1000}>
-                <ActionIcon radius="md" size="md" variant="subtle" color="blue">
-                  <IconMessage size="24" />
-                </ActionIcon>
-              </Tooltip>
-            </Link>
-              
+                href={{
+                  pathname: `/review/${resourceInfo.resourceType}/${resourceInfo.id}`,
+                  query: { authoring: `${authoring}` }
+                }}
+              >
+                <Tooltip label={authoring ? 'Review Draft Resource' : 'Review Resource'} openDelay={1000}>
+                  <ActionIcon radius="md" size="md" variant="subtle" color="blue">
+                    <IconMessage size="24" />
+                  </ActionIcon>
+                </Tooltip>
+              </Link>
             ) : (
               <></>
             )}

--- a/app/src/components/SearchComponent.tsx
+++ b/app/src/components/SearchComponent.tsx
@@ -8,6 +8,7 @@ import { trpc } from '@/util/trpc';
 
 interface SearchComponentProps {
   resourceType: ArtifactResourceType;
+  authoring: boolean;
 }
 
 interface Parameter {
@@ -20,7 +21,7 @@ interface Parameter {
 /**
  * SearchComponent is a component for displaying search inputs for a resource
  */
-export default function SearchComponent({ resourceType }: SearchComponentProps) {
+export default function SearchComponent({ resourceType, authoring }: SearchComponentProps) {
   const publicUrl = trpc.service.getPublicUrl.useQuery();
 
   const emptyInputs = ArtifactSearchParams[resourceType].map(p => ({
@@ -115,7 +116,9 @@ export default function SearchComponent({ resourceType }: SearchComponentProps) 
       requestParams.push({ name: 'version', value: version });
     }
     const query = requestParams.filter(si => si.value !== '').map(si => si.name + '=' + si.value);
-    return query.length !== 0 ? `?status=active&${query.join('&')}` : '?status=active';
+    return query.length !== 0
+      ? `?status=${authoring ? 'draft' : 'active'}&${query.join('&')}`
+      : `?status=${authoring ? 'draft' : 'active'}`;
   };
 
   return (

--- a/app/src/pages/[resourceType].tsx
+++ b/app/src/pages/[resourceType].tsx
@@ -53,15 +53,25 @@ export const getServerSideProps: GetServerSideProps<{
   const checkedResourceType = resourceType as ArtifactResourceType;
 
   // Fetch resource data with the _elements parameter so we only get the elements that we need
-  const res = await fetch(
-    `${process.env.MRS_SERVER}/${checkedResourceType}?_elements=id,extension,identifier,name,url,version&status=active`
+  const [artifactBundleActive, artifactBundleRetired] = await Promise.all([
+    fetch(
+      `${process.env.MRS_SERVER}/${checkedResourceType}?_elements=id,extension,identifier,name,url,version&status=active`
+    ),
+    fetch(
+      `${process.env.MRS_SERVER}/${checkedResourceType}?_elements=id,extension,identifier,name,url,version&status=retired`
+    )
+  ]).then(([resArtifactsActive, resArtifactsRetired]) =>
+    Promise.all([
+      resArtifactsActive.json() as Promise<fhir4.Bundle<FhirArtifact>>,
+      resArtifactsRetired.json() as Promise<fhir4.Bundle<FhirArtifact>>
+    ])
   );
-  const bundle = (await res.json()) as fhir4.Bundle<FhirArtifact>;
-  if (!bundle.entry) {
+
+  if (!artifactBundleActive.entry || !artifactBundleRetired.entry) {
     // Measure Repository should not provide a bundle without an entry
     throw new Error('Measure Repository bundle has no entry.');
   }
-  const resources = bundle.entry;
+  const resources = artifactBundleActive.entry.concat(artifactBundleRetired.entry);
   const resourceInfoArray = resources.reduce((acc: ResourceInfo[], entry) => {
     if (entry.resource && entry.resource.id) {
       const resourceInfo = extractResourceInfo(entry.resource);

--- a/app/src/pages/[resourceType].tsx
+++ b/app/src/pages/[resourceType].tsx
@@ -23,7 +23,7 @@ export default function ResourceList({
         </Center>
         <Divider my="md" />
         <Stack align="center">
-          <Link href={`/search?resourceType=${resourceType}`}>
+          <Link href={`/search?resourceType=${resourceType}&authoring=false`}>
             <Button>Search</Button>
           </Link>
           <div style={{ paddingTop: '18px' }}>
@@ -54,7 +54,7 @@ export const getServerSideProps: GetServerSideProps<{
 
   // Fetch resource data with the _elements parameter so we only get the elements that we need
   const res = await fetch(
-    `${process.env.MRS_SERVER}/${checkedResourceType}?_elements=id,identifier,name,url,version&status=active`
+    `${process.env.MRS_SERVER}/${checkedResourceType}?_elements=id,extension,identifier,name,url,version&status=active`
   );
   const bundle = (await res.json()) as fhir4.Bundle<FhirArtifact>;
   if (!bundle.entry) {

--- a/app/src/pages/[resourceType].tsx
+++ b/app/src/pages/[resourceType].tsx
@@ -71,7 +71,13 @@ export const getServerSideProps: GetServerSideProps<{
     // Measure Repository should not provide a bundle without an entry
     throw new Error('Measure Repository bundle has no entry.');
   }
+
   const resources = artifactBundleActive.entry.concat(artifactBundleRetired.entry);
+  resources.sort((a, b) => {
+    const strA = `${a.resource?.url}|${a.resource?.version}`;
+    const strB = `${b.resource?.url}|${b.resource?.version}`;
+    return strA.localeCompare(strB);
+  });
   const resourceInfoArray = resources.reduce((acc: ResourceInfo[], entry) => {
     if (entry.resource && entry.resource.id) {
       const resourceInfo = extractResourceInfo(entry.resource);

--- a/app/src/pages/[resourceType]/[id].tsx
+++ b/app/src/pages/[resourceType]/[id].tsx
@@ -159,8 +159,14 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
               {!!jsonData?.extension?.find(
                 ext =>
                   ext.url === 'http://hl7.org/fhir/StructureDefinition/artifact-isOwned' && ext.valueBoolean === true
-              ) ? (
-                <Tooltip label="Child artifacts cannot be directly drafted">
+              ) || jsonData.status === 'retired' ? (
+                <Tooltip
+                  label={
+                    jsonData.status === 'retired'
+                      ? 'Retired artifacts cannot be drafted'
+                      : 'Child artifacts cannot be directly drafted'
+                  }
+                >
                   <span>
                     <Button w={240} loading={draftFromArtifactMutation.isLoading} disabled={true}>
                       Create Draft of {jsonData.resourceType}

--- a/app/src/pages/[resourceType]/[id].tsx
+++ b/app/src/pages/[resourceType]/[id].tsx
@@ -21,7 +21,7 @@ import { CRMIShareableLibrary, FhirArtifact } from '@/util/types/fhir';
 import CQLRegex from '../../util/prismCQL';
 import { Prism as PrismRenderer } from 'prism-react-renderer';
 import parse from 'html-react-parser';
-import { AlertCircle, CircleCheck } from 'tabler-icons-react';
+import { IconAlertCircle, IconCircleCheck } from '@tabler/icons-react';
 import { useRouter } from 'next/router';
 import { trpc } from '@/util/trpc';
 import DataReqs from '@/components/DataRequirements';
@@ -95,7 +95,7 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
     notifications.show({
       title: `${resourceType} Created!`,
       message: message,
-      icon: <CircleCheck />,
+      icon: <IconCircleCheck />,
       color: 'green'
     });
     ctx.draft.getDraftCounts.invalidate();
@@ -111,7 +111,7 @@ export default function ResourceIDPage({ jsonData }: InferGetServerSidePropsType
     notifications.show({
       title: `${resourceType} Creation Failed!`,
       message: message,
-      icon: <AlertCircle />,
+      icon: <IconAlertCircle />,
       color: 'red'
     });
   };

--- a/app/src/pages/[resourceType]/search-result.tsx
+++ b/app/src/pages/[resourceType]/search-result.tsx
@@ -3,12 +3,14 @@ import { Center, Divider, Paper, Text, Stack } from '@mantine/core';
 import { ArtifactResourceType, FhirArtifact, ResourceInfo } from '@/util/types/fhir';
 import ResourceCards from '@/components/ResourceCards';
 import { extractResourceInfo } from '@/util/resourceCardUtils';
+import { useRouter } from 'next/router';
 
 export default function ResourceSearchResultsPage({
   resourceInfo,
   resourceType,
   error
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  const router = useRouter();
   return (
     <div
       style={{
@@ -26,7 +28,11 @@ export default function ResourceSearchResultsPage({
       <Divider my="md" />
       {resourceInfo ? (
         <Stack align="center" pt={18}>
-          <ResourceCards resourceInfo={resourceInfo} resourceType={resourceType} authoring={false} />
+          <ResourceCards
+            resourceInfo={resourceInfo}
+            resourceType={resourceType}
+            authoring={(router.query.status as string) === 'draft'}
+          />
         </Stack>
       ) : (
         <div

--- a/app/src/pages/_app.tsx
+++ b/app/src/pages/_app.tsx
@@ -19,7 +19,7 @@ import ServiceResourceButtons from '../components/ServiceResourceButtons';
 import { trpc } from '@/util/trpc';
 import { Open_Sans } from 'next/font/google';
 import { useRouter } from 'next/dist/client/router';
-import { Database } from 'tabler-icons-react';
+import { IconDatabase } from '@tabler/icons-react';
 import DraftResourceButtons from '@/components/DraftResourceButtons';
 
 const openSans = Open_Sans({
@@ -119,7 +119,7 @@ function App({ Component, pageProps }: AppProps) {
                 <Link href="/">
                   <Group align="center" spacing="xs">
                     <Center>
-                      <Database className={classes.dbIcon} />
+                      <IconDatabase className={classes.dbIcon} />
                     </Center>
                     <Text c="white" weight="bold">
                       Measure Repository

--- a/app/src/pages/_app.tsx
+++ b/app/src/pages/_app.tsx
@@ -42,6 +42,14 @@ function App({ Component, pageProps }: AppProps) {
   const router = useRouter();
   const { classes } = useStyles();
   const authoring = trpc.service.getAuthoring.useQuery();
+  let authoringTab = false;
+  if (
+    router.asPath.endsWith('authoring=true') ||
+    router.pathname.startsWith('/authoring') ||
+    router.asPath.includes('status=draft')
+  ) {
+    authoringTab = true;
+  }
 
   return (
     <>
@@ -63,7 +71,7 @@ function App({ Component, pageProps }: AppProps) {
           /** Consistent navbar shows available resources as regular content page changes to drill into details */
           navbar={
             <Navbar width={{ base: '320px' }}>
-              {(router.pathname.startsWith('/authoring') || router.asPath.endsWith('authoring=true')) && (
+              {authoringTab ? (
                 <>
                   <Navbar.Section pt={18}>
                     <Center>
@@ -71,13 +79,18 @@ function App({ Component, pageProps }: AppProps) {
                     </Center>
                   </Navbar.Section>
                   <Divider my="md" />
+                  <Navbar.Section px={18}>
+                    <Link href={'/search?resourceType=Measure&authoring=true'}>
+                      <Button variant="default" fullWidth>
+                        Search
+                      </Button>
+                    </Link>
+                  </Navbar.Section>
                   <Navbar.Section grow pt={18}>
                     <DraftResourceButtons />
                   </Navbar.Section>
                 </>
-              )}
-              {((!router.pathname.startsWith('/authoring') && !router.pathname.startsWith('/review')) ||
-                router.asPath.endsWith('authoring=false')) && (
+              ) : (
                 <>
                   <Navbar.Section pt={18}>
                     <Center>
@@ -86,7 +99,7 @@ function App({ Component, pageProps }: AppProps) {
                   </Navbar.Section>
                   <Divider my="md" />
                   <Navbar.Section px={18}>
-                    <Link href={'/search?resourceType=Measure'}>
+                    <Link href={'/search?resourceType=Measure&authoring=false'}>
                       <Button variant="default" fullWidth>
                         Search
                       </Button>
@@ -129,28 +142,11 @@ function App({ Component, pageProps }: AppProps) {
               </div>
               <Group position="center" className={classes.navGroup} spacing="xl">
                 <Link href="/">
-                  <Text
-                    c={
-                      router.asPath.endsWith('authoring=false') ||
-                      (!router.pathname.startsWith('/authoring') && !router.pathname.startsWith('/review'))
-                        ? 'orange.3'
-                        : 'gray.4'
-                    }
-                  >
-                    Repository
-                  </Text>
+                  <Text c={!authoringTab ? 'orange.3' : 'gray.4'}>Repository</Text>
                 </Link>
                 {authoring.data ? (
                   <Link href="/authoring">
-                    <Text
-                      c={
-                        router.asPath.endsWith(`authoring=true`) || router.pathname.startsWith('/authoring')
-                          ? 'orange.3'
-                          : 'gray.4'
-                      }
-                    >
-                      Authoring
-                    </Text>
+                    <Text c={authoringTab ? 'orange.3' : 'gray.4'}>Authoring</Text>
                   </Link>
                 ) : (
                   <> </>

--- a/app/src/pages/authoring/[resourceType]/[id].tsx
+++ b/app/src/pages/authoring/[resourceType]/[id].tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from 'react';
 import { useRouter } from 'next/router';
 import { Prism } from '@mantine/prism';
 import { notifications } from '@mantine/notifications';
-import { AlertCircle, CircleCheck, InfoCircle } from 'tabler-icons-react';
+import { IconAlertCircle, IconCircleCheck, IconInfoCircle } from '@tabler/icons-react';
 import { ArtifactResourceType } from '@/util/types/fhir';
 import ArtifactFieldInput from '@/components/ArtifactFieldInput';
 import ReleaseModal from '@/components/ReleaseModal';
@@ -114,7 +114,7 @@ export default function ResourceAuthoringPage() {
       notifications.show({
         title: 'Update Successful!',
         message: `${resourceType} Successfully Updated`,
-        icon: <CircleCheck />,
+        icon: <IconCircleCheck />,
         color: 'green'
       });
       ctx.draft.getDraftById.invalidate();
@@ -123,7 +123,7 @@ export default function ResourceAuthoringPage() {
       notifications.show({
         title: 'Update Failed!',
         message: `Attempt to update ${resourceType} failed with message: ${e.message}`,
-        icon: <AlertCircle />,
+        icon: <IconAlertCircle />,
         color: 'red'
       });
     }
@@ -184,7 +184,7 @@ export default function ResourceAuthoringPage() {
                     library
                     <Tooltip label="Only draft libraries with a valid url may be selected.">
                       <div>
-                        <InfoCircle size="1rem" style={{ display: 'block', opacity: 0.5 }} />
+                        <IconInfoCircle size="1rem" style={{ display: 'block', opacity: 0.5 }} />
                       </div>
                     </Tooltip>
                   </Group>

--- a/app/src/pages/authoring/[resourceType]/index.tsx
+++ b/app/src/pages/authoring/[resourceType]/index.tsx
@@ -1,10 +1,11 @@
 import { trpc } from '@/util/trpc';
-import { Center, Text, Divider, Title } from '@mantine/core';
+import { Center, Text, Divider, Title, Stack, Button } from '@mantine/core';
 import { useRouter } from 'next/router';
 import { ArtifactResourceType, ResourceInfo } from '@/util/types/fhir';
 import ResourceCards from '@/components/ResourceCards';
 import { extractResourceInfo } from '@/util/resourceCardUtils';
 import { useMemo } from 'react';
+import Link from 'next/link';
 
 export default function ResourceAuthoringPage() {
   const router = useRouter();
@@ -33,13 +34,18 @@ export default function ResourceAuthoringPage() {
         </Text>
       </Center>
       <Divider my="md" />
-      <div style={{ paddingTop: '18px' }}>
-        <ResourceCards
-          resourceInfo={resourceCardContent}
-          resourceType={resourceType as ArtifactResourceType}
-          authoring={true}
-        />
-      </div>
+      <Stack align="center">
+        <Link href={`/search?resourceType=${resourceType}&authoring=true`}>
+          <Button>Search</Button>
+        </Link>
+        <div style={{ paddingTop: '18px' }}>
+          <ResourceCards
+            resourceInfo={resourceCardContent}
+            resourceType={resourceType as ArtifactResourceType}
+            authoring={true}
+          />
+        </div>
+      </Stack>
     </div>
   );
 }

--- a/app/src/pages/authoring/index.tsx
+++ b/app/src/pages/authoring/index.tsx
@@ -15,7 +15,7 @@ import { trpc } from '../../util/trpc';
 import { MeasureSkeleton, LibrarySkeleton } from '@/util/authoringFixtures';
 import { useRouter } from 'next/router';
 import { notifications } from '@mantine/notifications';
-import { AlertCircle, CircleCheck } from 'tabler-icons-react';
+import { IconAlertCircle, IconCircleCheck } from '@tabler/icons-react';
 import { ArtifactResourceType } from '@/util/types/fhir';
 
 const useStyles = createStyles(() => ({
@@ -64,7 +64,7 @@ export default function AuthoringPage() {
     notifications.show({
       title: `${resourceType} Created!`,
       message: message,
-      icon: <CircleCheck />,
+      icon: <IconCircleCheck />,
       color: 'green'
     });
     utils.draft.getDraftCounts.invalidate();
@@ -88,7 +88,7 @@ export default function AuthoringPage() {
     notifications.show({
       title: `${resourceType} Creation Failed!`,
       message: message,
-      icon: <AlertCircle />,
+      icon: <IconAlertCircle />,
       color: 'red'
     });
   };

--- a/app/src/pages/index.tsx
+++ b/app/src/pages/index.tsx
@@ -1,20 +1,7 @@
+import CodeEditorModal from '@/components/CodeEditorModal';
 import { trpc } from '@/util/trpc';
 import { ArtifactResourceType } from '@/util/types/fhir';
-import {
-  Anchor,
-  Button,
-  Center,
-  Divider,
-  Group,
-  Modal,
-  Paper,
-  SegmentedControl,
-  Stack,
-  Table,
-  Text,
-  Textarea,
-  Title
-} from '@mantine/core';
+import { Anchor, Button, Center, Divider, Paper, SegmentedControl, Stack, Table, Text, Title } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import { notifications } from '@mantine/notifications';
 import { IconAlertCircle, IconCircleCheck } from '@tabler/icons-react';
@@ -28,7 +15,6 @@ export default function Home({
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const [resourceType, setResourceType] = useState<ArtifactResourceType>('Measure');
   const [opened, { open, close }] = useDisclosure(false);
-  const [jsonInput, setJsonInput] = useState('');
   const router = useRouter();
 
   const publishMutation = trpc.service.publish.useMutation({
@@ -99,38 +85,30 @@ export default function Home({
 
   return (
     <div>
-      <Modal opened={opened} onClose={close} withCloseButton={false} size="lg">
-        <Center>
-          <Text weight={700} align="center" lineClamp={2} p={'sm'}>
-            {`Add ${resourceType} JSON`}
-            <Textarea
-              value={jsonInput}
-              onChange={event => setJsonInput(event.currentTarget.value)}
-              autosize
-              minRows={6}
-              maxRows={24}
-            />
-          </Text>
-        </Center>
-        <Center>
-          <Group pt={8}>
-            <Button variant="default" onClick={close}>
-              Cancel
-            </Button>
-            <Button
-              onClick={() => {
-                publishMutation.mutate({
-                  resourceType: resourceType,
-                  jsonInput: jsonInput
-                });
-              }}
-              color={'green'}
-            >
-              Publish
-            </Button>
-          </Group>
-        </Center>
-      </Modal>
+      <CodeEditorModal
+        open={opened}
+        onClose={close}
+        title={`Create ${resourceType} JSON`}
+        onSave={value => {
+          publishMutation.mutate({
+            resourceType: resourceType,
+            jsonInput: value
+          });
+        }}
+        initialValue={JSON.stringify(
+          {
+            id: 'tempID',
+            resourceType: `${resourceType}`,
+            status: 'active',
+            version: '0.0.1',
+            url: 'http://example.update',
+            title: 'Sample title',
+            description: 'Sample description'
+          },
+          null,
+          2
+        )}
+      />
       <Text>
         This application is an interface for a prototype implementation of a{' '}
         <Anchor href="http://hl7.org/fhir/us/cqfmeasures/measure-repository-service.html">

--- a/app/src/pages/review/[resourceType]/[id].tsx
+++ b/app/src/pages/review/[resourceType]/[id].tsx
@@ -24,7 +24,7 @@ import { useRef, useState } from 'react';
 import { useRouter } from 'next/router';
 import { trpc } from '@/util/trpc';
 import { IconAlertCircle, IconCircleCheck, IconInfoCircle, IconStar } from '@tabler/icons-react';
-import { isNotEmpty, useForm } from '@mantine/form';
+import { useForm } from '@mantine/form';
 import { notifications } from '@mantine/notifications';
 import ArtifactTimeline from '@/components/ArtifactTimeline';
 import { isEmpty, trim } from 'lodash';

--- a/app/src/pages/review/[resourceType]/[id].tsx
+++ b/app/src/pages/review/[resourceType]/[id].tsx
@@ -23,7 +23,7 @@ import { ArtifactResourceType } from '@/util/types/fhir';
 import { useRef, useState } from 'react';
 import { useRouter } from 'next/router';
 import { trpc } from '@/util/trpc';
-import { AlertCircle, CircleCheck, InfoCircle, Star } from 'tabler-icons-react';
+import { IconAlertCircle, IconCircleCheck, IconInfoCircle, IconStar } from '@tabler/icons-react';
 import { isNotEmpty, useForm } from '@mantine/form';
 import { notifications } from '@mantine/notifications';
 import ArtifactTimeline from '@/components/ArtifactTimeline';
@@ -60,14 +60,14 @@ export default function CommentPage() {
       notifications.show({
         title: 'Review successfully added!',
         message: `Review successfully added to ${resourceType}/${resourceID}`,
-        icon: <CircleCheck />,
+        icon: <IconCircleCheck />,
         color: 'green'
       });
       data.children.forEach(c => {
         notifications.show({
           title: 'Review successfully added!',
           message: `Draft of child ${resourceType} artifact of url ${c.url} successfully reviewed`,
-          icon: <CircleCheck />,
+          icon: <IconCircleCheck />,
           color: 'green'
         });
       });
@@ -81,7 +81,7 @@ export default function CommentPage() {
       notifications.show({
         title: 'Review Failed!',
         message: `Attempt to review ${resourceType} failed with message: ${e.message}`,
-        icon: <AlertCircle />,
+        icon: <IconAlertCircle />,
         color: 'red'
       });
     }
@@ -147,13 +147,13 @@ export default function CommentPage() {
                         <HoverCard width={420} shadow="md" withArrow openDelay={200} closeDelay={200}>
                           <HoverCard.Target>
                             <div>
-                              <InfoCircle size="1rem" style={{ opacity: 0.5 }} />
+                              <IconInfoCircle size="1rem" style={{ opacity: 0.5 }} />
                             </div>
                           </HoverCard.Target>
                           <HoverCard.Dropdown>
                             <Group>
                               <Avatar color="blue" radius="xl">
-                                <InfoCircle size="1.5rem" />
+                                <IconInfoCircle size="1.5rem" />
                               </Avatar>
                               <Stack spacing={5}>
                                 <Text size="sm" weight={700} sx={{ lineHeight: 1 }}>
@@ -187,7 +187,7 @@ export default function CommentPage() {
                         </HoverCard>
                       </Group>
                     }
-                    icon={<Star opacity={0.5} />}
+                    icon={<IconStar opacity={0.5} />}
                     placeholder="Type"
                     data={[
                       { value: 'documentation', label: 'documentation' },

--- a/app/src/pages/review/[resourceType]/[id].tsx
+++ b/app/src/pages/review/[resourceType]/[id].tsx
@@ -74,7 +74,7 @@ export default function CommentPage() {
       data.children.forEach(c => {
         notifications.show({
           title: 'Review successfully added!',
-          message: `Draft of child ${resourceType} artifact of url ${c.url} successfully reviewed`,
+          message: `${resourceType} artifact of url ${c.url} successfully reviewed`,
           icon: <IconCircleCheck />,
           color: 'green'
         });
@@ -106,7 +106,7 @@ export default function CommentPage() {
       data.children.forEach(c => {
         notifications.show({
           title: 'Approval successfully added!',
-          message: `Draft of child ${resourceType} artifact of url ${c.url} successfully approved`,
+          message: `${resourceType} artifact of url ${c.url} successfully approved`,
           icon: <IconCircleCheck />,
           color: 'green'
         });

--- a/app/src/pages/review/[resourceType]/[id].tsx
+++ b/app/src/pages/review/[resourceType]/[id].tsx
@@ -27,6 +27,7 @@ import { IconAlertCircle, IconCircleCheck, IconInfoCircle, IconStar } from '@tab
 import { isNotEmpty, useForm } from '@mantine/form';
 import { notifications } from '@mantine/notifications';
 import ArtifactTimeline from '@/components/ArtifactTimeline';
+import { isEmpty, trim } from 'lodash';
 
 /**
  * Component which renders a page that displays the JSON data of a resource. Also will eventually
@@ -49,9 +50,16 @@ export default function CommentPage() {
       name: ''
     },
     // An error will be thrown if these fields aren't entered properly
+    // Type and comment are required unless all are empty
     validate: {
-      type: isNotEmpty('Select the type of comment'),
-      comment: isNotEmpty('Enter artifact comment')
+      type: (value, values) =>
+        (isEmpty(trim(value)) && isEmpty(trim(values.comment)) && isEmpty(trim(values.name))) || !isEmpty(trim(value))
+          ? null
+          : 'Type is required for any comment input.',
+      comment: (value, values) =>
+        (isEmpty(trim(value)) && isEmpty(trim(values.type)) && isEmpty(trim(values.name))) || !isEmpty(trim(value))
+          ? null
+          : 'Artifact comment text is required for any comment input.'
     }
   });
 
@@ -173,9 +181,7 @@ export default function CommentPage() {
                     radius="lg"
                     label={
                       <Group spacing="lg">
-                        <Text>
-                          Comment Type <span style={{ color: 'red' }}>*</span>
-                        </Text>
+                        <Text>Comment Type</Text>
                         <HoverCard width={420} shadow="md" withArrow openDelay={200} closeDelay={200}>
                           <HoverCard.Target>
                             <div>
@@ -237,7 +243,6 @@ export default function CommentPage() {
                   placeholder="Your Artifact comment"
                   label="Artifact Comment"
                   description="Add a comment to the artifact"
-                  withAsterisk
                   {...form.getInputProps('comment')}
                 />
                 <Space h="md" />
@@ -275,7 +280,7 @@ export default function CommentPage() {
                   <Button
                     loading={isLoading}
                     type="submit"
-                    color='green'
+                    color="green"
                     onClick={() => {
                       if (form.isValid()) {
                         setIsLoading(true);

--- a/app/src/pages/search.tsx
+++ b/app/src/pages/search.tsx
@@ -34,7 +34,7 @@ export default function SearchPage() {
     const resourcePanels = (Object.keys(ArtifactSearchParams) as ArtifactResourceType[]).map(resource => (
       <Tabs.Panel value={resource} key={resource}>
         <Stack style={{ paddingTop: '20px' }}>
-          <SearchComponent resourceType={resource} />
+          <SearchComponent resourceType={resource} authoring={(router.query.authoring as string) === 'true'} />
         </Stack>
       </Tabs.Panel>
     ));
@@ -42,7 +42,7 @@ export default function SearchPage() {
       <Tabs
         variant="outline"
         value={router.query.resourceType as string}
-        onTabChange={value => router.push(`search?resourceType=${value}`)}
+        onTabChange={value => router.push(`search?resourceType=${value}&authoring=${router.query.authoring as string}`)}
       >
         <ResourceTabGroup />
         {resourcePanels}

--- a/app/src/server/trpc/routers/draft.ts
+++ b/app/src/server/trpc/routers/draft.ts
@@ -172,13 +172,20 @@ export const draftRouter = router({
       const date = new Date().toISOString();
       const canonical = `${resource.url}|${resource.version}`;
 
-      const params = new URLSearchParams({
-        reviewDate: date,
-        artifactAssessmentType: input.type,
-        artifactAssessmentSummary: input.summary,
-        artifactAssessmentTarget: canonical,
-        artifactAssessmentAuthor: input.author
-      });
+      let params;
+      if (input.type && input.summary) {
+        params = new URLSearchParams({
+          reviewDate: date,
+          artifactAssessmentType: input.type,
+          artifactAssessmentSummary: input.summary,
+          artifactAssessmentTarget: canonical,
+          artifactAssessmentAuthor: input.author
+        });
+      } else {
+        params = new URLSearchParams({
+          reviewDate: date
+        });
+      }
       const res = await fetch(`${process.env.MRS_SERVER}/${input.resourceType}/${input.id}/$review?${params}`);
 
       if (res.status !== 200) {
@@ -224,13 +231,20 @@ export const draftRouter = router({
       const date = new Date().toISOString();
       const canonical = `${resource.url}|${resource.version}`;
 
-      const params = new URLSearchParams({
-        approvalDate: date,
-        artifactAssessmentType: input.type,
-        artifactAssessmentSummary: input.summary,
-        artifactAssessmentTarget: canonical,
-        artifactAssessmentAuthor: input.author
-      });
+      let params;
+      if (input.type && input.summary) {
+        params = new URLSearchParams({
+          approvalDate: date,
+          artifactAssessmentType: input.type,
+          artifactAssessmentSummary: input.summary,
+          artifactAssessmentTarget: canonical,
+          artifactAssessmentAuthor: input.author
+        });
+      } else {
+        params = new URLSearchParams({
+          approvalDate: date
+        });
+      }
       const res = await fetch(`${process.env.MRS_SERVER}/${input.resourceType}/${input.id}/$approve?${params}`);
 
       if (res.status !== 200) {

--- a/app/src/server/trpc/routers/draft.ts
+++ b/app/src/server/trpc/routers/draft.ts
@@ -30,6 +30,11 @@ export const draftRouter = router({
     const artifactList = artifactBundle.entry
       ?.filter(entry => entry.resource)
       .map(entry => entry.resource as FhirArtifact);
+    artifactList?.sort((a, b) => {
+      const strA = `${a.url}|${a.version}`;
+      const strB = `${b.url}|${b.version}`;
+      return strA.localeCompare(strB);
+    });
     return artifactList;
   }),
 

--- a/app/src/server/trpc/routers/service.ts
+++ b/app/src/server/trpc/routers/service.ts
@@ -4,7 +4,6 @@ import { z } from 'zod';
 import { TRPCError } from '@trpc/server';
 import { Bundle, OperationOutcome } from 'fhir/r4';
 import { calculateVersion } from '@/util/versionUtils';
-import { JsonInput } from '@mantine/core';
 
 /**
  * Endpoints dealing with outgoing calls to the central measure repository service to handle active (or retired) artifacts

--- a/app/src/server/trpc/routers/service.ts
+++ b/app/src/server/trpc/routers/service.ts
@@ -6,7 +6,7 @@ import { Bundle, OperationOutcome } from 'fhir/r4';
 import { calculateVersion } from '@/util/versionUtils';
 
 /**
- * Endpoints dealing with outgoing calls to the central measure repository service to handle active artifacts
+ * Endpoints dealing with outgoing calls to the central measure repository service to handle active (or retired) artifacts
  */
 export const serviceRouter = router({
   getPublicUrl: publicProcedure.query(async () => {
@@ -24,26 +24,40 @@ export const serviceRouter = router({
   }),
 
   getArtifactCounts: publicProcedure.query(async () => {
-    const [measureBundle, libraryBundle] = await Promise.all([
+    // TODO: simplify this query when server can handle OR'd search params (i.e. /Measure?_summary=count&status=active,retired)
+    const [measureBundleActive, measureBundleRetired, libraryBundleActive, libraryBundleRetired] = await Promise.all([
       fetch(`${process.env.MRS_SERVER}/Measure?_summary=count&status=active`),
-      fetch(`${process.env.MRS_SERVER}/Library?_summary=count&status=active`)
-    ]).then(([resMeasure, resLibrary]) =>
-      Promise.all([resMeasure.json() as Promise<Bundle>, resLibrary.json() as Promise<Bundle>])
+      fetch(`${process.env.MRS_SERVER}/Measure?_summary=count&status=retired`),
+      fetch(`${process.env.MRS_SERVER}/Library?_summary=count&status=active`),
+      fetch(`${process.env.MRS_SERVER}/Library?_summary=count&status=retired`)
+    ]).then(([resMeasureActive, resMeasureRetired, resLibraryActive, resLibraryRetired]) =>
+      Promise.all([
+        resMeasureActive.json() as Promise<Bundle>,
+        resMeasureRetired.json() as Promise<Bundle>,
+        resLibraryActive.json() as Promise<Bundle>,
+        resLibraryRetired.json() as Promise<Bundle>
+      ])
     );
 
     return {
-      Measure: measureBundle.total ?? 0,
-      Library: libraryBundle.total ?? 0
+      Measure: (measureBundleActive.total ?? 0) + (measureBundleRetired.total ?? 0),
+      Library: (libraryBundleActive.total ?? 0) + (libraryBundleRetired.total ?? 0)
     } as const;
   }),
 
   getArtifactsByType: publicProcedure
     .input(z.object({ resourceType: z.enum(['Measure', 'Library']) }))
     .query(async ({ input }) => {
-      const artifactBundle = await fetch(
-        `${process.env.MRS_SERVER}/${input.resourceType}?_elements=id,name,extension,version&status=active`
-      ).then(resArtifacts => resArtifacts.json() as Promise<Bundle<FhirArtifact>>);
-      const artifactList = artifactBundle.entry?.map(entry => ({
+      const [artifactBundleActive, artifactBundleRetired] = await Promise.all([
+        fetch(`${process.env.MRS_SERVER}/${input.resourceType}?_elements=id,name,extension,version&status=active`),
+        fetch(`${process.env.MRS_SERVER}/${input.resourceType}?_elements=id,name,extension,version&status=retired`)
+      ]).then(([resArtifactsActive, resArtifactsRetired]) =>
+        Promise.all([
+          resArtifactsActive.json() as Promise<Bundle<FhirArtifact>>,
+          resArtifactsRetired.json() as Promise<Bundle<FhirArtifact>>
+        ])
+      );
+      const artifactList = (artifactBundleActive.entry || []).concat(artifactBundleRetired.entry || []).map(entry => ({
         label:
           entry.resource?.name?.concat(`|${entry.resource.version}`) ||
           entry.resource?.id?.concat(`|${entry.resource.version}`) ||
@@ -147,5 +161,91 @@ export const serviceRouter = router({
       });
 
       return { location: `/${input.resourceType}/${input.id}`, released: released, status: res.status, error: null };
+    }),
+
+  retireParent: publicProcedure
+    .input(z.object({ resourceType: z.enum(['Measure', 'Library']), id: z.string() }))
+    .mutation(async ({ input }) => {
+      const raw = await fetch(`${process.env.MRS_SERVER}/${input.resourceType}/${input.id}`);
+      const resource: FhirArtifact = await raw.json();
+      resource.status = 'retired';
+      resource.date = new Date().toISOString();
+      const res = await fetch(`${process.env.MRS_SERVER}/${input.resourceType}/${input.id}`, {
+        method: 'PUT',
+        headers: {
+          Accept: 'application/json+fhir',
+          'Content-Type': 'application/json+fhir'
+        },
+        body: JSON.stringify(resource)
+      });
+
+      if (res.status !== 200) {
+        const outcome: OperationOutcome = await res.json();
+        throw new Error(`Received ${res.status} error on retire: ${outcome.issue[0].details?.text}`);
+      }
+
+      // TODO: Use this once we have a response from retire that includes the list of resources updated
+      // const resBundle: Bundle<FhirArtifact> = await res.json();
+      // if (!resBundle.entry || resBundle.entry.length === 0) {
+      //   throw new Error(`No artifacts found found from retiring ${input.resourceType}, id ${input.id}`);
+      // }
+
+      // const retired: {
+      //   resourceType: 'Measure' | 'Library';
+      //   id: string;
+      // }[] = [{ resourceType: input.resourceType, id: input.id }]; //start with parent and add children
+      // resBundle.entry.forEach(e => {
+      //   if (
+      //     e.resource?.extension?.find(
+      //       ext => ext.url === 'http://hl7.org/fhir/StructureDefinition/artifact-isOwned' && ext.valueBoolean
+      //     )
+      //   ) {
+      //     retired.push({ resourceType: e.resource.resourceType, id: e.resource.id });
+      //   }
+      // });
+
+      const retired: {
+        resourceType: 'Measure' | 'Library';
+        id: string;
+      }[] = [];
+
+      return { location: `/${input.resourceType}/${input.id}`, retired: retired, status: res.status, error: null };
+    }),
+
+  archiveParent: publicProcedure
+    .input(z.object({ resourceType: z.enum(['Measure', 'Library']), id: z.string() }))
+    .mutation(async ({ input }) => {
+      const res = await fetch(`${process.env.MRS_SERVER}/${input.resourceType}/${input.id}`, { method: 'DELETE' });
+
+      if (res.status !== 204 && res.status !== 200) {
+        const outcome: OperationOutcome = await res.json();
+        throw new Error(`Received ${res.status} error on archive: ${outcome.issue[0].details?.text}`);
+      }
+
+      // TODO: Use this once we have a response from archive that includes the list of resources updated
+      // const resBundle: Bundle<FhirArtifact> = await res.json();
+      // if (!resBundle.entry || resBundle.entry.length === 0) {
+      //   throw new Error(`No artifacts found found from archiving ${input.resourceType}, id ${input.id}`);
+      // }
+
+      // const archived: {
+      //   resourceType: 'Measure' | 'Library';
+      //   id: string;
+      // }[] = [{ resourceType: input.resourceType, id: input.id }]; //start with parent and add children
+      // resBundle.entry.forEach(e => {
+      //   if (
+      //     e.resource?.extension?.find(
+      //       ext => ext.url === 'http://hl7.org/fhir/StructureDefinition/artifact-isOwned' && ext.valueBoolean
+      //     )
+      //   ) {
+      //     archived.push({ resourceType: e.resource.resourceType, id: e.resource.id });
+      //   }
+      // });
+      const archived: {
+        resourceType: 'Measure' | 'Library';
+        id: string;
+      }[] = [];
+
+      return { location: `/${input.resourceType}/${input.id}`, archived: archived, status: res.status, error: null };
     })
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "@mantine/next": "^6.0.9",
         "@mantine/notifications": "^6.0.11",
         "@mantine/prism": "^6.0.9",
+        "@tabler/icons-react": "^3.26.0",
         "@tanstack/react-query": "^4.29.7",
         "@trpc/client": "^10.26.0",
         "@trpc/next": "^10.26.0",
@@ -42,7 +43,6 @@
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "semver": "^7.5.4",
-        "tabler-icons-react": "^1.56.0",
         "zod": "^3.21.4"
       },
       "devDependencies": {
@@ -3853,6 +3853,32 @@
       "integrity": "sha512-E4KcWTpoLHqwPHLxidpOqQbcrZVgi0rsmmZXUle1jXmJfuIf/UWpczUJ7MZZ5tlxytgJXyp0w4PGkkeLiuIdZw==",
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tabler/icons": {
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@tabler/icons/-/icons-3.26.0.tgz",
+      "integrity": "sha512-oO3D4ss+DxzxqU1aDy0f1HmToyrO0gcQWIMpzHAfV1quPUx0BZYvNm5xz1DQb4DxNm/+xNvbBGLJy4pzTLYWag==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/codecalm"
+      }
+    },
+    "node_modules/@tabler/icons-react": {
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@tabler/icons-react/-/icons-react-3.26.0.tgz",
+      "integrity": "sha512-t18Zmu1ROktB7M8hWQ6vJw+mNpI/LPk5PPxLuE+kNB+4Zzf38GfETL8VF98inhzcfHohsggdROzMzwSAfjcAxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tabler/icons": "3.26.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/codecalm"
+      },
+      "peerDependencies": {
+        "react": ">= 16"
       }
     },
     "node_modules/@tanstack/query-core": {
@@ -12394,14 +12420,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/tabler-icons-react": {
-      "version": "1.56.0",
-      "resolved": "https://registry.npmjs.org/tabler-icons-react/-/tabler-icons-react-1.56.0.tgz",
-      "integrity": "sha512-FOme3w6PJIWDpeXqQ4xjArQqdxzrr9xNy7PSSgWpRzOUQ71RyZ7jt6WThsfyLBz5os78TPJRA8f/0NLjnKcx9A==",
-      "peerDependencies": {
-        "react": ">= 16.8.0"
       }
     },
     "node_modules/tapable": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,8 @@
     "app": {
       "version": "0.1.0",
       "dependencies": {
+        "@codemirror/lang-json": "0.20.0",
+        "@codemirror/lint": "0.20.3",
         "@emotion/react": "^11.10.8",
         "@emotion/server": "^11.10.0",
         "@mantine/core": "^6.0.9",
@@ -35,6 +37,7 @@
         "@trpc/react-query": "^10.26.0",
         "@trpc/server": "^10.26.0",
         "@types/fhir": "^0.0.36",
+        "@uiw/react-codemirror": "4.7.0",
         "dayjs": "^1.11.7",
         "html-react-parser": "^3.0.15",
         "luxon": "^3.3.0",
@@ -1403,6 +1406,121 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "node_modules/@codemirror/autocomplete": {
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-0.20.3.tgz",
+      "integrity": "sha512-lYB+NPGP+LEzAudkWhLfMxhTrxtLILGl938w+RcFrGdrIc54A+UgmCoz+McE3IYRFp4xyQcL4uFJwo+93YdgHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^0.20.0",
+        "@codemirror/state": "^0.20.0",
+        "@codemirror/view": "^0.20.0",
+        "@lezer/common": "^0.16.0"
+      }
+    },
+    "node_modules/@codemirror/basic-setup": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/basic-setup/-/basic-setup-0.20.0.tgz",
+      "integrity": "sha512-W/ERKMLErWkrVLyP5I8Yh8PXl4r+WFNkdYVSzkXYPQv2RMPSkWpr2BgggiSJ8AHF/q3GuApncDD8I4BZz65fyg==",
+      "deprecated": "In version 6.0, this package has been renamed to just 'codemirror'",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^0.20.0",
+        "@codemirror/commands": "^0.20.0",
+        "@codemirror/language": "^0.20.0",
+        "@codemirror/lint": "^0.20.0",
+        "@codemirror/search": "^0.20.0",
+        "@codemirror/state": "^0.20.0",
+        "@codemirror/view": "^0.20.0"
+      }
+    },
+    "node_modules/@codemirror/commands": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-0.20.0.tgz",
+      "integrity": "sha512-v9L5NNVA+A9R6zaFvaTbxs30kc69F6BkOoiEbeFw4m4I0exmDEKBILN6mK+GksJtvTzGBxvhAPlVFTdQW8GB7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^0.20.0",
+        "@codemirror/state": "^0.20.0",
+        "@codemirror/view": "^0.20.0",
+        "@lezer/common": "^0.16.0"
+      }
+    },
+    "node_modules/@codemirror/lang-json": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-json/-/lang-json-0.20.0.tgz",
+      "integrity": "sha512-Dj9iW3larS3HDdzd8+GXP5+7EUG7SeQexy0mh7l3N/n7vicIY+9AxRPZ1H6nsVI97uZpYIm8OZWG/eUzCdksdA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^0.20.0",
+        "@lezer/json": "^0.16.0"
+      }
+    },
+    "node_modules/@codemirror/language": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-0.20.2.tgz",
+      "integrity": "sha512-WB3Bnuusw0xhVvhBocieYKwJm04SOk5bPoOEYksVHKHcGHFOaYaw+eZVxR4gIqMMcGzOIUil0FsCmFk8yrhHpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^0.20.0",
+        "@codemirror/view": "^0.20.0",
+        "@lezer/common": "^0.16.0",
+        "@lezer/highlight": "^0.16.0",
+        "@lezer/lr": "^0.16.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/lint": {
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-0.20.3.tgz",
+      "integrity": "sha512-06xUScbbspZ8mKoODQCEx6hz1bjaq9m8W8DxdycWARMiiX1wMtfCh/MoHpaL7ws/KUMwlsFFfp2qhm32oaCvVA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^0.20.0",
+        "@codemirror/view": "^0.20.2",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/search": {
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-0.20.1.tgz",
+      "integrity": "sha512-ROe6gRboQU5E4z6GAkNa2kxhXqsGNbeLEisbvzbOeB7nuDYXUZ70vGIgmqPu0tB+1M3F9yWk6W8k2vrFpJaD4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^0.20.0",
+        "@codemirror/view": "^0.20.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-0.20.1.tgz",
+      "integrity": "sha512-ms0tlV5A02OK0pFvTtSUGMLkoarzh1F8mr6jy1cD7ucSC2X/VLHtQCxfhdSEGqTYlQF2hoZtmLv+amqhdgbwjQ==",
+      "license": "MIT"
+    },
+    "node_modules/@codemirror/theme-one-dark": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/theme-one-dark/-/theme-one-dark-0.20.0.tgz",
+      "integrity": "sha512-iqTKaiOZddwlc2rYF+9D60Gfyz9EsSawVejSjyP2FCtOwZ1X0frG5/ByTKH5FBDD2+P7W8+h/OIG4r5dWq4bgA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^0.20.0",
+        "@codemirror/state": "^0.20.0",
+        "@codemirror/view": "^0.20.0",
+        "@lezer/highlight": "^0.16.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "0.20.7",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.20.7.tgz",
+      "integrity": "sha512-pqEPCb9QFTOtHgAH5XU/oVy9UR/Anj6r+tG5CRmkNVcqSKEPmBU05WtN/jxJCFZBXf6HumzWC9ydE4qstO3TxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^0.20.0",
+        "style-mod": "^4.0.0",
+        "w3c-keyname": "^2.2.4"
+      }
+    },
     "node_modules/@colors/colors": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
@@ -2152,6 +2270,40 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@lezer/common": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-0.16.1.tgz",
+      "integrity": "sha512-qPmG7YTZ6lATyTOAWf8vXE+iRrt1NJd4cm2nJHK+v7X9TsOF6+HtuU/ctaZy2RCrluxDb89hI6KWQ5LfQGQWuA==",
+      "license": "MIT"
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-0.16.0.tgz",
+      "integrity": "sha512-iE5f4flHlJ1g1clOStvXNLbORJoiW4Kytso6ubfYzHnaNo/eo5SKhxs4wv/rtvwZQeZrK3we8S9SyA7OGOoRKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^0.16.0"
+      }
+    },
+    "node_modules/@lezer/json": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@lezer/json/-/json-0.16.0.tgz",
+      "integrity": "sha512-Aqsi+qclD1f27tKGV9nND29WRXur8kfVnbPf5gUms3SNTY5mRIADnXy9/5dQxKlPkVHSuS1RCUJvA0+mdNQtsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/highlight": "^0.16.0",
+        "@lezer/lr": "^0.16.0"
+      }
+    },
+    "node_modules/@lezer/lr": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-0.16.3.tgz",
+      "integrity": "sha512-pau7um4eAw94BEuuShUIeQDTf3k4Wt6oIUOYxMmkZgDHdqtIcxWND4LRxi8nI9KuT4I1bXQv67BCapkxt7Ywqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^0.16.0"
       }
     },
     "node_modules/@lhncbc/ucum-lhc": {
@@ -4515,6 +4667,24 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@uiw/react-codemirror": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@uiw/react-codemirror/-/react-codemirror-4.7.0.tgz",
+      "integrity": "sha512-gRBsIScecZzqj1/vqPZ6XxykccBkp+qv6wLFyTk2DxHzuPl4cDIQwqCBl81u80by5nCKambceRkTvpiQ6oJ2Ew==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": ">=7.11.0",
+        "@codemirror/basic-setup": "^0.20.0",
+        "@codemirror/state": "^0.20.0",
+        "@codemirror/theme-one-dark": "^0.20.0",
+        "@codemirror/view": "^0.20.0"
+      },
+      "peerDependencies": {
+        "@babel/runtime": ">=7.11.0",
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
     "node_modules/@ungap/structured-clone": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
@@ -5857,6 +6027,12 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
+    },
+    "node_modules/crelt": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+      "license": "MIT"
     },
     "node_modules/cross-env": {
       "version": "5.2.1",
@@ -12158,6 +12334,12 @@
       "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
       "optional": true
     },
+    "node_modules/style-mod": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.2.tgz",
+      "integrity": "sha512-wnD1HyVqpJUI2+eKZ+eo1UwghftP6yuFheBqqe+bWCotBjC2K1YnteJILRMs3SM4V/0dLEW1SC27MWP5y+mwmw==",
+      "license": "MIT"
+    },
     "node_modules/style-to-js": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.3.tgz",
@@ -13080,6 +13262,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
     },
     "node_modules/walker": {
       "version": "1.0.8",

--- a/service/src/services/LibraryService.ts
+++ b/service/src/services/LibraryService.ts
@@ -263,6 +263,9 @@ export class LibraryService implements Service<CRMIShareableLibrary> {
     if (!activeLibrary) {
       throw new ResourceNotFoundError(`No resource found in collection: Library, with id: ${args.id}`);
     }
+    if (activeLibrary.status !== 'active') {
+      throw new BadRequestError('Authoring repository service drafting may only be made to active status resources.');
+    }
     checkIsOwned(activeLibrary, 'Child artifacts cannot be directly drafted');
 
     // recursively get any child artifacts from the artifact if they exist

--- a/service/src/services/MeasureService.ts
+++ b/service/src/services/MeasureService.ts
@@ -267,6 +267,9 @@ export class MeasureService implements Service<CRMIShareableMeasure> {
     if (!activeMeasure) {
       throw new ResourceNotFoundError(`No resource found in collection: Measure, with id: ${args.id}`);
     }
+    if (activeMeasure.status !== 'active') {
+      throw new BadRequestError('Authoring repository service drafting may only be made to active status resources.');
+    }
     checkIsOwned(activeMeasure, 'Child artifacts cannot be directly drafted.');
 
     // recursively get any child artifacts from the artifact if they exist


### PR DESCRIPTION
# Summary
Makes various updates to align the front end application with the implemented functionality in the backend to align more fully with the capabilities expected in the IG. Also makes one update in the backend to support expected functionality.

## New behavior
New capabilities in the front end include: $approve capability, $clone for active and retired measures, CRUD for non-draft measures (publish, retire, archive), and search for draft artifacts.
Backend has been updated to limit $draft to active artifacts.

## Code changes
- Updates to dependencies to update tabler icons and use codemirror for the added code editor.
- All Icons across the app now named "Icon*", i.e. `Message` to `IconMessage`
- Added CodeEditorModal (same as in fqm-testify)
- Update ConfirmationModal to handle additional actions
- ResourceInfoCard: Update all language to not read "draft" in non-draft cases, invalidate page for active/retired artifact updates, add retire and archive capabilities, expand button icon logic for active/retired artifacts
- Expand SearchComponent to be used in either draft or active/retired contexts
- Expand all pulls of active measures to also pull retired artifacts
- Order both active/retired and draft artifacts by url|version
- For `search-result`, use the draft/authoring context to pass through the correct results
- Update `_app` to highlight the correct tab and show the search based on the draft/authoring context
- Add search bar to /authoring/[resourceType]/index.tsx page
- Add publish functionality to active index page (under the capability statement info)
- Add approve capabilities to the review page and update input validation to match spec
- Add `approveDraft` trpc procedure to draft router (and adjust parameters passed through for $review)
- Add publish, retire, and archive to service router procedures

Server side:
- Add check in Measure and Library services for active artifact for the draft operation

# Testing guidance

- `npm install`
- `npm run check:all`
- `npm run start:all`
- Use your favorite script to load your favorite bundle(s)
- At http://localhost:3001/mrs , exercise all features and make sure they act appropriately according to the spec. 
- Use Insomnia to test the backend change with something like: http://localhost:3000/4_0_1/Measure/$draft?id=ColorectalCancerScreeningsFHIR&version=1.0.2 where the chosen Measure is in draft or retired status.


