### PR TITLE
Remove MongoDB github action and update mongodb version used in jest-mongodb

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Use MongoDB
-        uses: supercharge/mongodb-github-action@1.6.0
+        uses: supercharge/mongodb-github-action@1.12.0
         with:
           mongodb-version: ${{ matrix.mongodb-version }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,6 @@ jobs:
     strategy:
       matrix:
         node-version: [18.x]
-        # mongodb-version: ["6.0"]
 
     steps:
       - uses: actions/checkout@v2
@@ -17,11 +16,6 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-
-      # - name: Use MongoDB
-      #   uses: supercharge/mongodb-github-action@1.12.0
-      #   with:
-      #     mongodb-version: ${{ matrix.mongodb-version }}
 
       - name: Setup Dependencies
         run: npm ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         node-version: [18.x]
-        mongodb-version: ["6.0"]
+        # mongodb-version: ["6.0"]
 
     steps:
       - uses: actions/checkout@v2
@@ -18,10 +18,10 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - name: Use MongoDB
-        uses: supercharge/mongodb-github-action@1.12.0
-        with:
-          mongodb-version: ${{ matrix.mongodb-version }}
+      # - name: Use MongoDB
+      #   uses: supercharge/mongodb-github-action@1.12.0
+      #   with:
+      #     mongodb-version: ${{ matrix.mongodb-version }}
 
       - name: Setup Dependencies
         run: npm ci

--- a/package-lock.json
+++ b/package-lock.json
@@ -3229,19 +3229,20 @@
       }
     },
     "node_modules/@shelf/jest-mongodb": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@shelf/jest-mongodb/-/jest-mongodb-4.2.0.tgz",
-      "integrity": "sha512-AtrG0EGtoDX4/jiTHlVCtAT0QAW1RjKQDYVXK89fog07RcKr42r6hYOL+7XT/8Wj9pEmnOc1GoYQUWiOk0y8Nw==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@shelf/jest-mongodb/-/jest-mongodb-4.3.2.tgz",
+      "integrity": "sha512-LL7NBaT04sJspoOZXqw3HGLw0+XnZNlIV72x2ymzyuloqIKXwgUl8eL1XKDUh4Ud8dUBRMrOngCQBcHKjWnrHQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "debug": "4.3.4",
-        "mongodb-memory-server": "9.1.1"
+        "mongodb-memory-server": "9.2.0"
       },
       "engines": {
         "node": ">=16"
       },
       "peerDependencies": {
-        "jest-environment-node": "27.x.x || 28.x || 29.x",
+        "jest-environment-node": "28.x || 29.x",
         "mongodb": "3.x.x || 4.x || 5.x || 6.x"
       }
     },
@@ -4541,13 +4542,11 @@
       }
     },
     "node_modules/agent-base": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
-      "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
       "dev": true,
-      "dependencies": {
-        "debug": "^4.3.4"
-      },
+      "license": "MIT",
       "engines": {
         "node": ">= 14"
       }
@@ -4835,10 +4834,11 @@
       "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg=="
     },
     "node_modules/async-mutex": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.4.0.tgz",
-      "integrity": "sha512-eJFZ1YhRR8UN8eBLoNzcDPcy/jqjsg6I1AP+KvWQX80BqOSW1oJPJXDylPUEeMr2ZQvHgnQ//Lp6f3RQ1zI7HA==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.4.1.tgz",
+      "integrity": "sha512-WfoBo4E/TbCX1G95XTjbWTE3X2XLG0m1Xbv2cwOtuPdyH9CZvnaA5nCt1ucjaKEgW2A5IF71hxrRhr83Je5xjA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -4896,10 +4896,11 @@
       }
     },
     "node_modules/b4a": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.4.tgz",
