### PR TITLE
Change tacoma docker hub org to mitrehealthdocker

### DIFF
--- a/docker-build.sh
+++ b/docker-build.sh
@@ -1,4 +1,4 @@
-npm#!/bin/bash
+#!/bin/bash
 
-docker buildx build --platform linux/arm64,linux/amd64 -t tacoma/measure-repository-service:latest -f service.Dockerfile . --push
-docker buildx build --platform linux/arm64,linux/amd64 -t tacoma/measure-repository-app:latest -f app.Dockerfile . --push
+docker buildx build --platform linux/arm64,linux/amd64 -t mitrehealthdocker/measure-repository-service:latest -f service.Dockerfile . --push
+docker buildx build --platform linux/arm64,linux/amd64 -t mitrehealthdocker/measure-repository-app:latest -f app.Dockerfile . --push

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -4,7 +4,7 @@ services:
   measure-service:
     depends_on:
       - mongo
-    image: tacoma/measure-repository-service
+    image: mitrehealthdocker/measure-repository-service
     environment:
       DATABASE_URL: "mongodb://mongo:27017/measure-repository?replicaSet=rs0"
     ports:
@@ -16,7 +16,7 @@ services:
     depends_on:
       - mongo
       - measure-service
-    image: tacoma/measure-repository-app
+    image: mitrehealthdocker/measure-repository-app
     environment:
       # Change this for public location of measure-service this should be the FQDN and location of where the
       # measure-service container is made public to users with `4_0_1` appended. ex. https://abacus.example.com/mrs/4_0_1

--- a/service.Dockerfile
+++ b/service.Dockerfile
@@ -23,6 +23,9 @@ RUN npm install --prefer-online=true
 
 FROM deps AS build
 
+USER node
+WORKDIR /home/node/app
+
 # copy over all source and build just app
 COPY --chown=node:node service service
 COPY --chown=node:node tsconfig-base.json .


### PR DESCRIPTION
# Summary

Updates docker hub org from tacoma to mitrehealthdocker. Fix issue in service docker build.

## New behavior

N/A

## Code changes

- service.Dockerfile - Proper user and working dir for build stage.

# Testing guidance

Run docker build script and/or docker compose. Test compose setup.