-      "integrity": "sha512-fpWrvyVHEKyeEvbKZTVOeZF3VSKKWtJxFIxX/jaVPf+cLbGUSitjb49pHLqPV2BUNNZ0LcoeEGfE/YCpyDYHIw==",
-      "dev": true
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.7.tgz",
+      "integrity": "sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/babel-jest": {
       "version": "29.7.0",
@@ -5035,6 +5036,14 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
+    "node_modules/bare-events": {
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.5.4.tgz",
+      "integrity": "sha512-+gFfDkR8pj4/TrWCGUGWmJIkBwuxPS5F+a5yWjOHQt2hHvNZd5YLzadjmDUtFmMM4y429bnKLa8bYBMHcYdnQA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -5233,6 +5242,7 @@
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "*"
       }
@@ -5573,7 +5583,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/component-emitter": {
       "version": "1.3.1",
@@ -7201,7 +7212,8 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
       "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-glob": {
       "version": "3.3.2",
@@ -7285,15 +7297,6 @@
       "dev": true,
       "dependencies": {
         "bser": "2.1.1"
-      }
-    },
-    "node_modules/fd-slicer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-      "dev": true,
-      "dependencies": {
-        "pend": "~1.2.0"
       }
     },
     "node_modules/feature-policy": {
@@ -7390,6 +7393,7 @@
       "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
       "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "commondir": "^1.0.1",
         "make-dir": "^3.0.2",
@@ -7407,6 +7411,7 @@
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
       "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "semver": "^6.0.0"
       },
@@ -7422,6 +7427,7 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -8121,12 +8127,13 @@
       }
     },
     "node_modules/https-proxy-agent": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.2.tgz",
-      "integrity": "sha512-NmLNjm6ucYwtcUmL7JQC1ZQ57LmHP4lT15FQ8D61nak1rO6DH+fz5qNK2Ap5UN4ZapYICE3/0KodcLYSPsPbaA==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "agent-base": "^7.0.2",
+        "agent-base": "^7.1.2",
         "debug": "4"
       },
       "engines": {
@@ -9959,13 +9966,14 @@
       }
     },
     "node_modules/mongodb-memory-server": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/mongodb-memory-server/-/mongodb-memory-server-9.1.1.tgz",
-      "integrity": "sha512-ZOHOdb7//sBR2ea1lPHDPRaw8oO2MIfMdF+z82/KnzfNZ6yY6igR48cfG8u+QArKJQFsA392GMMHSevfPWsrRA==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/mongodb-memory-server/-/mongodb-memory-server-9.2.0.tgz",
+      "integrity": "sha512-w/usKdYtby5EALERxmA0+et+D0brP0InH3a26shNDgGefXA61hgl6U0P3IfwqZlEGRZdkbZig3n57AHZgDiwvg==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
-        "mongodb-memory-server-core": "9.1.1",
+        "mongodb-memory-server-core": "9.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -9973,23 +9981,24 @@
       }
     },
     "node_modules/mongodb-memory-server-core": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/mongodb-memory-server-core/-/mongodb-memory-server-core-9.1.1.tgz",
-      "integrity": "sha512-5toYR4A7DfV5k+Qf6L9FG86baID2rPP/JYwp8TPrdm8ZzfTfyHTwQwa2BzVpSwmLoVW5gXN0znYmXiE68mImMg==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/mongodb-memory-server-core/-/mongodb-memory-server-core-9.2.0.tgz",
+      "integrity": "sha512-9SWZEy+dGj5Fvm5RY/mtqHZKS64o4heDwReD4SsfR7+uNgtYo+JN41kPCcJeIH3aJf04j25i5Dia2s52KmsMPA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "async-mutex": "^0.4.0",
         "camelcase": "^6.3.0",
         "debug": "^4.3.4",
         "find-cache-dir": "^3.3.2",
-        "follow-redirects": "^1.15.3",
-        "https-proxy-agent": "^7.0.2",
+        "follow-redirects": "^1.15.6",
+        "https-proxy-agent": "^7.0.4",
         "mongodb": "^5.9.1",
         "new-find-package-json": "^2.0.0",
-        "semver": "^7.5.4",
-        "tar-stream": "^3.0.0",
+        "semver": "^7.6.0",
+        "tar-stream": "^3.1.7",
         "tslib": "^2.6.2",
-        "yauzl": "^2.10.0"
+        "yauzl": "^3.1.3"
       },
       "engines": {
         "node": ">=14.20.1"
@@ -10000,6 +10009,7 @@
       "resolved": "https://registry.npmjs.org/bson/-/bson-5.5.1.tgz",
       "integrity": "sha512-ix0EwukN2EpC0SRWIj/7B5+A6uQMQy6KMREI9qQqvgpkV2frH63T0UDVd1SYedL6dNCmDBYB3QtXi4ISk9YT+g==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=14.20.1"
       }
@@ -10009,6 +10019,7 @@
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
       "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -10021,6 +10032,7 @@
       "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.9.2.tgz",
       "integrity": "sha512-H60HecKO4Bc+7dhOv4sJlgvenK4fQNqqUIlXxZYQNbfEWSALGAwGoyJd/0Qwk4TttFXUOHJ2ZJQe/52ScaUwtQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "bson": "^5.5.0",
         "mongodb-connection-string-url": "^2.6.0",
@@ -10122,6 +10134,7 @@
       "resolved": "https://registry.npmjs.org/new-find-package-json/-/new-find-package-json-2.0.0.tgz",
       "integrity": "sha512-lDcBsjBSMlj3LXH2v/FW3txlh2pYTjmbOXPYJD93HI5EwuLzI11tdHSIpUMmfq/IOsldj4Ps8M8flhm+pCK4Ew==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4"
       },
@@ -10681,7 +10694,8 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.0.0",
@@ -10989,7 +11003,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.1.tgz",
       "integrity": "sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
@@ -11473,12 +11488,10 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -11490,22 +11503,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
       "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow=="
-    },
-    "node_modules/semver/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semver/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/send": {
       "version": "0.18.0",
@@ -11943,13 +11940,18 @@
       }
     },
     "node_modules/streamx": {
-      "version": "2.15.6",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.15.6.tgz",
-      "integrity": "sha512-q+vQL4AAz+FdfT137VF69Cc/APqUbxy+MDOImRrMvchJpigHj9GksgDU2LYbO9rx7RX6osWgxJB2WxhYv4SZAw==",
+      "version": "2.21.1",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.21.1.tgz",
+      "integrity": "sha512-PhP9wUnFLa+91CPy3N6tiQsK+gnYyUNuk15S3YG/zjYE7RuPeCjJngqnzpC31ow0lzBHQ+QGO4cNJnd0djYUsw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "fast-fifo": "^1.1.0",
-        "queue-tick": "^1.0.1"
+        "fast-fifo": "^1.3.2",
+        "queue-tick": "^1.0.1",
+        "text-decoder": "^1.1.0"
+      },
+      "optionalDependencies": {
+        "bare-events": "^2.2.0"
       }
     },
     "node_modules/string_decoder": {
@@ -12412,10 +12414,11 @@
       }
     },
     "node_modules/tar-stream": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.6.tgz",
-      "integrity": "sha512-B/UyjYwPpMBv+PaFSWAmtYjwdrlEaZQEhMIBFNC5oEG8lpiW8XjcSdmEaClj28ArfKScKHs2nshz3k2le6crsg==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "b4a": "^1.6.4",
         "fast-fifo": "^1.2.0",
@@ -12434,6 +12437,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
+      "integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
       }
     },
     "node_modules/text-hex": {
@@ -13473,13 +13486,17 @@
       }
     },
     "node_modules/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.2.0.tgz",
+      "integrity": "sha512-Ow9nuGZE+qp1u4JIPvg+uCiUr7xGQWdff7JQSk5VGYTAZMDe2q8lxJ10ygv10qmSj031Ty/6FNJpLO4o1Sgc+w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
+        "pend": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/yn": {
@@ -13526,7 +13543,7 @@
         "zod": "^3.20.2"
       },
       "devDependencies": {
-        "@shelf/jest-mongodb": "^4.1.4",
+        "@shelf/jest-mongodb": "^4.3.0",
         "@types/cors": "^2.8.13",
         "@types/express": "^4.17.17",
         "@types/fhir": "^0.0.35",

--- a/service/jest-mongodb-config.js
+++ b/service/jest-mongodb-config.js
@@ -1,7 +1,7 @@
 module.exports = {
   mongodbMemoryServerOptions: {
     binary: {
-      version: '6.0.1',
+      version: '6.0.19',
       skipMD5: true
     },
     autoStart: false,

--- a/service/package.json
+++ b/service/package.json
@@ -27,7 +27,7 @@
     "test:watch": "jest --watch"
   },
   "devDependencies": {
-    "@shelf/jest-mongodb": "^4.1.4",
+    "@shelf/jest-mongodb": "^4.3.0",
     "@types/cors": "^2.8.13",
     "@types/express": "^4.17.17",
     "@types/fhir": "^0.0.35",


### PR DESCRIPTION
# Summary

- Removes mongodb action from ci.yml since it was not needed.
- Updates jest-mongodb plugin.
- Updates mongodb version used by jest-mongodb to 6.0.19 which has support for new GH actions spec

## New behavior

## Code changes

# Testing guidance
